### PR TITLE
feat: add lossless JPEG (SOF3) encoding

### DIFF
--- a/src/api/high_level.rs
+++ b/src/api/high_level.rs
@@ -135,6 +135,19 @@ pub fn compress_with_metadata(
     )
 }
 
+/// Compress as lossless JPEG (SOF3).
+///
+/// Uses predictor 1 (left) with no point transform. Produces exact
+/// pixel-identical output when decoded. Currently supports grayscale only.
+pub fn compress_lossless(
+    pixels: &[u8],
+    width: usize,
+    height: usize,
+    pixel_format: PixelFormat,
+) -> Result<Vec<u8>> {
+    encoder::compress_lossless(pixels, width, height, pixel_format)
+}
+
 /// Compress with arithmetic entropy coding (SOF9).
 ///
 /// Uses QM-coder binary arithmetic coding instead of Huffman coding.

--- a/src/encode/huffman_encode.rs
+++ b/src/encode/huffman_encode.rs
@@ -205,6 +205,20 @@ impl HuffmanEncoder {
             writer.write_bits(ac_table.ehufco[0x00], ac_table.ehufsi[0x00]);
         }
     }
+
+    /// Encode a single DC difference value (for lossless JPEG).
+    ///
+    /// Writes the Huffman code for the category, then the magnitude bits.
+    pub fn encode_dc_only(writer: &mut BitWriter, diff: i16, dc_table: &HuffTable) {
+        let (magnitude_bits, category) = encode_dc_value(diff);
+        writer.write_bits(
+            dc_table.ehufco[category as usize],
+            dc_table.ehufsi[category as usize],
+        );
+        if category > 0 {
+            writer.write_bits(magnitude_bits, category);
+        }
+    }
 }
 
 /// Compute the category and magnitude bits for a DC difference value.

--- a/src/encode/marker_writer.rs
+++ b/src/encode/marker_writer.rs
@@ -292,6 +292,50 @@ pub fn write_app14_adobe(buf: &mut Vec<u8>, transform: u8) {
     buf.push(transform); // color transform
 }
 
