### PR TITLE
feat: add custom quantization table support

### DIFF
--- a/src/api/encoder.rs
+++ b/src/api/encoder.rs
@@ -27,6 +27,7 @@ pub struct Encoder<'a> {
     icc_profile: Option<&'a [u8]>,
     exif_data: Option<&'a [u8]>,
     comment: Option<&'a str>,
+    custom_quant_tables: [Option<[u16; 64]>; 4],
 }
 
 impl<'a> Encoder<'a> {
@@ -47,6 +48,7 @@ impl<'a> Encoder<'a> {
             icc_profile: None,
             exif_data: None,
             comment: None,
+            custom_quant_tables: [None; 4],
         }
     }
 
@@ -122,6 +124,17 @@ impl<'a> Encoder<'a> {
         self
     }
 
+    /// Set a custom quantization table for the given table slot (0-3).
+    ///
+    /// Index 0 is used for luma, index 1 for chroma. When set, the custom
+    /// table overrides the quality-scaled standard table for that component.
+    /// Values are raw quantization coefficients in zigzag order.
+    pub fn quant_table(mut self, index: usize, table: [u16; 64]) -> Self {
+        assert!(index < 4, "quantization table index must be 0..3");
+        self.custom_quant_tables[index] = Some(table);
+        self
+    }
+
     /// Compute the restart interval in MCU blocks from the configured restart setting.
     fn compute_restart_interval(&self) -> u16 {
         match self.restart_interval {
@@ -141,6 +154,11 @@ impl<'a> Encoder<'a> {
                 n.saturating_mul(mcus_x)
             }
         }
+    }
+
+    /// Returns true if any custom quantization table has been set.
+    fn has_custom_quant_tables(&self) -> bool {
+        self.custom_quant_tables.iter().any(|t| t.is_some())
     }
 
     /// Encode and return the JPEG byte stream.
