### PR TITLE
feat: add custom progressive scan script support

### DIFF
--- a/src/api/encoder.rs
+++ b/src/api/encoder.rs
@@ -1,5 +1,5 @@
 use crate::common::error::Result;
-use crate::common::types::{PixelFormat, Subsampling};
+use crate::common::types::{PixelFormat, ScanScript, Subsampling};
 use crate::encode::pipeline as encoder;
 
 /// Configuration for DRI restart interval encoding.
@@ -42,6 +42,7 @@ pub struct Encoder<'a> {
     icc_profile: Option<&'a [u8]>,
     exif_data: Option<&'a [u8]>,
     comment: Option<&'a str>,
+    scan_script: Option<Vec<ScanScript>>,
     custom_quant_tables: [Option<[u16; 64]>; 4],
     custom_huffman_dc: [Option<HuffmanTableDef>; 4],
     custom_huffman_ac: [Option<HuffmanTableDef>; 4],
@@ -65,6 +66,7 @@ impl<'a> Encoder<'a> {
             lossless_point_transform: 0,
             grayscale_from_color: false,
             restart_interval: None,
+            scan_script: None,
             icc_profile: None,
             exif_data: None,
             comment: None,
@@ -95,6 +97,17 @@ impl<'a> Encoder<'a> {
     /// Enable progressive JPEG mode.
     pub fn progressive(mut self, progressive: bool) -> Self {
         self.progressive = progressive;
+        self
+    }
+
+    /// Set a custom progressive scan script.
+    ///
+    /// When progressive mode is enabled, this script replaces the default
+    /// `simple_progression()` scan order. Each `ScanScript` entry defines
+    /// one scan pass with its component set and spectral/successive-approximation
+    /// parameters.
+    pub fn scan_script(mut self, script: Vec<ScanScript>) -> Self {
+        self.scan_script = Some(script);
         self
     }
 
@@ -311,14 +324,26 @@ impl<'a> Encoder<'a> {
                 self.subsampling,
             )?
         } else if self.progressive {
-            encoder::compress_progressive(
-                effective_pixels,
-                self.width,
-                self.height,
-                effective_format,
-                self.quality,
-                self.subsampling,
-            )?
+            if let Some(ref script) = self.scan_script {
+                encoder::compress_progressive_custom(
+                    effective_pixels,
+                    self.width,
+                    self.height,
+                    effective_format,
+                    self.quality,
+                    self.subsampling,
+                    script,
+                )?
+            } else {
+                encoder::compress_progressive(
+                    effective_pixels,
+                    self.width,
+                    self.height,
+                    effective_format,
+                    self.quality,
+                    self.subsampling,
+                )?
+            }
         } else if self.optimize_huffman {
             encoder::compress_optimized(
                 effective_pixels,

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -221,6 +221,25 @@ pub struct SavedMarker {
     pub data: Vec<u8>,
 }
 
+/// Progressive scan script entry.
+///
+/// Defines one scan in a custom progressive scan script. Users can build
+/// a `Vec<ScanScript>` to control the exact ordering and spectral/successive
+/// approximation parameters of each progressive scan pass.
+#[derive(Debug, Clone)]
+pub struct ScanScript {
+    /// Component indices (0-based) included in this scan.
+    pub components: Vec<u8>,
+    /// Spectral selection start (0 for DC).
+    pub ss: u8,
+    /// Spectral selection end (0 for DC-only, 63 for full AC).
+    pub se: u8,
+    /// Successive approximation high bit (0 for first pass).
+    pub ah: u8,
+    /// Successive approximation low bit.
+    pub al: u8,
+}
+
 /// One chunk of an ICC profile stored in an APP2 marker.
 ///
 /// ICC profiles larger than 65519 bytes are split across multiple APP2 markers,

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -4,11 +4,12 @@
 /// and marker writing to produce a valid baseline JPEG file.
 use crate::api::encoder::HuffmanTableDef;
 use crate::common::error::{JpegError, Result};
-use crate::common::types::{PixelFormat, Subsampling};
+use crate::common::types::{PixelFormat, ScanScript, Subsampling};
 use crate::encode::color;
 use crate::encode::fdct;
 use crate::encode::huffman_encode::{build_huff_table, BitWriter, HuffTable, HuffmanEncoder};
 use crate::encode::marker_writer;
+use crate::encode::progressive::ProgressiveScan;
 use crate::encode::quant;
 use crate::encode::tables;
 
@@ -1342,7 +1343,7 @@ struct CompLayout {
 /// Compress as progressive JPEG (SOF2, multi-scan).
 ///
 /// Buffers all DCT coefficients, then encodes across multiple scans
-/// following a standard scan progression script.
+/// following the default `simple_progression()` scan script.
 pub fn compress_progressive(
     pixels: &[u8],
     width: usize,
@@ -1353,6 +1354,67 @@ pub fn compress_progressive(
 ) -> Result<Vec<u8>> {
     use crate::encode::progressive::simple_progression;
 
+    let is_grayscale = pixel_format == PixelFormat::Grayscale;
+    let num_components = if is_grayscale { 1 } else { 3 };
+    let scans = simple_progression(num_components);
+
+    compress_progressive_with_scans(
+        pixels,
+        width,
+        height,
+        pixel_format,
+        quality,
+        subsampling,
+        &scans,
+    )
+}
+
+/// Compress as progressive JPEG (SOF2) with a user-supplied scan script.
+///
+/// Same as `compress_progressive` but uses the provided `ScanScript` entries
+/// instead of the default `simple_progression()` scan order.
+pub fn compress_progressive_custom(
+    pixels: &[u8],
+    width: usize,
+    height: usize,
+    pixel_format: PixelFormat,
+    quality: u8,
+    subsampling: Subsampling,
+    script: &[ScanScript],
+) -> Result<Vec<u8>> {
+    // Convert user-facing ScanScript to internal ProgressiveScan representation
+    let scans: Vec<ProgressiveScan> = script
+        .iter()
+        .map(|s| ProgressiveScan {
+            component_indices: s.components.iter().map(|&c| c as usize).collect(),
+            ss: s.ss,
+            se: s.se,
+            ah: s.ah,
+            al: s.al,
+        })
+        .collect();
+
+    compress_progressive_with_scans(
+        pixels,
+        width,
+        height,
+        pixel_format,
+        quality,
+        subsampling,
+        &scans,
+    )
+}
+
+/// Shared progressive encoding logic used by both default and custom scan scripts.
+fn compress_progressive_with_scans(
+    pixels: &[u8],
+    width: usize,
+    height: usize,
+    pixel_format: PixelFormat,
+    quality: u8,
+    subsampling: Subsampling,
+    scans: &[ProgressiveScan],
+) -> Result<Vec<u8>> {
     if width == 0 || height == 0 {
         return Err(JpegError::CorruptData(
             "image dimensions must be non-zero".to_string(),
@@ -1369,7 +1431,6 @@ pub fn compress_progressive(
     }
 
     let is_grayscale = pixel_format == PixelFormat::Grayscale;
-    let num_components = if is_grayscale { 1 } else { 3 };
 
     let luma_quant = tables::quality_scale_quant_table(&tables::STD_LUMINANCE_QUANT_TABLE, quality);
     let chroma_quant =
@@ -1394,7 +1455,6 @@ pub fn compress_progressive(
     let mcus_x = (width + mcu_w - 1) / mcu_w;
     let mcus_y = (height + mcu_h - 1) / mcu_h;
 
-    // Compute per-component block dimensions
     let (h_samp, v_samp) = if is_grayscale {
         (1usize, 1usize)
     } else {
@@ -1533,9 +1593,6 @@ pub fn compress_progressive(
     let ac_chroma_table =
         build_huff_table(&tables::AC_CHROMINANCE_BITS, &tables::AC_CHROMINANCE_VALUES);
 
-    // Generate scan progression
-    let scans = simple_progression(num_components);
-
     // Assemble output
     let mut output = Vec::with_capacity(width * height * 2);
 
@@ -1594,7 +1651,7 @@ pub fn compress_progressive(
     }
 
     // Encode each scan
-    for scan in &scans {
+    for scan in scans {
         // Build SOS component list
         let sos_comps: Vec<(u8, u8, u8)> = scan
             .component_indices

--- a/tests/custom_scan.rs
+++ b/tests/custom_scan.rs
@@ -1,0 +1,147 @@
+use libjpeg_turbo_rs::{decompress, Encoder, PixelFormat, ScanScript, Subsampling};
+
+#[test]
+fn custom_scan_script_roundtrip() {
+    let pixels = vec![128u8; 16 * 16 * 3];
+    let script = vec![
+        ScanScript {
+            components: vec![0, 1, 2],
+            ss: 0,
+            se: 0,
+            ah: 0,
+            al: 1,
+        }, // DC first, al=1
+        ScanScript {
+            components: vec![0],
+            ss: 1,
+            se: 63,
+            ah: 0,
+            al: 0,
+        }, // Y AC
+        ScanScript {
+            components: vec![1],
+            ss: 1,
+            se: 63,
+            ah: 0,
+            al: 0,
+        }, // Cb AC
+        ScanScript {
+            components: vec![2],
+            ss: 1,
+            se: 63,
+            ah: 0,
+            al: 0,
+        }, // Cr AC
+        ScanScript {
+            components: vec![0, 1, 2],
+            ss: 0,
+            se: 0,
+            ah: 1,
+            al: 0,
+        }, // DC refine
+    ];
+    let jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .quality(75)
+        .progressive(true)
+        .scan_script(script)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 16);
+    assert_eq!(img.height, 16);
+}
+
+#[test]
+fn custom_scan_script_grayscale_roundtrip() {
+    let pixels = vec![200u8; 32 * 32];
+    let script = vec![
+        ScanScript {
+            components: vec![0],
+            ss: 0,
+            se: 0,
+            ah: 0,
+            al: 1,
+        }, // DC first
+        ScanScript {
+            components: vec![0],
+            ss: 1,
+            se: 63,
+            ah: 0,
+            al: 0,
+        }, // AC full
+        ScanScript {
+            components: vec![0],
+            ss: 0,
+            se: 0,
+            ah: 1,
+            al: 0,
+        }, // DC refine
+    ];
+    let jpeg = Encoder::new(&pixels, 32, 32, PixelFormat::Grayscale)
+        .quality(90)
+        .progressive(true)
+        .scan_script(script)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 32);
+    assert_eq!(img.height, 32);
+}
+
+#[test]
+fn custom_scan_script_differs_from_default() {
+    // A minimal 2-scan script (DC + AC) should produce different output
+    // than the default multi-pass progression.
+    let pixels = vec![100u8; 8 * 8 * 3];
+
+    let default_jpeg = Encoder::new(&pixels, 8, 8, PixelFormat::Rgb)
+        .quality(75)
+        .subsampling(Subsampling::S444)
+        .progressive(true)
+        .encode()
+        .unwrap();
+
+    let simple_script = vec![
+        ScanScript {
+            components: vec![0, 1, 2],
+            ss: 0,
+            se: 0,
+            ah: 0,
+            al: 0,
+        }, // DC, no successive approx
+        ScanScript {
+            components: vec![0],
+            ss: 1,
+            se: 63,
+            ah: 0,
+            al: 0,
+        },
+        ScanScript {
+            components: vec![1],
+            ss: 1,
+            se: 63,
+            ah: 0,
+            al: 0,
+        },
+        ScanScript {
+            components: vec![2],
+            ss: 1,
+            se: 63,
+            ah: 0,
+            al: 0,
+        },
+    ];
+    let custom_jpeg = Encoder::new(&pixels, 8, 8, PixelFormat::Rgb)
+        .quality(75)
+        .subsampling(Subsampling::S444)
+        .progressive(true)
+        .scan_script(simple_script)
+        .encode()
+        .unwrap();
+
+    // Both should decode, but byte streams differ because scan scripts differ
+    assert_ne!(default_jpeg, custom_jpeg);
+    let img = decompress(&custom_jpeg).unwrap();
+    assert_eq!(img.width, 8);
+    assert_eq!(img.height, 8);
+}


### PR DESCRIPTION
## Summary
- Add `scan_script(Vec<ScanScript>)` to Encoder for custom progressive scan scripts
- `ScanScript` struct: components, ss, se, ah, al fields
- Refactored progressive encode to share logic between default and custom scripts

## Test plan
- [x] Color roundtrip with 5-scan custom script
- [x] Grayscale roundtrip with 3-scan custom script
- [x] Custom script differs from default progression

🤖 Generated with [Claude Code](https://claude.com/claude-code)