+/// Write SOF3 (lossless, Huffman-coded) frame header.
+pub fn write_sof3(
+    buf: &mut Vec<u8>,
+    width: u16,
+    height: u16,
+    precision: u8,
+    components: &[(u8, u8, u8, u8)],
+) {
+    buf.push(0xFF);
+    buf.push(0xC3); // SOF3
+    let length: u16 = 2 + 1 + 2 + 2 + 1 + (components.len() as u16 * 3);
+    buf.extend_from_slice(&length.to_be_bytes());
+    buf.push(precision);
+    buf.extend_from_slice(&height.to_be_bytes());
+    buf.extend_from_slice(&width.to_be_bytes());
+    buf.push(components.len() as u8);
+    for &(id, h_samp, v_samp, qt_idx) in components {
+        buf.push(id);
+        buf.push((h_samp << 4) | v_samp);
+        buf.push(qt_idx);
+    }
+}
+
+/// Write SOS for lossless scan. Ss=predictor (1-7), Se=0, Ah=0, Al=point_transform.
+pub fn write_sos_lossless(
+    buf: &mut Vec<u8>,
+    components: &[(u8, u8)],
+    predictor: u8,
+    point_transform: u8,
+) {
+    buf.push(0xFF);
+    buf.push(0xDA); // SOS
+    let length: u16 = 2 + 1 + (components.len() as u16 * 2) + 3;
+    buf.extend_from_slice(&length.to_be_bytes());
+    buf.push(components.len() as u8);
+    for &(id, dc_tbl) in components {
+        buf.push(id);
+        buf.push((dc_tbl << 4) | 0); // DC table only, AC unused
+    }
+    buf.push(predictor); // Ss = predictor selection (1-7)
+    buf.push(0); // Se = 0
+    buf.push(point_transform & 0x0F); // Ah=0, Al=point_transform
+}
+
 /// Write EOI (End Of Image) marker: 0xFFD9.
 pub fn write_eoi(buf: &mut Vec<u8>) {
     buf.push(0xFF);

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -355,6 +355,112 @@ fn compress_cmyk(pixels: &[u8], width: usize, height: usize, quality: u8) -> Res
     marker_writer::write_sos(&mut output, &scan_components);
 
     output.extend_from_slice(bit_writer.data());
+
+    marker_writer::write_eoi(&mut output);
+
+    Ok(output)
+}
+
+/// Compress as lossless JPEG (SOF3).
+///
+/// Uses predictor 1 (left) and no point transform.
+/// Produces exact pixel-identical output when decoded.
+pub fn compress_lossless(
+    pixels: &[u8],
+    width: usize,
+    height: usize,
+    pixel_format: PixelFormat,
+) -> Result<Vec<u8>> {
+    if pixel_format != PixelFormat::Grayscale {
+        return Err(JpegError::Unsupported(
+            "lossless encoding only supports grayscale".to_string(),
+        ));
+    }
+
+    if width == 0 || height == 0 {
+        return Err(JpegError::CorruptData(
+            "image dimensions must be non-zero".to_string(),
+        ));
+    }
+
+    if pixels.len() < width * height {
+        return Err(JpegError::BufferTooSmall {
+            need: width * height,
+            got: pixels.len(),
+        });
+    }
+
+    let precision: u8 = 8;
+    let predictor: u8 = 1; // left
+    let point_transform: u8 = 0;
+    let initial_pred: i32 = 1 << (precision as i32 - point_transform as i32 - 1); // 128
+    let mask: i32 = (1i32 << precision) - 1;
+
+    // Compute differences using predictor 1 (left)
+    // Then Huffman-encode each difference using DC coding (category + extra bits)
+    let mut bit_writer = BitWriter::new(width * height);
+    let dc_table = build_huff_table(&tables::DC_LUMINANCE_BITS, &tables::DC_LUMINANCE_VALUES);
+
+    for y in 0..height {
+        for x in 0..width {
+            let pixel = pixels[y * width + x] as i32;
+            let prediction = if y == 0 && x == 0 {
+                initial_pred
+            } else if y == 0 {
+                pixels[y * width + x - 1] as i32
+            } else if x == 0 {
+                pixels[(y - 1) * width + x] as i32
+            } else {
+                // predictor 1 = left
+                pixels[y * width + x - 1] as i32
+            };
+
+            let diff = (pixel - prediction) & mask;
+            // Convert to signed: if >= 2^(p-1), it's negative
+            let signed_diff = if diff >= (1 << (precision - 1)) {
+                diff - (1 << precision)
+            } else {
+                diff
+            };
+
+            // Encode as DC coefficient (category + extra bits)
+            HuffmanEncoder::encode_dc_only(&mut bit_writer, signed_diff as i16, &dc_table);
+        }
+    }
+
+    bit_writer.flush();
+
+    // Assemble: SOI, DHT (DC table), SOF3, SOS (predictor=1, pt=0), entropy data, EOI
+    let mut output = Vec::with_capacity(bit_writer.data().len() + 256);
+
+    marker_writer::write_soi(&mut output);
+
+    // DC Huffman table
+    marker_writer::write_dht(
+        &mut output,
+        0,
+        0,
+        &tables::DC_LUMINANCE_BITS,
+        &tables::DC_LUMINANCE_VALUES,
+    );
+
+    // SOF3 frame header
+    let components = vec![(1, 1, 1, 0)]; // id=1, h=1, v=1, qt=0
+    marker_writer::write_sof3(
+        &mut output,
+        width as u16,
+        height as u16,
+        precision,
+        &components,
+    );
+
+    // SOS lossless scan header
+    let scan_components = vec![(1, 0)]; // component 1, DC table 0
+    marker_writer::write_sos_lossless(&mut output, &scan_components, predictor, point_transform);
+
+    // Entropy data
+    output.extend_from_slice(bit_writer.data());
+
     marker_writer::write_eoi(&mut output);
 
     Ok(output)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub use api::coefficient::{
     read_coefficients, transform_jpeg as transform, write_coefficients, JpegCoefficients,
 };
 pub use api::high_level::{
-    compress, compress_arithmetic, compress_optimized, compress_progressive,
+    compress, compress_arithmetic, compress_lossless, compress_optimized, compress_progressive,
     compress_with_metadata, decompress, decompress_cropped, decompress_lenient, decompress_to,
 };
 pub use common::error::{DecodeWarning, JpegError, Result};

--- a/tests/lossless_encode.rs
+++ b/tests/lossless_encode.rs
@@ -1,0 +1,41 @@
+use libjpeg_turbo_rs::{compress_lossless, decompress, PixelFormat};
+
+#[test]
+fn lossless_encode_grayscale_roundtrip() {
+    let pixels: Vec<u8> = (0..=255).collect();
+    let jpeg = compress_lossless(&pixels, 16, 16, PixelFormat::Grayscale).unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 16);
+    assert_eq!(img.height, 16);
+    assert_eq!(img.data, pixels); // Lossless = exact match
+}
+
+#[test]
+fn lossless_encode_gradient() {
+    let (w, h) = (32, 32);
+    let mut pixels = vec![0u8; w * h];
+    for y in 0..h {
+        for x in 0..w {
+            pixels[y * w + x] = ((x * 7 + y * 3) % 256) as u8;
+        }
+    }
+    let jpeg = compress_lossless(&pixels, w, h, PixelFormat::Grayscale).unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.data, pixels);
+}
+
+#[test]
+fn lossless_encode_produces_sof3_marker() {
+    let pixels = vec![128u8; 8 * 8];
+    let jpeg = compress_lossless(&pixels, 8, 8, PixelFormat::Grayscale).unwrap();
+    let has_sof3 = jpeg.windows(2).any(|w| w[0] == 0xFF && w[1] == 0xC3);
+    assert!(has_sof3, "should contain SOF3 marker");
+}
+
+#[test]
+fn lossless_encode_flat_image() {
+    let pixels = vec![42u8; 64];
+    let jpeg = compress_lossless(&pixels, 8, 8, PixelFormat::Grayscale).unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.data, pixels);
+}


### PR DESCRIPTION
## Summary
- Add `compress_lossless()` for grayscale with predictor 1 (left), no point transform
- Add `write_sof3()` and `write_sos_lossless()` marker writers
- Add `encode_dc_only()` to HuffmanEncoder for difference-only encoding
- Produces exact pixel-identical output when decoded (verified roundtrip)

## Test plan
- [x] Grayscale roundtrip exact match (16x16, full 0-255 ramp)
- [x] Gradient pattern roundtrip exact match (32x32)
- [x] SOF3 marker present in output
- [x] Flat image roundtrip exact match
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)