### PR TITLE
feat: add multi-component lossless JPEG (SOF3) decode

### DIFF
--- a/src/decode/pipeline.rs
+++ b/src/decode/pipeline.rs
@@ -1101,102 +1101,184 @@ impl<'a> Decoder<'a> {
         }
 
         let num_components = frame.components.len();
-        if num_components != 1 {
-            return Err(JpegError::Unsupported(format!(
-                "lossless {} components (only grayscale supported)",
-                num_components
-            )));
-        }
 
-        // Resolve DC Huffman table (lossless uses DC tables only)
-        let dc_tbl_idx = scan.components[0].dc_table_index as usize;
-        let dc_table = self.metadata.dc_huffman_tables[dc_tbl_idx]
-            .as_ref()
-            .ok_or_else(|| {
-                JpegError::CorruptData(format!("missing DC Huffman table {}", dc_tbl_idx))
-            })?;
+        // Resolve DC Huffman tables for each scan component
+        let mut dc_tables: Vec<&HuffmanTable> = Vec::with_capacity(num_components);
+        for i in 0..scan.components.len().min(num_components) {
+            let dc_tbl_idx = scan.components[i].dc_table_index as usize;
+            let dc_table = self.metadata.dc_huffman_tables[dc_tbl_idx]
+                .as_ref()
+                .ok_or_else(|| {
+                    JpegError::CorruptData(format!("missing DC Huffman table {}", dc_tbl_idx))
+                })?;
+            dc_tables.push(dc_table);
+        }
 
         let entropy_data = &self.raw_data[self.metadata.entropy_data_offset..];
         let mut reader = BitReader::new(entropy_data);
 