@@ -175,6 +193,16 @@ impl<'a> Encoder<'a> {
                 self.pixel_format,
                 self.quality,
                 self.subsampling,
+            )?
+        } else if self.has_custom_quant_tables() {
+            encoder::compress_custom_quant(
+                self.pixels,
+                self.width,
+                self.height,
+                self.pixel_format,
+                self.quality,
+                self.subsampling,
+                &self.custom_quant_tables,
             )?
         } else if restart_interval > 0 {
             encoder::compress_with_restart(

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -222,6 +222,216 @@ pub fn compress(
     Ok(output)
 }
 
+/// Compress raw pixel data into a JPEG byte stream using custom quantization tables.
+///
+/// When `custom_quant[0]` is `Some`, it overrides the quality-scaled luminance table.
+/// When `custom_quant[1]` is `Some`, it overrides the quality-scaled chrominance table.
+/// Unset slots fall back to the standard quality-scaled tables.
+pub fn compress_custom_quant(
+    pixels: &[u8],
+    width: usize,
+    height: usize,
+    pixel_format: PixelFormat,
+    quality: u8,
+    subsampling: Subsampling,
+    custom_quant: &[Option<[u16; 64]>; 4],
+) -> Result<Vec<u8>> {
+    // Validate inputs
+    if width == 0 || height == 0 {
+        return Err(JpegError::CorruptData(
+            "image dimensions must be non-zero".to_string(),
+        ));
+    }
+
+    let bpp = pixel_format.bytes_per_pixel();
+    let expected_size = width * height * bpp;
+    if pixels.len() < expected_size {
+        return Err(JpegError::BufferTooSmall {
+            need: expected_size,
+            got: pixels.len(),
+        });
+    }
+
+    // CMYK: 4-component path, no color conversion
+    if pixel_format == PixelFormat::Cmyk {
+        return compress_cmyk(pixels, width, height, quality);
+    }
+
+    let is_grayscale = pixel_format == PixelFormat::Grayscale;
+
+    // Use custom tables when provided, otherwise fall back to quality-scaled defaults
+    let luma_quant = match custom_quant[0] {
+        Some(table) => table,
+        None => tables::quality_scale_quant_table(&tables::STD_LUMINANCE_QUANT_TABLE, quality),
+    };
+    let chroma_quant = match custom_quant[1] {
+        Some(table) => table,
+        None => tables::quality_scale_quant_table(&tables::STD_CHROMINANCE_QUANT_TABLE, quality),
+    };
+
+    // The islow FDCT leaves a factor-of-8 scaling in its output. To absorb this,
+    // the divisor tables used during quantization multiply the quant values by 8,
+    // matching libjpeg-turbo's jcdctmgr.c (quantval[i] << 3).
+    let luma_divisors = scale_quant_for_fdct(&luma_quant);
+    let chroma_divisors = scale_quant_for_fdct(&chroma_quant);
+
+    // Build Huffman tables
+    let dc_luma_table = build_huff_table(&tables::DC_LUMINANCE_BITS, &tables::DC_LUMINANCE_VALUES);
+    let ac_luma_table = build_huff_table(&tables::AC_LUMINANCE_BITS, &tables::AC_LUMINANCE_VALUES);
+    let dc_chroma_table =
+        build_huff_table(&tables::DC_CHROMINANCE_BITS, &tables::DC_CHROMINANCE_VALUES);
+    let ac_chroma_table =
+        build_huff_table(&tables::AC_CHROMINANCE_BITS, &tables::AC_CHROMINANCE_VALUES);
+
+    // Color convert to YCbCr planes (or just Y for grayscale)
+    let (y_plane, cb_plane, cr_plane) = convert_to_ycbcr(pixels, width, height, pixel_format)?;
+
+    // Determine MCU dimensions based on subsampling
+    let (mcu_w, mcu_h) = if is_grayscale {
+        (8, 8)
+    } else {
+        match subsampling {
+            Subsampling::S444 => (8, 8),
+            Subsampling::S422 => (16, 8),
+            Subsampling::S420 => (16, 16),
+            Subsampling::S440 => (8, 16),
+            Subsampling::S411 => (32, 8),
+        }
+    };
+
+    let mcus_x = (width + mcu_w - 1) / mcu_w;
+    let mcus_y = (height + mcu_h - 1) / mcu_h;
+
+    // Entropy encode all MCUs
+    let mut bit_writer = BitWriter::new(width * height);
+    let mut prev_dc_y: i16 = 0;
+    let mut prev_dc_cb: i16 = 0;
+    let mut prev_dc_cr: i16 = 0;
+
+    for mcu_row in 0..mcus_y {
+        for mcu_col in 0..mcus_x {
+            let x0 = mcu_col * mcu_w;
+            let y0 = mcu_row * mcu_h;
+
+            if is_grayscale {
+                encode_single_block(
+                    &y_plane,
+                    width,
+                    height,
+                    x0,
+                    y0,
+                    &luma_divisors,
+                    &dc_luma_table,
+                    &ac_luma_table,
+                    &mut bit_writer,
+                    &mut prev_dc_y,
+                );
+            } else {
+                encode_color_mcu(
+                    &y_plane,
+                    &cb_plane,
+                    &cr_plane,
+                    width,
+                    height,
+                    x0,
+                    y0,
+                    subsampling,
+                    &luma_divisors,
+                    &chroma_divisors,
+                    &dc_luma_table,
+                    &ac_luma_table,
+                    &dc_chroma_table,
+                    &ac_chroma_table,
+                    &mut bit_writer,
+                    &mut prev_dc_y,
+                    &mut prev_dc_cb,
+                    &mut prev_dc_cr,
+                );
+            }
+        }
+    }
+
+    bit_writer.flush();
+
+    // Assemble output: markers + entropy data + EOI
+    let mut output = Vec::with_capacity(bit_writer.data().len() + 1024);
+
+    marker_writer::write_soi(&mut output);
+    marker_writer::write_app0_jfif(&mut output);
+
+    // Quantization tables
+    marker_writer::write_dqt(&mut output, 0, &luma_quant);
+    if !is_grayscale {
+        marker_writer::write_dqt(&mut output, 1, &chroma_quant);
+    }
+
+    // Frame header
+    if is_grayscale {
+        let components = vec![(1, 1, 1, 0)];
+        marker_writer::write_sof0(&mut output, width as u16, height as u16, &components);
+    } else {
+        let (h_samp, v_samp) = subsampling.sampling_factors();
+        let components = vec![
+            (1, h_samp, v_samp, 0), // Y
+            (2, 1, 1, 1),           // Cb
+            (3, 1, 1, 1),           // Cr
+        ];
+        marker_writer::write_sof0(&mut output, width as u16, height as u16, &components);
+    }
+
+    // Huffman tables
+    marker_writer::write_dht(
+        &mut output,
+        0,
+        0,
+        &tables::DC_LUMINANCE_BITS,
+        &tables::DC_LUMINANCE_VALUES,
+    );
+    marker_writer::write_dht(
+        &mut output,
+        1,
+        0,
+        &tables::AC_LUMINANCE_BITS,
+        &tables::AC_LUMINANCE_VALUES,
+    );
+    if !is_grayscale {
+        marker_writer::write_dht(
+            &mut output,
+            0,
+            1,
+            &tables::DC_CHROMINANCE_BITS,
+            &tables::DC_CHROMINANCE_VALUES,
+        );
+        marker_writer::write_dht(
+            &mut output,
+            1,
+            1,
+            &tables::AC_CHROMINANCE_BITS,
+            &tables::AC_CHROMINANCE_VALUES,
+        );
+    }
+
+    // Scan header
+    if is_grayscale {
+        let scan_components = vec![(1, 0, 0)];
+        marker_writer::write_sos(&mut output, &scan_components);
+    } else {
+        let scan_components = vec![
+            (1, 0, 0), // Y: DC table 0, AC table 0
+            (2, 1, 1), // Cb: DC table 1, AC table 1
+            (3, 1, 1), // Cr: DC table 1, AC table 1
+        ];
+        marker_writer::write_sos(&mut output, &scan_components);
+    }
+
+    // Entropy-coded data
+    output.extend_from_slice(bit_writer.data());
+
+    marker_writer::write_eoi(&mut output);
+
+    Ok(output)
+}
+
 /// Compress raw pixel data into a JPEG byte stream with DRI restart markers.
 ///
 /// `restart_interval` is the number of MCU blocks between restart markers.

--- a/tests/custom_quant.rs
+++ b/tests/custom_quant.rs
@@ -1,0 +1,73 @@
+use libjpeg_turbo_rs::{decompress, Encoder, PixelFormat, Subsampling};
+
+#[test]
+fn custom_quant_table_roundtrip() {
+    let pixels = vec![128u8; 16 * 16 * 3];
+    let table = [16u16; 64]; // flat quant table
+    let jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .quality(75)
+        .quant_table(0, table)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 16);
+    assert_eq!(img.height, 16);
+}
+
+#[test]
+fn custom_quant_table_affects_output() {
+    let pixels = vec![128u8; 16 * 16 * 3];
+
+    let default_jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .quality(75)
+        .encode()
+        .unwrap();
+
+    let custom_table = [1u16; 64]; // very fine quantization
+    let custom_jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .quality(75)
+        .quant_table(0, custom_table)
+        .encode()
+        .unwrap();
+
+    // Different quant tables should produce different output
+    assert_ne!(default_jpeg, custom_jpeg);
+}
+
+#[test]
+fn custom_quant_table_chroma() {
+    let pixels = vec![128u8; 16 * 16 * 3];
+
+    let default_jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .quality(75)
+        .subsampling(Subsampling::S444)
+        .encode()
+        .unwrap();
+
+    let chroma_table = [2u16; 64]; // custom chroma quantization
+    let custom_jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .quality(75)
+        .subsampling(Subsampling::S444)
+        .quant_table(1, chroma_table)
+        .encode()
+        .unwrap();
+
+    // Custom chroma table should produce different output
+    assert_ne!(default_jpeg, custom_jpeg);
+}
+
+#[test]
+fn custom_quant_table_both_luma_and_chroma() {
+    let pixels = vec![128u8; 16 * 16 * 3];
+    let luma_table = [8u16; 64];
+    let chroma_table = [32u16; 64];
+    let jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .quality(75)
+        .quant_table(0, luma_table)
+        .quant_table(1, chroma_table)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 16);
+    assert_eq!(img.height, 16);
+}


### PR DESCRIPTION
## Summary
- Add `quant_table(index, table)` builder method to Encoder
- Custom quant tables override quality-scaled defaults per slot (0=luma, 1=chroma)

## Test plan
- [x] Custom luma table roundtrip
- [x] Custom table produces different output than default
- [x] Custom chroma table
- [x] Both luma+chroma custom tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)