### PR TITLE
feat: add SOF10 arithmetic progressive JPEG encode

### DIFF
--- a/src/api/encoder.rs
+++ b/src/api/encoder.rs
@@ -301,6 +301,15 @@ impl<'a> Encoder<'a> {
                 self.lossless_predictor,
                 self.lossless_point_transform,
             )?
+        } else if self.arithmetic && self.progressive {
+            encoder::compress_arithmetic_progressive(
+                effective_pixels,
+                self.width,
+                self.height,
+                effective_format,
+                self.quality,
+                self.subsampling,
+            )?
         } else if self.arithmetic {
             encoder::compress_arithmetic(
                 effective_pixels,

--- a/src/api/high_level.rs
+++ b/src/api/high_level.rs
@@ -181,6 +181,29 @@ pub fn compress_lossless_extended(
     )
 }
 
+/// Compress with arithmetic progressive encoding (SOF10).
+///
+/// Combines progressive multi-scan encoding with arithmetic entropy coding.
+/// Produces a progressive JPEG that renders incrementally and uses arithmetic
+/// coding for better compression than Huffman-based progressive.
+pub fn compress_arithmetic_progressive(
+    pixels: &[u8],
+    width: usize,
+    height: usize,
+    pixel_format: PixelFormat,
+    quality: u8,
+    subsampling: Subsampling,
+) -> Result<Vec<u8>> {
+    encoder::compress_arithmetic_progressive(
+        pixels,
+        width,
+        height,
+        pixel_format,
+        quality,
+        subsampling,
+    )
+}
+
 /// Compress with arithmetic entropy coding (SOF9).
 ///
 /// Uses QM-coder binary arithmetic coding instead of Huffman coding.

--- a/src/encode/arithmetic.rs
+++ b/src/encode/arithmetic.rs
@@ -413,6 +413,337 @@ impl ArithEncoder {
         }
     }
 