-        let mask = ((1u32 << precision) - 1) as i32;
-        let initial_pred = 1i32 << (precision as i32 - pt as i32 - 1);
+        if num_components == 1 {
+            // Single-component (grayscale) lossless decode
+            let dc_table = dc_tables[0];
+            let mut output = vec![0u16; width * height];
+            let mut prev_row: Option<Vec<u16>> = None;
 
-        // Decode all samples using Huffman-coded differences + prediction
-        let mut output = vec![0u16; width * height];
-        let mut prev_row: Option<Vec<u16>> = None;
-
-        for y in 0..height {
-            let row_start = y * width;
-            let mut diffs = Vec::with_capacity(width);
-
-            // Decode one row of difference values using DC Huffman table
-            for _ in 0..width {
-                let diff = huffman::decode_dc_coefficient(&mut reader, dc_table)?;
-                diffs.push(diff);
+            for y in 0..height {
+                let row_start = y * width;
+                let mut diffs = Vec::with_capacity(width);
+                for _ in 0..width {
+                    let diff = huffman::decode_dc_coefficient(&mut reader, dc_table)?;
+                    diffs.push(diff);
+                }
+                lossless::undifference_row(
+                    &diffs,
+                    prev_row.as_deref(),
+                    &mut output[row_start..row_start + width],
+                    psv,
+                    precision,
+                    pt,
+                    y == 0,
+                );
+                prev_row = Some(output[row_start..row_start + width].to_vec());
             }
 
-            // Undifference using the selected predictor
-            lossless::undifference_row(
-                &diffs,
-                prev_row.as_deref(),
-                &mut output[row_start..row_start + width],
-                psv,
-                precision,
-                pt,
-                y == 0,
-            );
+            // Convert to output format
+            let out_format = self.output_format.unwrap_or(PixelFormat::Grayscale);
+            let bpp = out_format.bytes_per_pixel();
 
-            prev_row = Some(output[row_start..row_start + width].to_vec());
-        }
-
-        // Apply point transform (upscale) and convert to u8
-        let out_format = self.output_format.unwrap_or(PixelFormat::Grayscale);
-        let bpp = out_format.bytes_per_pixel();
-
-        if out_format == PixelFormat::Grayscale {
-            let mut data = Vec::with_capacity(width * height);
-            for &sample in &output {
-                let val = if pt > 0 {
-                    ((sample as u32) << pt) as u8
-                } else {
-                    sample as u8
-                };
-                data.push(val);
+            if out_format == PixelFormat::Grayscale {
+                let mut data = Vec::with_capacity(width * height);
+                for &sample in &output {
+                    let val = if pt > 0 {
+                        ((sample as u32) << pt) as u8
+                    } else {
+                        sample as u8
+                    };
+                    data.push(val);
+                }
+                Ok(Image {
+                    width,
+                    height,
+                    pixel_format: PixelFormat::Grayscale,
+                    data,
+                    icc_profile,
+                    exif_data,
+                    warnings: Vec::new(),
+                })
+            } else {
+                let mut data = Vec::with_capacity(width * height * bpp);
+                for &sample in &output {
+                    let val = if pt > 0 {
+                        ((sample as u32) << pt) as u8
+                    } else {
+                        sample as u8
+                    };
+                    match out_format {
+                        PixelFormat::Rgb | PixelFormat::Bgr => {
+                            data.push(val);
+                            data.push(val);
+                            data.push(val);
+                        }
+                        PixelFormat::Rgba | PixelFormat::Bgra => {
+                            data.push(val);
+                            data.push(val);
+                            data.push(val);
+                            data.push(255);
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+                Ok(Image {
+                    width,
+                    height,
+                    pixel_format: out_format,
+                    data,
+                    icc_profile,
+                    exif_data,
+                    warnings: Vec::new(),
+                })
             }
-            Ok(Image {
-                width,
-                height,
-                pixel_format: PixelFormat::Grayscale,
-                data,
-                icc_profile,
-                exif_data,
-                warnings: Vec::new(),
-            })
-        } else {
-            // Expand to color format
-            let mut data = Vec::with_capacity(width * height * bpp);
-            for &sample in &output {
-                let val = if pt > 0 {
-                    ((sample as u32) << pt) as u8
-                } else {
-                    sample as u8
-                };
-                match out_format {
-                    PixelFormat::Rgb | PixelFormat::Bgr => {
-                        data.push(val);
-                        data.push(val);
-                        data.push(val);
+        } else if num_components == 3 {
+            // Multi-component (color) lossless decode — interleaved scan
+            let mut comp_planes: Vec<Vec<u16>> =
+                (0..3).map(|_| vec![0u16; width * height]).collect();
+            let mut prev_rows: Vec<Option<Vec<u16>>> = vec![None; 3];
+
+            for y in 0..height {
+                let row_start = y * width;
+                let mut comp_diffs: Vec<Vec<i16>> =
+                    (0..3).map(|_| Vec::with_capacity(width)).collect();
+
+                // Interleaved: for each pixel, decode diff for each component
+                for _ in 0..width {
+                    for c in 0..3 {
+                        let diff = huffman::decode_dc_coefficient(&mut reader, dc_tables[c])?;
+                        comp_diffs[c].push(diff);
                     }
-                    PixelFormat::Rgba | PixelFormat::Bgra => {
-                        data.push(val);
-                        data.push(val);
-                        data.push(val);
-                        data.push(255);
-                    }
-                    _ => unreachable!(),
+                }
+
+                // Undifference each component
+                for c in 0..3 {
+                    lossless::undifference_row(
+                        &comp_diffs[c],
+                        prev_rows[c].as_deref(),
+                        &mut comp_planes[c][row_start..row_start + width],
+                        psv,
+                        precision,
+                        pt,
+                        y == 0,
+                    );
+                    prev_rows[c] = Some(comp_planes[c][row_start..row_start + width].to_vec());
                 }
             }
+
+            // Color convert YCbCr → RGB and output
+            let out_format = self.output_format.unwrap_or(PixelFormat::Rgb);
+            let bpp = out_format.bytes_per_pixel();
+            let mut data = Vec::with_capacity(width * height * bpp);
+
+            for i in 0..width * height {
+                let y_val = comp_planes[0][i] as i32;
+                let cb_val = comp_planes[1][i] as i32;
+                let cr_val = comp_planes[2][i] as i32;
+
+                // YCbCr to RGB (JFIF convention: Y,Cb,Cr centered at 128)
+                let r = (y_val + ((cr_val - 128) * 359 + 128) / 256).clamp(0, 255) as u8;
+                let g = (y_val - ((cb_val - 128) * 88 + (cr_val - 128) * 183 - 128) / 256)
+                    .clamp(0, 255) as u8;
+                let b = (y_val + ((cb_val - 128) * 454 + 128) / 256).clamp(0, 255) as u8;
+
+                match out_format {
+                    PixelFormat::Rgb => {
+                        data.push(r);
+                        data.push(g);
+                        data.push(b);
+                    }
+                    PixelFormat::Bgr => {
+                        data.push(b);
+                        data.push(g);
+                        data.push(r);
+                    }
+                    PixelFormat::Rgba => {
+                        data.push(r);
+                        data.push(g);
+                        data.push(b);
+                        data.push(255);
+                    }
+                    PixelFormat::Bgra => {
+                        data.push(b);
+                        data.push(g);
+                        data.push(r);
+                        data.push(255);
+                    }
+                    _ => {
+                        return Err(JpegError::Unsupported(
+                            "cannot convert lossless 3-component to requested format".to_string(),
+                        ));
+                    }
+                }
+            }
+
             Ok(Image {
                 width,
                 height,
@@ -1206,6 +1288,11 @@ impl<'a> Decoder<'a> {
                 exif_data,
                 warnings: Vec::new(),
             })
+        } else {
+            Err(JpegError::Unsupported(format!(
+                "{} components not yet supported for lossless",
+                num_components
+            )))
         }
     }
 

--- a/tests/lossless_decode.rs
+++ b/tests/lossless_decode.rs
@@ -119,6 +119,146 @@ fn make_lossless_jpeg(pixels: &[u8], width: u16, height: u16, precision: u8) -> 
     out
 }
 
+/// Build a 3-component SOF3 (lossless) JPEG for testing.
+/// Interleaved scan: components decoded round-robin per pixel.
+fn make_lossless_jpeg_3comp(
+    y_data: &[u8],
+    cb_data: &[u8],
+    cr_data: &[u8],
+    width: u16,
+    height: u16,
+    precision: u8,
+) -> Vec<u8> {
+    let mut out = Vec::new();
+
+    // SOI
+    out.extend_from_slice(&[0xFF, 0xD8]);
+
+    // DHT — DC Huffman table 0
+    let dc_bits: [u8; 17] = [0, 0, 1, 5, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0];
+    let dc_values: &[u8] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+    out.extend_from_slice(&[0xFF, 0xC4]);
+    let dht_len: u16 = 2 + 1 + 16 + dc_values.len() as u16;
+    out.extend_from_slice(&dht_len.to_be_bytes());
+    out.push(0x00); // DC table 0
+    out.extend_from_slice(&dc_bits[1..]);
+    out.extend_from_slice(dc_values);
+
+    // SOF3 — Lossless, Huffman-coded, 3 components
+    out.extend_from_slice(&[0xFF, 0xC3]);
+    let sof_len: u16 = 2 + 1 + 2 + 2 + 1 + 3 * 3; // 3 components
+    out.extend_from_slice(&sof_len.to_be_bytes());
+    out.push(precision);
+    out.extend_from_slice(&height.to_be_bytes());
+    out.extend_from_slice(&width.to_be_bytes());
+    out.push(3); // 3 components
+                 // Y: id=1, h=1, v=1, qt=0
+    out.push(1);
+    out.push(0x11);
+    out.push(0);
+    // Cb: id=2, h=1, v=1, qt=0
+    out.push(2);
+    out.push(0x11);
+    out.push(0);
+    // Cr: id=3, h=1, v=1, qt=0
+    out.push(3);
+    out.push(0x11);
+    out.push(0);
+
+    // SOS — 3 components, interleaved, predictor 1
+    out.extend_from_slice(&[0xFF, 0xDA]);
+    let sos_len: u16 = 2 + 1 + 3 * 2 + 3;
+    out.extend_from_slice(&sos_len.to_be_bytes());
+    out.push(3); // 3 components
+    out.push(1);
+    out.push(0x00); // Y: DC table 0
+    out.push(2);
+    out.push(0x00); // Cb: DC table 0
+    out.push(3);
+    out.push(0x00); // Cr: DC table 0
+    out.push(1); // Ss = predictor 1 (left)
+    out.push(0); // Se = 0
+    out.push(0x00); // Ah=0, Al=0
+
+    // Entropy-coded data: interleaved — for each pixel, encode Y diff, Cb diff, Cr diff
+    let huff_codes = build_dc_encode_table(&dc_bits, dc_values);
+    let initial_pred = 1u32 << (precision as u32 - 1);
+    let mask = (1u32 << precision) - 1;
+
+    let mut bit_buf: u32 = 0;
+    let mut bit_count: u32 = 0;
+
+    let planes: [&[u8]; 3] = [y_data, cb_data, cr_data];
+    let mut prev_rows: [Option<Vec<u16>>; 3] = [None, None, None];
+    let mut cur_rows: [Vec<u16>; 3] = [
+        vec![0u16; width as usize],
+        vec![0u16; width as usize],
+        vec![0u16; width as usize],
+    ];
+
+    for y in 0..height as usize {
+        for x in 0..width as usize {
+            for c in 0..3 {
+                let pixel = planes[c][y * width as usize + x] as i32;
+                let prediction = if y == 0 && x == 0 {
+                    initial_pred as i32
+                } else if y == 0 {
+                    cur_rows[c][x - 1] as i32
+                } else if x == 0 {
+                    prev_rows[c].as_ref().unwrap()[x] as i32
+                } else {
+                    cur_rows[c][x - 1] as i32
+                };
+
+                cur_rows[c][x] = pixel as u16;
+
+                let diff = ((pixel - prediction) as i32) & (mask as i32);
+                let signed_diff = if diff >= (1 << (precision - 1)) {
+                    diff - (1 << precision)
+                } else {
+                    diff
+                };
+
+                let (category, extra_bits, extra_len) = categorize_dc(signed_diff);
+                let (code, code_len) = huff_codes[category as usize];
+
+                bit_buf = (bit_buf << code_len) | code as u32;
+                bit_count += code_len as u32;
+                if extra_len > 0 {
+                    bit_buf = (bit_buf << extra_len) | extra_bits as u32;
+                    bit_count += extra_len as u32;
+                }
+
+                while bit_count >= 8 {
+                    bit_count -= 8;
+                    let byte = (bit_buf >> bit_count) as u8;
+                    out.push(byte);
+                    if byte == 0xFF {
+                        out.push(0x00);
+                    }
+                    bit_buf &= (1 << bit_count) - 1;
+                }
+            }
+        }
+        for c in 0..3 {
+            prev_rows[c] = Some(cur_rows[c].clone());
+        }
+    }
+
+    if bit_count > 0 {
+        let padding = 8 - bit_count;
+        bit_buf = (bit_buf << padding) | ((1 << padding) - 1);
+        let byte = bit_buf as u8;
+        out.push(byte);
+        if byte == 0xFF {
+            out.push(0x00);
+        }
+    }
+
+    out.extend_from_slice(&[0xFF, 0xD9]);
+    out
+}
+
 fn build_dc_encode_table(bits: &[u8; 17], values: &[u8]) -> Vec<(u16, u8)> {
     // Build codes from JPEG standard Huffman table specification
     let mut table = vec![(0u16, 0u8); 17]; // category 0..16
@@ -187,4 +327,30 @@ fn decode_lossless_grayscale_ramp() {
     assert_eq!(img.width, 16);
     assert_eq!(img.height, 16);
     assert_eq!(img.data, pixels);
+}
+
+#[test]
+fn decode_lossless_3comp_flat() {
+    let (w, h) = (4, 4);
+    let y_data = vec![128u8; w * h];
+    let cb_data = vec![100u8; w * h];
+    let cr_data = vec![150u8; w * h];
+    let jpeg = make_lossless_jpeg_3comp(&y_data, &cb_data, &cr_data, w as u16, h as u16, 8);
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, w);
+    assert_eq!(img.height, h);
+    assert_eq!(img.data.len(), w * h * 3);
+}
+
+#[test]
+fn decode_lossless_3comp_gradient() {
+    let (w, h) = (8, 4);
+    let y_data: Vec<u8> = (0..w * h).map(|i| (i * 3 % 256) as u8).collect();
+    let cb_data: Vec<u8> = (0..w * h).map(|i| (128 + i % 128) as u8).collect();
+    let cr_data: Vec<u8> = (0..w * h).map(|i| (64 + i * 2 % 192) as u8).collect();
+    let jpeg = make_lossless_jpeg_3comp(&y_data, &cb_data, &cr_data, w as u16, h as u16, 8);
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, w);
+    assert_eq!(img.height, h);
+    assert_eq!(img.data.len(), w * h * 3);
 }


### PR DESCRIPTION
## Summary
- Extend `decode_lossless_image()` to handle 3-component interleaved lossless JPEG
- Per-component Huffman tables with round-robin interleaved decoding
- YCbCr-to-RGB color conversion for 3-component output

## Test plan
- [x] 3-component flat data decode (4x4)
- [x] 3-component gradient data decode (8x4)
- [x] Existing grayscale lossless tests still pass
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)