### PR TITLE
feat: add SOF11 lossless arithmetic JPEG encode and decode

### DIFF
--- a/src/api/encoder.rs
+++ b/src/api/encoder.rs
@@ -305,7 +305,16 @@ impl<'a> Encoder<'a> {
             effective_format = self.pixel_format;
         }
 
-        let base = if self.lossless {
+        let base = if self.lossless && self.arithmetic {
+            encoder::compress_lossless_arithmetic(
+                effective_pixels,
+                self.width,
+                self.height,
+                effective_format,
+                self.lossless_predictor,
+                self.lossless_point_transform,
+            )?
+        } else if self.lossless {
             encoder::compress_lossless_extended(
                 effective_pixels,
                 self.width,

--- a/src/api/high_level.rs
+++ b/src/api/high_level.rs
@@ -204,6 +204,28 @@ pub fn compress_arithmetic_progressive(
     )
 }
 
+/// Compress as lossless JPEG with arithmetic entropy coding (SOF11).
+///
+/// Uses predictor-based lossless encoding with arithmetic (QM-coder) entropy
+/// coding instead of Huffman. Produces exact pixel-identical output when decoded.
+pub fn compress_lossless_arithmetic(
+    pixels: &[u8],
+    width: usize,
+    height: usize,
+    pixel_format: PixelFormat,
+    predictor: u8,
+    point_transform: u8,
+) -> Result<Vec<u8>> {
+    encoder::compress_lossless_arithmetic(
+        pixels,
+        width,
+        height,
+        pixel_format,
+        predictor,
+        point_transform,
+    )
+}
+
 /// Compress with arithmetic entropy coding (SOF9).
 ///
 /// Uses QM-coder binary arithmetic coding instead of Huffman coding.

--- a/src/decode/marker.rs
+++ b/src/decode/marker.rs
@@ -17,6 +17,7 @@ const SOF2: u8 = 0xC2;
 const SOF3: u8 = 0xC3; // Lossless, Huffman-coded
 const SOF9: u8 = 0xC9; // Arithmetic sequential
 const SOF10: u8 = 0xCA; // Arithmetic progressive
+const SOF11: u8 = 0xCB; // Lossless, arithmetic-coded
 const DHT: u8 = 0xC4;
 const DAC: u8 = 0xCC; // Define arithmetic conditioning
 const DQT: u8 = 0xDB;
@@ -125,6 +126,11 @@ impl<'a> MarkerReader<'a> {
                 SOF10 => {
                     // Arithmetic progressive
                     frame = Some(self.read_sof(true, false)?);
+                    is_arithmetic = true;
+                }
+                SOF11 => {
+                    // Lossless, arithmetic-coded
+                    frame = Some(self.read_sof(false, true)?);
                     is_arithmetic = true;
                 }
                 DAC => {

--- a/src/decode/pipeline.rs
+++ b/src/decode/pipeline.rs
@@ -1286,6 +1286,22 @@ impl<'a> Decoder<'a> {
         icc_profile: Option<Vec<u8>>,
         exif_data: Option<Vec<u8>>,
     ) -> Result<Image> {
+        if self.metadata.is_arithmetic {
+            self.decode_lossless_arithmetic(frame, width, height, icc_profile, exif_data)
+        } else {
+            self.decode_lossless_huffman(frame, width, height, icc_profile, exif_data)
+        }
+    }
+
+    /// Decode lossless JPEG with Huffman entropy coding (SOF3).
+    fn decode_lossless_huffman(
+        &self,
+        frame: &FrameHeader,
+        width: usize,
+        height: usize,
+        icc_profile: Option<Vec<u8>>,
+        exif_data: Option<Vec<u8>>,
+    ) -> Result<Image> {
         let scan = &self.metadata.scan;
         let precision = frame.precision;
         let psv = scan.spec_start; // Predictor selection value (Ss field)
@@ -1340,70 +1356,7 @@ impl<'a> Decoder<'a> {
                 prev_row = Some(output[row_start..row_start + width].to_vec());
             }
 
-            // Convert to output format
-            let out_format = self.output_format.unwrap_or(PixelFormat::Grayscale);
-            let bpp = out_format.bytes_per_pixel();
-
-            if out_format == PixelFormat::Grayscale {
-                let mut data = Vec::with_capacity(width * height);
-                for &sample in &output {
-                    let val = if pt > 0 {
-                        ((sample as u32) << pt) as u8
-                    } else {
-                        sample as u8
-                    };
-                    data.push(val);
-                }
-                Ok(Image {
-                    width,
-                    height,
-                    pixel_format: PixelFormat::Grayscale,
-                    precision: 8,
-                    data,
-                    icc_profile,
-                    exif_data,
-                    comment: self.metadata.comment.clone(),
-                    density: self.metadata.density,
-                    saved_markers: Vec::new(),
-                    warnings: Vec::new(),
-                })
-            } else {
-                let mut data = Vec::with_capacity(width * height * bpp);
-                for &sample in &output {
-                    let val = if pt > 0 {
-                        ((sample as u32) << pt) as u8
-                    } else {
-                        sample as u8
-                    };
-                    match out_format {
-                        PixelFormat::Rgb | PixelFormat::Bgr => {
-                            data.push(val);
-                            data.push(val);
-                            data.push(val);
-                        }
-                        PixelFormat::Rgba | PixelFormat::Bgra => {
-                            data.push(val);
-                            data.push(val);
-                            data.push(val);
-                            data.push(255);
-                        }
-                        _ => unreachable!(),
-                    }
-                }
-                Ok(Image {
-                    width,
-                    height,
-                    pixel_format: out_format,
-                    precision: 8,
-                    data,
-                    icc_profile,
-                    exif_data,
-                    comment: self.metadata.comment.clone(),
-                    density: self.metadata.density,
-                    saved_markers: Vec::new(),
-                    warnings: Vec::new(),
-                })
-            }
+            self.lossless_output_grayscale(&output, width, height, pt, icc_profile, exif_data)
         } else if num_components == 3 {
             // Multi-component (color) lossless decode — interleaved scan
             let mut comp_planes: Vec<Vec<u16>> =
@@ -1438,53 +1391,191 @@ impl<'a> Decoder<'a> {
                 }
             }
 
-            // Color convert YCbCr → RGB and output
-            let out_format = self.output_format.unwrap_or(PixelFormat::Rgb);
-            let bpp = out_format.bytes_per_pixel();
-            let mut data = Vec::with_capacity(width * height * bpp);
+            self.lossless_output_color(&comp_planes, width, height, icc_profile, exif_data)
+        } else {
+            Err(JpegError::Unsupported(format!(
+                "{} components not yet supported for lossless",
+                num_components
+            )))
+        }
+    }
 
-            for i in 0..width * height {
-                let y_val = comp_planes[0][i] as i32;
-                let cb_val = comp_planes[1][i] as i32;
-                let cr_val = comp_planes[2][i] as i32;
+    /// Decode lossless JPEG with arithmetic entropy coding (SOF11).
+    fn decode_lossless_arithmetic(
+        &self,
+        frame: &FrameHeader,
+        width: usize,
+        height: usize,
+        icc_profile: Option<Vec<u8>>,
+        exif_data: Option<Vec<u8>>,
+    ) -> Result<Image> {
+        use crate::decode::arithmetic::ArithDecoder;
 
-                // YCbCr to RGB (JFIF convention: Y,Cb,Cr centered at 128)
-                let r = (y_val + ((cr_val - 128) * 359 + 128) / 256).clamp(0, 255) as u8;
-                let g = (y_val - ((cb_val - 128) * 88 + (cr_val - 128) * 183 - 128) / 256)
-                    .clamp(0, 255) as u8;
-                let b = (y_val + ((cb_val - 128) * 454 + 128) / 256).clamp(0, 255) as u8;
+        let scan = &self.metadata.scan;
+        let precision = frame.precision;
+        let psv = scan.spec_start;
+        let pt = scan.succ_low;
 
-                match out_format {
-                    PixelFormat::Rgb => {
-                        data.push(r);
-                        data.push(g);
-                        data.push(b);
+        if psv < 1 || psv > 7 {
+            return Err(JpegError::Unsupported(format!(
+                "lossless predictor {} (must be 1-7)",
+                psv
+            )));
+        }
+
+        let num_components = frame.components.len();
+
+        // Resolve DC table indices for each scan component
+        let dc_tbl_indices: Vec<usize> = scan
+            .components
+            .iter()
+            .take(num_components)
+            .map(|sc| sc.dc_table_index as usize)
+            .collect();
+
+        let entropy_data = &self.raw_data[self.metadata.entropy_data_offset..];
+        let mut arith = ArithDecoder::new(entropy_data, 0);
+
+        // Set conditioning parameters from DAC marker
+        for i in 0..4 {
+            let (l, u) = self.metadata.arith_dc_params[i];
+            arith.set_dc_conditioning(i, l, u);
+            arith.set_ac_conditioning(i, self.metadata.arith_ac_params[i]);
+        }
+
+        if num_components == 1 {
+            let dc_tbl = dc_tbl_indices[0];
+            let mut output = vec![0u16; width * height];
+            let mut prev_row: Option<Vec<u16>> = None;
+
+            for y in 0..height {
+                let row_start = y * width;
+                let mut diffs = Vec::with_capacity(width);
+                for _ in 0..width {
+                    // Save previous accumulated DC to extract the raw difference
+                    let prev_dc: i32 = arith.last_dc_val[0];
+                    let mut block: [i16; 64] = [0i16; 64];
+                    arith.decode_dc_sequential(&mut block, 0, dc_tbl)?;
+                    let diff: i16 = ((arith.last_dc_val[0] - prev_dc) as i16) as i16;
+                    diffs.push(diff);
+                }
+                lossless::undifference_row(
+                    &diffs,
+                    prev_row.as_deref(),
+                    &mut output[row_start..row_start + width],
+                    psv,
+                    precision,
+                    pt,
+                    y == 0,
+                );
+                prev_row = Some(output[row_start..row_start + width].to_vec());
+            }
+
+            self.lossless_output_grayscale(&output, width, height, pt, icc_profile, exif_data)
+        } else if num_components == 3 {
+            let mut comp_planes: Vec<Vec<u16>> =
+                (0..3).map(|_| vec![0u16; width * height]).collect();
+            let mut prev_rows: Vec<Option<Vec<u16>>> = vec![None; 3];
+
+            for y in 0..height {
+                let row_start = y * width;
+                let mut comp_diffs: Vec<Vec<i16>> =
+                    (0..3).map(|_| Vec::with_capacity(width)).collect();
+
+                // Interleaved: for each pixel, decode diff for each component
+                for _ in 0..width {
+                    for c in 0..3 {
+                        let prev_dc: i32 = arith.last_dc_val[c];
+                        let mut block: [i16; 64] = [0i16; 64];
+                        arith.decode_dc_sequential(&mut block, c, dc_tbl_indices[c])?;
+                        let diff: i16 = (arith.last_dc_val[c] - prev_dc) as i16;
+                        comp_diffs[c].push(diff);
                     }
-                    PixelFormat::Bgr => {
-                        data.push(b);
-                        data.push(g);
-                        data.push(r);
-                    }
-                    PixelFormat::Rgba => {
-                        data.push(r);
-                        data.push(g);
-                        data.push(b);
-                        data.push(255);
-                    }
-                    PixelFormat::Bgra => {
-                        data.push(b);
-                        data.push(g);
-                        data.push(r);
-                        data.push(255);
-                    }
-                    _ => {
-                        return Err(JpegError::Unsupported(
-                            "cannot convert lossless 3-component to requested format".to_string(),
-                        ));
-                    }
+                }
+
+                // Undifference each component
+                for c in 0..3 {
+                    lossless::undifference_row(
+                        &comp_diffs[c],
+                        prev_rows[c].as_deref(),
+                        &mut comp_planes[c][row_start..row_start + width],
+                        psv,
+                        precision,
+                        pt,
+                        y == 0,
+                    );
+                    prev_rows[c] = Some(comp_planes[c][row_start..row_start + width].to_vec());
                 }
             }
 
+            self.lossless_output_color(&comp_planes, width, height, icc_profile, exif_data)
+        } else {
+            Err(JpegError::Unsupported(format!(
+                "{} components not yet supported for lossless",
+                num_components
+            )))
+        }
+    }
+
+    /// Convert decoded lossless grayscale samples to output Image.
+    fn lossless_output_grayscale(
+        &self,
+        output: &[u16],
+        width: usize,
+        height: usize,
+        pt: u8,
+        icc_profile: Option<Vec<u8>>,
+        exif_data: Option<Vec<u8>>,
+    ) -> Result<Image> {
+        let out_format = self.output_format.unwrap_or(PixelFormat::Grayscale);
+        let bpp = out_format.bytes_per_pixel();
+
+        if out_format == PixelFormat::Grayscale {
+            let mut data = Vec::with_capacity(width * height);
+            for &sample in output {
+                let val = if pt > 0 {
+                    ((sample as u32) << pt) as u8
+                } else {
+                    sample as u8
+                };
+                data.push(val);
+            }
+            Ok(Image {
+                width,
+                height,
+                pixel_format: PixelFormat::Grayscale,
+                precision: 8,
+                data,
+                icc_profile,
+                exif_data,
+                comment: self.metadata.comment.clone(),
+                density: self.metadata.density,
+                saved_markers: Vec::new(),
+                warnings: Vec::new(),
+            })
+        } else {
+            let mut data = Vec::with_capacity(width * height * bpp);
+            for &sample in output {
+                let val = if pt > 0 {
+                    ((sample as u32) << pt) as u8
+                } else {
+                    sample as u8
+                };
+                match out_format {
+                    PixelFormat::Rgb | PixelFormat::Bgr => {
+                        data.push(val);
+                        data.push(val);
+                        data.push(val);
+                    }
+                    PixelFormat::Rgba | PixelFormat::Bgra => {
+                        data.push(val);
+                        data.push(val);
+                        data.push(val);
+                        data.push(255);
+                    }
+                    _ => unreachable!(),
+                }
+            }
             Ok(Image {
                 width,
                 height,
@@ -1498,12 +1589,77 @@ impl<'a> Decoder<'a> {
                 saved_markers: Vec::new(),
                 warnings: Vec::new(),
             })
-        } else {
-            Err(JpegError::Unsupported(format!(
-                "{} components not yet supported for lossless",
-                num_components
-            )))
         }
+    }
+
+    /// Convert decoded lossless YCbCr component planes to output Image.
+    fn lossless_output_color(
+        &self,
+        comp_planes: &[Vec<u16>],
+        width: usize,
+        height: usize,
+        icc_profile: Option<Vec<u8>>,
+        exif_data: Option<Vec<u8>>,
+    ) -> Result<Image> {
+        let out_format = self.output_format.unwrap_or(PixelFormat::Rgb);
+        let bpp = out_format.bytes_per_pixel();
+        let mut data = Vec::with_capacity(width * height * bpp);
+
+        for i in 0..width * height {
+            let y_val = comp_planes[0][i] as i32;
+            let cb_val = comp_planes[1][i] as i32;
+            let cr_val = comp_planes[2][i] as i32;
+
+            // YCbCr to RGB (JFIF convention: Y,Cb,Cr centered at 128)
+            let r = (y_val + ((cr_val - 128) * 359 + 128) / 256).clamp(0, 255) as u8;
+            let g = (y_val - ((cb_val - 128) * 88 + (cr_val - 128) * 183 - 128) / 256).clamp(0, 255)
+                as u8;
+            let b = (y_val + ((cb_val - 128) * 454 + 128) / 256).clamp(0, 255) as u8;
+
+            match out_format {
+                PixelFormat::Rgb => {
+                    data.push(r);
+                    data.push(g);
+                    data.push(b);
+                }
+                PixelFormat::Bgr => {
+                    data.push(b);
+                    data.push(g);
+                    data.push(r);
+                }
+                PixelFormat::Rgba => {
+                    data.push(r);
+                    data.push(g);
+                    data.push(b);
+                    data.push(255);
+                }
+                PixelFormat::Bgra => {
+                    data.push(b);
+                    data.push(g);
+                    data.push(r);
+                    data.push(255);
+                }
+                _ => {
+                    return Err(JpegError::Unsupported(
+                        "cannot convert lossless 3-component to requested format".to_string(),
+                    ));
+                }
+            }
+        }
+
+        Ok(Image {
+            width,
+            height,
+            pixel_format: out_format,
+            precision: 8,
+            data,
+            icc_profile,
+            exif_data,
+            comment: self.metadata.comment.clone(),
+            density: self.metadata.density,
+            saved_markers: Vec::new(),
+            warnings: Vec::new(),
+        })
     }
 
     pub fn decode_image(&self) -> Result<Image> {
@@ -1560,7 +1716,7 @@ impl<'a> Decoder<'a> {
         let out_width = self.scale.scale_dim(width);
         let out_height = self.scale.scale_dim(height);
 
-        // Lossless JPEG (SOF3) — different pipeline, no IDCT/quant
+        // Lossless JPEG (SOF3/SOF11) — different pipeline, no IDCT/quant
         if frame.is_lossless {
             return self.decode_lossless_image(frame, width, height, icc_profile, exif_data);
         }

--- a/src/encode/marker_writer.rs
+++ b/src/encode/marker_writer.rs
@@ -337,6 +337,29 @@ pub fn write_sof3(
     }
 }
 
+/// Write SOF11 (lossless, arithmetic-coded) frame header.
+pub fn write_sof11(
+    buf: &mut Vec<u8>,
+    width: u16,
+    height: u16,
+    precision: u8,
+    components: &[(u8, u8, u8, u8)],
+) {
+    buf.push(0xFF);
+    buf.push(0xCB); // SOF11
+    let length: u16 = 2 + 1 + 2 + 2 + 1 + (components.len() as u16 * 3);
+    buf.extend_from_slice(&length.to_be_bytes());
+    buf.push(precision);
+    buf.extend_from_slice(&height.to_be_bytes());
+    buf.extend_from_slice(&width.to_be_bytes());
+    buf.push(components.len() as u8);
+    for &(id, h_samp, v_samp, qt_idx) in components {
+        buf.push(id);
+        buf.push((h_samp << 4) | v_samp);
+        buf.push(qt_idx);
+    }
+}
+
 /// Write SOS for lossless scan. Ss=predictor (1-7), Se=0, Ah=0, Al=point_transform.
 pub fn write_sos_lossless(
     buf: &mut Vec<u8>,

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -1332,6 +1332,231 @@ fn compress_lossless_rgb(
     Ok(output)
 }
 
+/// Compress as lossless JPEG with arithmetic entropy coding (SOF11).
+///
+/// Same predictor-based pipeline as SOF3 but uses ArithEncoder instead of
+/// Huffman coding. Writes SOF11 (0xCB) marker and DAC conditioning parameters.
+pub fn compress_lossless_arithmetic(
+    pixels: &[u8],
+    width: usize,
+    height: usize,
+    pixel_format: PixelFormat,
+    predictor: u8,
+    point_transform: u8,
+) -> Result<Vec<u8>> {
+    if predictor < 1 || predictor > 7 {
+        return Err(JpegError::Unsupported(format!(
+            "lossless predictor must be 1-7, got {}",
+            predictor
+        )));
+    }
+
+    if point_transform > 15 {
+        return Err(JpegError::Unsupported(format!(
+            "point transform must be 0-15, got {}",
+            point_transform
+        )));
+    }
+
+    if width == 0 || height == 0 {
+        return Err(JpegError::CorruptData(
+            "image dimensions must be non-zero".to_string(),
+        ));
+    }
+
+    let bpp: usize = pixel_format.bytes_per_pixel();
+    let expected_size: usize = width * height * bpp;
+    if pixels.len() < expected_size {
+        return Err(JpegError::BufferTooSmall {
+            need: expected_size,
+            got: pixels.len(),
+        });
+    }
+
+    match pixel_format {
+        PixelFormat::Grayscale => compress_lossless_arithmetic_grayscale(
+            pixels,
+            width,
+            height,
+            predictor,
+            point_transform,
+        ),
+        PixelFormat::Rgb => {
+            compress_lossless_arithmetic_rgb(pixels, width, height, predictor, point_transform)
+        }
+        _ => Err(JpegError::Unsupported(format!(
+            "lossless arithmetic encoding does not support {:?}, use Grayscale or Rgb",
+            pixel_format
+        ))),
+    }
+}
+
+/// Encode a single-component (grayscale) lossless JPEG with arithmetic coding.
+fn compress_lossless_arithmetic_grayscale(
+    pixels: &[u8],
+    width: usize,
+    height: usize,
+    predictor: u8,
+    point_transform: u8,
+) -> Result<Vec<u8>> {
+    use crate::encode::arithmetic::ArithEncoder;
+
+    let precision: u8 = 8;
+
+    let mut arith_enc: ArithEncoder = ArithEncoder::new(width * height);
+
+    // Encode each pixel's difference as a DC coefficient
+    for y in 0..height {
+        for x in 0..width {
+            let pixel: i32 = pixels[y * width + x] as i32;
+            let signed_diff: i16 = lossless_diff(
+                pixel,
+                x,
+                y,
+                pixels,
+                width,
+                predictor,
+                point_transform,
+                precision,
+            );
+            // Pack the difference into block[0] and encode as DC-only
+            let mut block: [i16; 64] = [0i16; 64];
+            block[0] = signed_diff.wrapping_add(arith_enc.last_dc_val[0] as i16);
+            arith_enc.encode_dc_sequential(&block, 0, 0);
+        }
+    }
+
+    arith_enc.finish();
+
+    let mut output: Vec<u8> = Vec::with_capacity(arith_enc.data().len() + 256);
+
+    marker_writer::write_soi(&mut output);
+
+    // SOF11 with 1 component
+    let components: Vec<(u8, u8, u8, u8)> = vec![(1, 1, 1, 0)];
+    marker_writer::write_sof11(
+        &mut output,
+        width as u16,
+        height as u16,
+        precision,
+        &components,
+    );
+
+    // DAC marker for DC table 0
+    let dc_params: [(u8, u8); 2] = [(0u8, 1u8), (0, 1)];
+    let ac_params: [u8; 2] = [5u8, 5];
+    marker_writer::write_dac(&mut output, 1, &dc_params, 0, &ac_params);
+
+    // SOS for lossless scan
+    let scan_components: Vec<(u8, u8)> = vec![(1, 0)];
+    marker_writer::write_sos_lossless(&mut output, &scan_components, predictor, point_transform);
+
+    output.extend_from_slice(arith_enc.data());
+
+    marker_writer::write_eoi(&mut output);
+
+    Ok(output)
+}
+
+/// Encode a 3-component (RGB via YCbCr) interleaved lossless JPEG with arithmetic coding.
+fn compress_lossless_arithmetic_rgb(
+    pixels: &[u8],
+    width: usize,
+    height: usize,
+    predictor: u8,
+    point_transform: u8,
+) -> Result<Vec<u8>> {
+    use crate::encode::arithmetic::ArithEncoder;
+
+    let precision: u8 = 8;
+    let num_pixels: usize = width * height;
+
+    // Convert RGB to YCbCr planes
+    let mut y_plane: Vec<u8> = vec![0u8; num_pixels];
+    let mut cb_plane: Vec<u8> = vec![0u8; num_pixels];
+    let mut cr_plane: Vec<u8> = vec![0u8; num_pixels];
+
+    for row in 0..height {
+        let row_start: usize = row * width * 3;
+        let plane_start: usize = row * width;
+        color::rgb_to_ycbcr_row(
+            &pixels[row_start..row_start + width * 3],
+            &mut y_plane[plane_start..plane_start + width],
+            &mut cb_plane[plane_start..plane_start + width],
+            &mut cr_plane[plane_start..plane_start + width],
+            width,
+        );
+    }
+
+    let planes: [&[u8]; 3] = [&y_plane, &cb_plane, &cr_plane];
+    // comp_idx 0=Y uses dc_tbl 0, comp_idx 1=Cb and 2=Cr use dc_tbl 1
+    let dc_tbls: [usize; 3] = [0, 1, 1];
+
+    let mut arith_enc: ArithEncoder = ArithEncoder::new(num_pixels * 3);
+
+    // Interleaved encoding: for each pixel, encode diff for Y, Cb, Cr
+    for y in 0..height {
+        for x in 0..width {
+            for c in 0..3 {
+                let pixel: i32 = planes[c][y * width + x] as i32;
+                let signed_diff: i16 = lossless_diff(
+                    pixel,
+                    x,
+                    y,
+                    planes[c],
+                    width,
+                    predictor,
+                    point_transform,
+                    precision,
+                );
+                // Pack the difference into block[0] and encode as DC-only
+                let mut block: [i16; 64] = [0i16; 64];
+                block[0] = signed_diff.wrapping_add(arith_enc.last_dc_val[c] as i16);
+                arith_enc.encode_dc_sequential(&block, c, dc_tbls[c]);
+            }
+        }
+    }
+
+    arith_enc.finish();
+
+    let mut output: Vec<u8> = Vec::with_capacity(arith_enc.data().len() + 512);
+
+    marker_writer::write_soi(&mut output);
+
+    // SOF11 with 3 components: Y(id=1), Cb(id=2), Cr(id=3), all 1x1, qt=0
+    let components: Vec<(u8, u8, u8, u8)> = vec![
+        (1, 1, 1, 0), // Y
+        (2, 1, 1, 0), // Cb
+        (3, 1, 1, 0), // Cr
+    ];
+    marker_writer::write_sof11(
+        &mut output,
+        width as u16,
+        height as u16,
+        precision,
+        &components,
+    );
+
+    // DAC marker for DC tables 0 and 1
+    let dc_params: [(u8, u8); 2] = [(0u8, 1u8), (0, 1)];
+    let ac_params: [u8; 2] = [5u8, 5];
+    marker_writer::write_dac(&mut output, 2, &dc_params, 0, &ac_params);
+
+    // SOS with 3 components: Y uses DC table 0, Cb/Cr use DC table 1
+    let scan_components: Vec<(u8, u8)> = vec![
+        (1, 0), // Y -> DC table 0
+        (2, 1), // Cb -> DC table 1
+        (3, 1), // Cr -> DC table 1
+    ];
+    marker_writer::write_sos_lossless(&mut output, &scan_components, predictor, point_transform);
+
+    output.extend_from_slice(arith_enc.data());
+
+    marker_writer::write_eoi(&mut output);
+
+    Ok(output)
+}
+
 /// Per-component block layout for progressive encoding.
 struct CompLayout {
     blocks_x: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,9 @@ pub use api::coefficient::{
 pub use api::encoder::{Encoder, HuffmanTableDef};
 pub use api::high_level::{
     compress, compress_arithmetic, compress_arithmetic_progressive, compress_lossless,
-    compress_lossless_extended, compress_optimized, compress_progressive, compress_with_metadata,
-    decompress, decompress_cropped, decompress_lenient, decompress_to,
+    compress_lossless_arithmetic, compress_lossless_extended, compress_optimized,
+    compress_progressive, compress_with_metadata, decompress, decompress_cropped,
+    decompress_lenient, decompress_to,
 };
 pub use common::error::{DecodeWarning, JpegError, Result};
 pub use common::sample::Sample;

--- a/tests/sof11.rs
+++ b/tests/sof11.rs
@@ -1,0 +1,43 @@
+use libjpeg_turbo_rs::{decompress, Encoder, PixelFormat};
+
+#[test]
+fn sof11_grayscale_roundtrip() {
+    let pixels: Vec<u8> = (0..=255).collect();
+    let jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Grayscale)
+        .lossless(true)
+        .arithmetic(true)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.data, pixels); // Lossless = exact
+}
+
+#[test]
+fn sof11_contains_marker() {
+    let pixels = vec![128u8; 64];
+    let jpeg = Encoder::new(&pixels, 8, 8, PixelFormat::Grayscale)
+        .lossless(true)
+        .arithmetic(true)
+        .encode()
+        .unwrap();
+    let has_sof11 = jpeg.windows(2).any(|w| w[0] == 0xFF && w[1] == 0xCB);
+    assert!(has_sof11);
+}
+
+#[test]
+fn sof11_gradient_roundtrip() {
+    let (w, h) = (32, 32);
+    let mut pixels = vec![0u8; w * h];
+    for y in 0..h {
+        for x in 0..w {
+            pixels[y * w + x] = ((x * 7 + y * 3) % 256) as u8;
+        }
+    }
+    let jpeg = Encoder::new(&pixels, w, h, PixelFormat::Grayscale)
+        .lossless(true)
+        .arithmetic(true)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.data, pixels);
+}


### PR DESCRIPTION
## Summary
- `compress_lossless_arithmetic()` — lossless encode with ArithEncoder instead of Huffman
- `write_sof11()` marker writer (0xCB)
- Decode: SOF11 recognized in marker reader, `decode_lossless_arithmetic()` using ArithDecoder
- Encoder builder: `lossless(true) + arithmetic(true)` routes to SOF11

## Test plan
- [x] Grayscale exact roundtrip (256 values)
- [x] SOF11 marker (0xCB) present
- [x] Gradient pattern exact roundtrip

🤖 Generated with [Claude Code](https://claude.com/claude-code)