+    /// Reset encoder state for a new scan, keeping output buffer.
+    ///
+    /// Clears arithmetic coding state, DC prediction, and statistics
+    /// so the encoder is ready for a fresh progressive scan.
+    pub fn reset(&mut self) {
+        self.c = 0;
+        self.a = 0x10000;
+        self.ct = 11;
+        self.sc = 0;
+        self.zc = 0;
+        self.buffer = -1;
+        self.output.clear();
+        self.last_dc_val = [0; 4];
+        self.dc_context = [0; 4];
+        self.dc_stats = [[0; DC_STAT_BINS]; 4];
+        self.ac_stats = [[0; AC_STAT_BINS]; 4];
+        self.fixed_bin = [0; 4];
+    }
+
+    /// Encode DC coefficient for first progressive scan (DC first, Ah=0).
+    ///
+    /// Like encode_dc_sequential but applies point transform shift by `al`.
+    /// Ported from jcarith.c encode_mcu_DC_first.
+    pub fn encode_dc_first(&mut self, block: &[i16; 64], comp_idx: usize, dc_tbl: usize, al: u8) {
+        // Apply point transform (arithmetic right shift by Al)
+        let m_val: i32 = (block[0] as i32) >> al;
+
+        let s0: usize = self.dc_context[comp_idx];
+
+        if m_val - self.last_dc_val[comp_idx] == 0 {
+            self.encode(StatRef::Dc(dc_tbl, s0), 0);
+            self.dc_context[comp_idx] = 0;
+            return;
+        }
+
+        let mut v: i32 = m_val - self.last_dc_val[comp_idx];
+        self.last_dc_val[comp_idx] = m_val;
+        self.encode(StatRef::Dc(dc_tbl, s0), 1);
+
+        // Sign encoding + stat pointer selection (Table F.4)
+        let st: usize;
+        if v > 0 {
+            self.encode(StatRef::Dc(dc_tbl, s0 + 1), 0); // positive
+            st = s0 + 2;
+            self.dc_context[comp_idx] = 4;
+        } else {
+            v = -v;
+            self.encode(StatRef::Dc(dc_tbl, s0 + 1), 1); // negative
+            st = s0 + 3;
+            self.dc_context[comp_idx] = 8;
+        }
+
+        // Magnitude category encoding (Figure F.8)
+        let mut m: i32 = 0;
+        v -= 1;
+        let v_orig: i32 = v;
+        if v != 0 {
+            self.encode(StatRef::Dc(dc_tbl, st), 1);
+            m = 1;
+            let mut v2: i32 = v;
+            let mut x1: usize = 20;
+            v2 >>= 1;
+            while v2 != 0 {
+                self.encode(StatRef::Dc(dc_tbl, x1), 1);
+                m <<= 1;
+                x1 += 1;
+                v2 >>= 1;
+            }
+            self.encode(StatRef::Dc(dc_tbl, x1), 0);
+
+            // Context conditioning (Section F.1.4.4.1.2)
+            let l_thresh: i32 = (1i32 << self.arith_dc_l[dc_tbl]) >> 1;
+            let u_thresh: i32 = (1i32 << self.arith_dc_u[dc_tbl]) >> 1;
+            if m < l_thresh {
+                self.dc_context[comp_idx] = 0;
+            } else if m > u_thresh {
+                self.dc_context[comp_idx] += 8;
+            }
+
+            // Magnitude bit pattern (Figure F.9) — uses fixed-probability bin
+            // jcarith.c uses st += 14 here, which points into the stats array.
+            // Our sequential encoder uses Fixed(0) for compatibility; progressive
+            // follows the same approach for consistency.
+            let mut bit_mask: i32 = m >> 1;
+            while bit_mask != 0 {
+                let bit: u8 = if (bit_mask & v_orig) != 0 { 1 } else { 0 };
+                self.encode(StatRef::Fixed(0), bit);
+                bit_mask >>= 1;
+            }
+        } else {
+            self.encode(StatRef::Dc(dc_tbl, st), 0);
+            let l_thresh: i32 = (1i32 << self.arith_dc_l[dc_tbl]) >> 1;
+            if m < l_thresh {
+                self.dc_context[comp_idx] = 0;
+            }
+        }
+    }
+
+    /// Encode DC coefficient for successive approximation refinement scan (Ah!=0).
+    ///
+    /// Simply emits the Al'th bit of the DC coefficient using fixed probability.
+    /// Ported from jcarith.c encode_mcu_DC_refine.
+    pub fn encode_dc_refine(&mut self, block: &[i16; 64], al: u8) {
+        let bit: u8 = ((block[0] >> al) & 1) as u8;
+        self.encode(StatRef::Fixed(0), bit);
+    }
+
+    /// Encode AC coefficients for first progressive scan (AC first, Ah=0).
+    ///
+    /// Encodes AC coefficients in spectral range [ss, se] with point transform
+    /// shift by `al`. Ported from jcarith.c encode_mcu_AC_first.
+    pub fn encode_ac_first(&mut self, block: &[i16; 64], ac_tbl: usize, ss: u8, se: u8, al: u8) {
+        let ss_idx: usize = ss as usize;
+        let se_idx: usize = se as usize;
+
+        // Establish EOB index: find highest nonzero coefficient after shift
+        let mut ke: usize = se_idx;
+        while ke >= ss_idx {
+            let v_raw: i16 = block[ke];
+            let v_abs: i32 = if v_raw >= 0 {
+                v_raw as i32
+            } else {
+                -(v_raw as i32)
+            };
+            if (v_abs >> al) != 0 {
+                break;
+            }
+            if ke == ss_idx {
+                // All coefficients are zero after shift — encode EOB and return
+                let st: usize = 3 * (ss_idx - 1);
+                self.encode(StatRef::Ac(ac_tbl, st), 1);
+                return;
+            }
+            ke -= 1;
+        }
+
+        // Encode AC coefficients (Figure F.5)
+        let mut k: usize = ss_idx;
+        while k <= ke {
+            let mut st: usize = 3 * (k - 1);
+            self.encode(StatRef::Ac(ac_tbl, st), 0); // EOB decision: not EOB
+
+            // Zero-run with point transform
+            loop {
+                let v_raw: i16 = block[k];
+                let mut v: i32;
+                if v_raw >= 0 {
+                    v = (v_raw as i32) >> al;
+                    if v != 0 {
+                        self.encode(StatRef::Ac(ac_tbl, st + 1), 1);
+                        self.encode(StatRef::Fixed(0), 0); // positive sign
+                        break;
+                    }
+                } else {
+                    v = -(v_raw as i32);
+                    v >>= al;
+                    if v != 0 {
+                        self.encode(StatRef::Ac(ac_tbl, st + 1), 1);
+                        self.encode(StatRef::Fixed(0), 1); // negative sign
+                        break;
+                    }
+                }
+                self.encode(StatRef::Ac(ac_tbl, st + 1), 0);
+                st += 3;
+                k += 1;
+            }
+
+            // v is the absolute value of the shifted coefficient
+            let v_raw: i16 = block[k];
+            let mut v: i32 = if v_raw >= 0 {
+                (v_raw as i32) >> al
+            } else {
+                (-(v_raw as i32)) >> al
+            };
+
+            st += 2;
+
+            // Magnitude category encoding (Figure F.8)
+            let mut m: i32 = 0;
+            v -= 1;
+            let v_orig: i32 = v;
+            if v != 0 {
+                self.encode(StatRef::Ac(ac_tbl, st), 1);
+                m = 1;
+                let mut v2: i32 = v >> 1;
+                if v2 != 0 {
+                    self.encode(StatRef::Ac(ac_tbl, st), 1);
+                    m <<= 1;
+                    let kx: usize = self.arith_ac_k[ac_tbl] as usize;
+                    let mut st2: usize = if k <= kx { 189 } else { 217 };
+                    v2 >>= 1;
+                    while v2 != 0 {
+                        self.encode(StatRef::Ac(ac_tbl, st2), 1);
+                        m <<= 1;
+                        st2 += 1;
+                        v2 >>= 1;
+                    }
+                    st = st2;
+                }
+            }
+            self.encode(StatRef::Ac(ac_tbl, st), 0); // magnitude terminator
+
+            // Magnitude bit pattern (Figure F.9)
+            let mut bit_mask: i32 = m >> 1;
+            while bit_mask != 0 {
+                let bit: u8 = if (bit_mask & v_orig) != 0 { 1 } else { 0 };
+                self.encode(StatRef::Fixed(0), bit);
+                bit_mask >>= 1;
+            }
+
+            k += 1;
+        }
+
+        // Encode EOB if k <= se
+        if k <= se_idx {
+            let st: usize = 3 * (k - 1);
+            self.encode(StatRef::Ac(ac_tbl, st), 1);
+        }
+    }
+
+    /// Encode AC coefficients for successive approximation refinement scan (Ah!=0).
+    ///
+    /// Interleaves correction bits for previously-nonzero coefficients with
+    /// newly-significant coefficients. Ported from jcarith.c encode_mcu_AC_refine.
+    pub fn encode_ac_refine(
+        &mut self,
+        block: &[i16; 64],
+        ac_tbl: usize,
+        ss: u8,
+        se: u8,
+        al: u8,
+        ah: u8,
+    ) {
+        let ss_idx: usize = ss as usize;
+        let se_idx: usize = se as usize;
+
+        // Establish EOB (end-of-block) index for current approximation
+        let mut ke: usize = ss_idx;
+        let mut found_ke: bool = false;
+        for i in (ss_idx..=se_idx).rev() {
+            let v_raw: i16 = block[i];
+            let v_abs: i32 = if v_raw >= 0 {
+                v_raw as i32
+            } else {
+                -(v_raw as i32)
+            };
+            if (v_abs >> al) != 0 {
+                ke = i;
+                found_ke = true;
+                break;
+            }
+        }
+        if !found_ke {
+            // All zero after current shift — encode EOB
+            if ss_idx > 0 {
+                let st: usize = 3 * (ss_idx - 1);
+                self.encode(StatRef::Ac(ac_tbl, st), 1);
+            }
+            return;
+        }
+
+        // Establish EOBx (previous stage end-of-block) index
+        let mut kex: usize = 0;
+        for i in (ss_idx..=ke).rev() {
+            let v_raw: i16 = block[i];
+            let v_abs: i32 = if v_raw >= 0 {
+                v_raw as i32
+            } else {
+                -(v_raw as i32)
+            };
+            if (v_abs >> ah) != 0 {
+                kex = i;
+                break;
+            }
+        }
+
+        // Figure G.10: Encode_AC_Coefficients_SA
+        let mut k: usize = ss_idx;
+        while k <= ke {
+            let st: usize = 3 * (k - 1);
+            if k > kex {
+                self.encode(StatRef::Ac(ac_tbl, st), 0); // EOB decision
+            }
+            loop {
+                let v_raw: i16 = block[k];
+                if v_raw >= 0 {
+                    let v_shifted: i32 = (v_raw as i32) >> al;
+                    if v_shifted != 0 {
+                        if v_shifted >> 1 != 0 {
+                            // Previously nonzero: emit correction bit
+                            let st2: usize = 3 * (k - 1) + 2;
+                            self.encode(StatRef::Ac(ac_tbl, st2), (v_shifted & 1) as u8);
+                        } else {
+                            // Newly nonzero
+                            let st2: usize = 3 * (k - 1) + 1;
+                            self.encode(StatRef::Ac(ac_tbl, st2), 1);
+                            self.encode(StatRef::Fixed(0), 0); // positive sign
+                        }
+                        break;
+                    }
+                } else {
+                    let v_abs: i32 = (-(v_raw as i32)) >> al;
+                    if v_abs != 0 {
+                        if v_abs >> 1 != 0 {
+                            // Previously nonzero: emit correction bit
+                            let st2: usize = 3 * (k - 1) + 2;
+                            self.encode(StatRef::Ac(ac_tbl, st2), (v_abs & 1) as u8);
+                        } else {
+                            // Newly nonzero
+                            let st2: usize = 3 * (k - 1) + 1;
+                            self.encode(StatRef::Ac(ac_tbl, st2), 1);
+                            self.encode(StatRef::Fixed(0), 1); // negative sign
+                        }
+                        break;
+                    }
+                }
+                // Zero coefficient — encode zero run
+                let st2: usize = 3 * (k - 1) + 1;
+                self.encode(StatRef::Ac(ac_tbl, st2), 0);
+                k += 1;
+            }
+            k += 1;
+        }
+
+        // Encode EOB if k <= se
+        if k <= se_idx {
+            let st: usize = 3 * (k - 1);
+            self.encode(StatRef::Ac(ac_tbl, st), 1);
+        }
+    }
+
     pub fn data(&self) -> &[u8] {
         &self.output
     }

--- a/src/encode/marker_writer.rs
+++ b/src/encode/marker_writer.rs
@@ -187,6 +187,28 @@ pub fn write_sof9(buf: &mut Vec<u8>, width: u16, height: u16, components: &[(u8,
     }
 }
 
+/// Write SOF10 (Start Of Frame, Arithmetic Progressive DCT) marker.
+///
+/// Same structure as SOF2 but uses marker code 0xCA for arithmetic coding.
+pub fn write_sof10(buf: &mut Vec<u8>, width: u16, height: u16, components: &[(u8, u8, u8, u8)]) {
+    buf.push(0xFF);
+    buf.push(0xCA); // SOF10
+
+    let length: u16 = 2 + 1 + 2 + 2 + 1 + (components.len() as u16 * 3);
+    buf.extend_from_slice(&length.to_be_bytes());
+
+    buf.push(8); // 8-bit precision
+    buf.extend_from_slice(&height.to_be_bytes());
+    buf.extend_from_slice(&width.to_be_bytes());
+    buf.push(components.len() as u8);
+
+    for &(id, h_samp, v_samp, quant_tbl_id) in components {
+        buf.push(id);
+        buf.push((h_samp << 4) | v_samp);
+        buf.push(quant_tbl_id);
+    }
+}
+
 /// Write SOS marker for progressive scan with spectral selection and successive approximation.
 pub fn write_sos_progressive(
     buf: &mut Vec<u8>,

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -1913,6 +1913,429 @@ pub fn compress_arithmetic(
     Ok(output)
 }
 
+/// Compress with arithmetic progressive encoding (SOF10).
+///
+/// Combines progressive multi-scan encoding with arithmetic entropy coding.
+/// Buffers all DCT coefficients, then encodes across multiple scans using
+/// a standard scan progression script with ArithEncoder.
+pub fn compress_arithmetic_progressive(
+    pixels: &[u8],
+    width: usize,
+    height: usize,
+    pixel_format: PixelFormat,
+    quality: u8,
+    subsampling: Subsampling,
+) -> Result<Vec<u8>> {
+    use crate::encode::arithmetic::ArithEncoder;
+    use crate::encode::progressive::simple_progression;
+
+    if width == 0 || height == 0 {
+        return Err(JpegError::CorruptData(
+            "image dimensions must be non-zero".to_string(),
+        ));
+    }
+
+    let bpp: usize = pixel_format.bytes_per_pixel();
+    let expected_size: usize = width * height * bpp;
+    if pixels.len() < expected_size {
+        return Err(JpegError::BufferTooSmall {
+            need: expected_size,
+            got: pixels.len(),
+        });
+    }
+
+    let is_grayscale: bool = pixel_format == PixelFormat::Grayscale;
+    let num_components: usize = if is_grayscale { 1 } else { 3 };
+
+    let luma_quant: [u16; 64] =
+        tables::quality_scale_quant_table(&tables::STD_LUMINANCE_QUANT_TABLE, quality);
+    let chroma_quant: [u16; 64] =
+        tables::quality_scale_quant_table(&tables::STD_CHROMINANCE_QUANT_TABLE, quality);
+    let luma_divisors: [u16; 64] = scale_quant_for_fdct(&luma_quant);
+    let chroma_divisors: [u16; 64] = scale_quant_for_fdct(&chroma_quant);
+
+    let (y_plane, cb_plane, cr_plane) = convert_to_ycbcr(pixels, width, height, pixel_format)?;
+
+    let (mcu_w, mcu_h): (usize, usize) = if is_grayscale {
+        (8, 8)
+    } else {
+        match subsampling {
+            Subsampling::S444 => (8, 8),
+            Subsampling::S422 => (16, 8),
+            Subsampling::S420 => (16, 16),
+            Subsampling::S440 => (8, 16),
+            Subsampling::S411 => (32, 8),
+        }
+    };
+
+    let mcus_x: usize = (width + mcu_w - 1) / mcu_w;
+    let mcus_y: usize = (height + mcu_h - 1) / mcu_h;
+
+    // Compute per-component block dimensions
+    let (h_samp, v_samp): (usize, usize) = if is_grayscale {
+        (1, 1)
+    } else {
+        let (h, v) = subsampling.sampling_factors();
+        (h as usize, v as usize)
+    };
+
+    let comp_layouts: Vec<CompLayout> = if is_grayscale {
+        vec![CompLayout {
+            blocks_x: mcus_x,
+            blocks_y: mcus_y,
+            h_blocks: 1,
+            v_blocks: 1,
+        }]
+    } else {
+        vec![
+            CompLayout {
+                blocks_x: mcus_x * h_samp,
+                blocks_y: mcus_y * v_samp,
+                h_blocks: h_samp,
+                v_blocks: v_samp,
+            },
+            CompLayout {
+                blocks_x: mcus_x,
+                blocks_y: mcus_y,
+                h_blocks: 1,
+                v_blocks: 1,
+            },
+            CompLayout {
+                blocks_x: mcus_x,
+                blocks_y: mcus_y,
+                h_blocks: 1,
+                v_blocks: 1,
+            },
+        ]
+    };
+
+    // Buffer all quantized coefficients per component
+    let mut coeff_bufs: Vec<Vec<[i16; 64]>> = comp_layouts
+        .iter()
+        .map(|cl| vec![[0i16; 64]; cl.blocks_x * cl.blocks_y])
+        .collect();
+
+    // FDCT + quantize all blocks into coefficient buffers
+    for mcu_y in 0..mcus_y {
+        for mcu_x in 0..mcus_x {
+            let x0: usize = mcu_x * mcu_w;
+            let y0: usize = mcu_y * mcu_h;
+
+            if is_grayscale {
+                let bx: usize = mcu_x;
+                let by: usize = mcu_y;
+                let mut block = [0i16; 64];
+                extract_block(&y_plane, width, height, x0, y0, &mut block);
+                let mut dct = [0i32; 64];
+                fdct::fdct_islow(&block, &mut dct);
+                quant::quantize_block(&dct, &luma_divisors, &mut coeff_bufs[0][by * mcus_x + bx]);
+            } else {
+                // Y blocks
+                for bv in 0..v_samp {
+                    for bh in 0..h_samp {
+                        let bx: usize = mcu_x * h_samp + bh;
+                        let by: usize = mcu_y * v_samp + bv;
+                        let mut block = [0i16; 64];
+                        extract_block(
+                            &y_plane,
+                            width,
+                            height,
+                            x0 + bh * 8,
+                            y0 + bv * 8,
+                            &mut block,
+                        );
+                        let mut dct = [0i32; 64];
+                        fdct::fdct_islow(&block, &mut dct);
+                        let blocks_x: usize = comp_layouts[0].blocks_x;
+                        quant::quantize_block(
+                            &dct,
+                            &luma_divisors,
+                            &mut coeff_bufs[0][by * blocks_x + bx],
+                        );
+                    }
+                }
+                // Cb block
+                {
+                    let bx: usize = mcu_x;
+                    let by: usize = mcu_y;
+                    let mut block = [0i16; 64];
+                    let hf: usize = if h_samp > 1 { 2 } else { 1 };
+                    let vf: usize = if v_samp > 1 { 2 } else { 1 };
+                    if hf == 1 && vf == 1 {
+                        extract_block(&cb_plane, width, height, x0, y0, &mut block);
+                    } else {
+                        downsample_chroma_block(
+                            &cb_plane, width, height, x0, y0, hf, vf, &mut block,
+                        );
+                    }
+                    let mut dct = [0i32; 64];
+                    fdct::fdct_islow(&block, &mut dct);
+                    quant::quantize_block(
+                        &dct,
+                        &chroma_divisors,
+                        &mut coeff_bufs[1][by * mcus_x + bx],
+                    );
+                }
+                // Cr block
+                {
+                    let bx: usize = mcu_x;
+                    let by: usize = mcu_y;
+                    let mut block = [0i16; 64];
+                    let hf: usize = if h_samp > 1 { 2 } else { 1 };
+                    let vf: usize = if v_samp > 1 { 2 } else { 1 };
+                    if hf == 1 && vf == 1 {
+                        extract_block(&cr_plane, width, height, x0, y0, &mut block);
+                    } else {
+                        downsample_chroma_block(
+                            &cr_plane, width, height, x0, y0, hf, vf, &mut block,
+                        );
+                    }
+                    let mut dct = [0i32; 64];
+                    fdct::fdct_islow(&block, &mut dct);
+                    quant::quantize_block(
+                        &dct,
+                        &chroma_divisors,
+                        &mut coeff_bufs[2][by * mcus_x + bx],
+                    );
+                }
+            }
+        }
+    }
+
+    // Generate scan progression
+    let scans = simple_progression(num_components);
+
+    // Assemble output
+    let mut output: Vec<u8> = Vec::with_capacity(width * height * 2);
+
+    marker_writer::write_soi(&mut output);
+    marker_writer::write_app0_jfif(&mut output);
+
+    // Quantization tables
+    marker_writer::write_dqt(&mut output, 0, &luma_quant);
+    if !is_grayscale {
+        marker_writer::write_dqt(&mut output, 1, &chroma_quant);
+    }
+
+    // SOF10 (arithmetic progressive)
+    if is_grayscale {
+        let components = vec![(1, 1, 1, 0)];
+        marker_writer::write_sof10(&mut output, width as u16, height as u16, &components);
+    } else {
+        let components = vec![
+            (1, h_samp as u8, v_samp as u8, 0),
+            (2, 1, 1, 1),
+            (3, 1, 1, 1),
+        ];
+        marker_writer::write_sof10(&mut output, width as u16, height as u16, &components);
+    }
+
+    // DAC marker for arithmetic conditioning parameters
+    let dc_params: [(u8, u8); 2] = [(0u8, 1u8), (0, 1)];
+    let ac_params: [u8; 2] = [5u8, 5];
+    let num_dc: usize = if is_grayscale { 1 } else { 2 };
+    let num_ac: usize = if is_grayscale { 1 } else { 2 };
+    marker_writer::write_dac(&mut output, num_dc, &dc_params, num_ac, &ac_params);
+
+    // Encode each scan with arithmetic coding
+    let mut arith_enc: ArithEncoder = ArithEncoder::new(width * height / 4);
+
+    for scan in &scans {
+        // Reset encoder state for each scan
+        arith_enc.reset();
+
+        // Build SOS component list
+        let sos_comps: Vec<(u8, u8, u8)> = scan
+            .component_indices
+            .iter()
+            .map(|&ci| {
+                let comp_id: u8 = (ci + 1) as u8;
+                let (dc_tbl, ac_tbl): (u8, u8) = if ci == 0 { (0, 0) } else { (1, 1) };
+                (comp_id, dc_tbl, ac_tbl)
+            })
+            .collect();
+
+        marker_writer::write_sos_progressive(
+            &mut output,
+            &sos_comps,
+            scan.ss,
+            scan.se,
+            scan.ah,
+            scan.al,
+        );
+
+        let is_dc_scan: bool = scan.ss == 0 && scan.se == 0;
+
+        if is_dc_scan {
+            if scan.ah == 0 {
+                // DC first scan
+                encode_arith_dc_first_scan(
+                    &coeff_bufs,
+                    &comp_layouts,
+                    scan,
+                    mcus_x,
+                    mcus_y,
+                    &mut arith_enc,
+                );
+            } else {
+                // DC refine scan
+                encode_arith_dc_refine_scan(
+                    &coeff_bufs,
+                    &comp_layouts,
+                    scan,
+                    mcus_x,
+                    mcus_y,
+                    &mut arith_enc,
+                );
+            }
+        } else if scan.ah == 0 {
+            // AC first scan
+            encode_arith_ac_first_scan(
+                &coeff_bufs,
+                &comp_layouts,
+                scan,
+                mcus_x,
+                mcus_y,
+                &mut arith_enc,
+            );
+        } else {
+            // AC refine scan
+            encode_arith_ac_refine_scan(
+                &coeff_bufs,
+                &comp_layouts,
+                scan,
+                mcus_x,
+                mcus_y,
+                &mut arith_enc,
+            );
+        }
+
+        arith_enc.finish();
+        output.extend_from_slice(arith_enc.data());
+    }
+
+    marker_writer::write_eoi(&mut output);
+
+    Ok(output)
+}
+
+/// Encode arithmetic DC first scan (Ah=0) across all MCUs.
+fn encode_arith_dc_first_scan(
+    coeff_bufs: &[Vec<[i16; 64]>],
+    comp_layouts: &[CompLayout],
+    scan: &crate::encode::progressive::ProgressiveScan,
+    mcus_x: usize,
+    mcus_y: usize,
+    arith_enc: &mut crate::encode::arithmetic::ArithEncoder,
+) {
+    let al: u8 = scan.al;
+
+    for mcu_y in 0..mcus_y {
+        for mcu_x in 0..mcus_x {
+            for &ci in &scan.component_indices {
+                let layout: &CompLayout = &comp_layouts[ci];
+                let dc_tbl: usize = if ci == 0 { 0 } else { 1 };
+
+                for bv in 0..layout.v_blocks {
+                    for bh in 0..layout.h_blocks {
+                        let bx: usize = mcu_x * layout.h_blocks + bh;
+                        let by: usize = mcu_y * layout.v_blocks + bv;
+                        let block: &[i16; 64] = &coeff_bufs[ci][by * layout.blocks_x + bx];
+
+                        arith_enc.encode_dc_first(block, ci, dc_tbl, al);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Encode arithmetic DC refine scan (Ah!=0) across all MCUs.
+fn encode_arith_dc_refine_scan(
+    coeff_bufs: &[Vec<[i16; 64]>],
+    comp_layouts: &[CompLayout],
+    scan: &crate::encode::progressive::ProgressiveScan,
+    mcus_x: usize,
+    mcus_y: usize,
+    arith_enc: &mut crate::encode::arithmetic::ArithEncoder,
+) {
+    let al: u8 = scan.al;
+
+    for mcu_y in 0..mcus_y {
+        for mcu_x in 0..mcus_x {
+            for &ci in &scan.component_indices {
+                let layout: &CompLayout = &comp_layouts[ci];
+
+                for bv in 0..layout.v_blocks {
+                    for bh in 0..layout.h_blocks {
+                        let bx: usize = mcu_x * layout.h_blocks + bh;
+                        let by: usize = mcu_y * layout.v_blocks + bv;
+                        let block: &[i16; 64] = &coeff_bufs[ci][by * layout.blocks_x + bx];
+
+                        arith_enc.encode_dc_refine(block, al);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Encode arithmetic AC first scan (Ah=0, single component).
+fn encode_arith_ac_first_scan(
+    coeff_bufs: &[Vec<[i16; 64]>],
+    comp_layouts: &[CompLayout],
+    scan: &crate::encode::progressive::ProgressiveScan,
+    mcus_x: usize,
+    mcus_y: usize,
+    arith_enc: &mut crate::encode::arithmetic::ArithEncoder,
+) {
+    let ci: usize = scan.component_indices[0]; // AC scans are single-component
+    let layout: &CompLayout = &comp_layouts[ci];
+    let ac_tbl: usize = if ci == 0 { 0 } else { 1 };
+
+    for mcu_y in 0..mcus_y {
+        for mcu_x in 0..mcus_x {
+            for bv in 0..layout.v_blocks {
+                for bh in 0..layout.h_blocks {
+                    let bx: usize = mcu_x * layout.h_blocks + bh;
+                    let by: usize = mcu_y * layout.v_blocks + bv;
+                    let block: &[i16; 64] = &coeff_bufs[ci][by * layout.blocks_x + bx];
+
+                    arith_enc.encode_ac_first(block, ac_tbl, scan.ss, scan.se, scan.al);
+                }
+            }
+        }
+    }
+}
+
+/// Encode arithmetic AC refine scan (Ah!=0, single component).
+fn encode_arith_ac_refine_scan(
+    coeff_bufs: &[Vec<[i16; 64]>],
+    comp_layouts: &[CompLayout],
+    scan: &crate::encode::progressive::ProgressiveScan,
+    mcus_x: usize,
+    mcus_y: usize,
+    arith_enc: &mut crate::encode::arithmetic::ArithEncoder,
+) {
+    let ci: usize = scan.component_indices[0]; // AC scans are single-component
+    let layout: &CompLayout = &comp_layouts[ci];
+    let ac_tbl: usize = if ci == 0 { 0 } else { 1 };
+
+    for mcu_y in 0..mcus_y {
+        for mcu_x in 0..mcus_x {
+            for bv in 0..layout.v_blocks {
+                for bh in 0..layout.h_blocks {
+                    let bx: usize = mcu_x * layout.h_blocks + bh;
+                    let by: usize = mcu_y * layout.v_blocks + bv;
+                    let block: &[i16; 64] = &coeff_bufs[ci][by * layout.blocks_x + bx];
+
+                    arith_enc.encode_ac_refine(block, ac_tbl, scan.ss, scan.se, scan.al, scan.ah);
+                }
+            }
+        }
+    }
+}
+
 /// Encode a progressive DC scan.
 #[allow(clippy::too_many_arguments)]
 fn encode_progressive_dc_scan(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@ pub use api::coefficient::{
 };
 pub use api::encoder::{Encoder, HuffmanTableDef};
 pub use api::high_level::{
-    compress, compress_arithmetic, compress_lossless, compress_lossless_extended,
-    compress_optimized, compress_progressive, compress_with_metadata, decompress,
-    decompress_cropped, decompress_lenient, decompress_to,
+    compress, compress_arithmetic, compress_arithmetic_progressive, compress_lossless,
+    compress_lossless_extended, compress_optimized, compress_progressive, compress_with_metadata,
+    decompress, decompress_cropped, decompress_lenient, decompress_to,
 };
 pub use common::error::{DecodeWarning, JpegError, Result};
 pub use common::sample::Sample;

--- a/tests/sof10_encode.rs
+++ b/tests/sof10_encode.rs
@@ -1,0 +1,53 @@
+use libjpeg_turbo_rs::{
+    compress_arithmetic_progressive, decompress, Encoder, PixelFormat, Subsampling,
+};
+
+#[test]
+fn sof10_encode_roundtrip() {
+    let pixels = vec![128u8; 32 * 32 * 3];
+    let jpeg =
+        compress_arithmetic_progressive(&pixels, 32, 32, PixelFormat::Rgb, 75, Subsampling::S444)
+            .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 32);
+    assert_eq!(img.height, 32);
+}
+
+#[test]
+fn sof10_contains_correct_marker() {
+    let pixels = vec![128u8; 16 * 16 * 3];
+    let jpeg =
+        compress_arithmetic_progressive(&pixels, 16, 16, PixelFormat::Rgb, 75, Subsampling::S444)
+            .unwrap();
+    let has_sof10 = jpeg.windows(2).any(|w| w[0] == 0xFF && w[1] == 0xCA);
+    assert!(has_sof10, "should contain SOF10 marker");
+}
+
+#[test]
+fn sof10_via_encoder_builder() {
+    let pixels = vec![128u8; 16 * 16 * 3];
+    let jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .quality(75)
+        .arithmetic(true)
+        .progressive(true)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 16);
+}
+
+#[test]
+fn sof10_grayscale() {
+    let pixels = vec![128u8; 32 * 32];
+    let jpeg = compress_arithmetic_progressive(
+        &pixels,
+        32,
+        32,
+        PixelFormat::Grayscale,
+        75,
+        Subsampling::S444,
+    )
+    .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.pixel_format, PixelFormat::Grayscale);
+}


### PR DESCRIPTION
## Summary
- Add `compress_arithmetic_progressive()` combining progressive multi-scan with arithmetic coding
- 4 progressive methods on ArithEncoder: dc_first, dc_refine, ac_first, ac_refine
- `write_sof10()` marker writer (0xCA)
- Encoder builder: `arithmetic(true) + progressive(true)` routes to SOF10

## Test plan
- [x] Roundtrip encode/decode
- [x] SOF10 marker (0xCA) present in output
- [x] Encoder builder API integration
- [x] Grayscale support

🤖 Generated with [Claude Code](https://claude.com/claude-code)