### PR TITLE
feat: add DctMethod selection (IsLow, IsFast, Float)

### DIFF
--- a/src/api/encoder.rs
+++ b/src/api/encoder.rs
@@ -1,5 +1,5 @@
 use crate::common::error::Result;
-use crate::common::types::{PixelFormat, ScanScript, Subsampling};
+use crate::common::types::{DctMethod, PixelFormat, ScanScript, Subsampling};
 use crate::encode::pipeline as encoder;
 
 /// Configuration for DRI restart interval encoding.
@@ -46,6 +46,7 @@ pub struct Encoder<'a> {
     custom_quant_tables: [Option<[u16; 64]>; 4],
     custom_huffman_dc: [Option<HuffmanTableDef>; 4],
     custom_huffman_ac: [Option<HuffmanTableDef>; 4],
+    dct_method: DctMethod,
 }
 
 impl<'a> Encoder<'a> {
@@ -73,6 +74,7 @@ impl<'a> Encoder<'a> {
             custom_quant_tables: [None; 4],
             custom_huffman_dc: [None, None, None, None],
             custom_huffman_ac: [None, None, None, None],
+            dct_method: DctMethod::IsLow,
         }
     }
 
@@ -181,6 +183,16 @@ impl<'a> Encoder<'a> {
     /// Set a COM (comment) marker in the JPEG output.
     pub fn comment(mut self, text: &'a str) -> Self {
         self.comment = Some(text);
+        self
+    }
+
+    /// Select the DCT algorithm for encoding (default: `DctMethod::IsLow`).
+    ///
+    /// - `IsLow`: accurate integer DCT (13-bit fixed-point)
+    /// - `IsFast`: fast integer DCT with reduced accuracy (8-bit fixed-point)
+    /// - `Float`: floating-point DCT
+    pub fn dct_method(mut self, method: DctMethod) -> Self {
+        self.dct_method = method;
         self
     }
 
@@ -410,6 +422,7 @@ impl<'a> Encoder<'a> {
                 effective_format,
                 self.quality,
                 self.subsampling,
+                self.dct_method,
             )?
         };
 

--- a/src/api/high_level.rs
+++ b/src/api/high_level.rs
@@ -89,7 +89,15 @@ pub fn compress(
     quality: u8,
     subsampling: Subsampling,
 ) -> Result<Vec<u8>> {
-    encoder::compress(pixels, width, height, pixel_format, quality, subsampling)
+    encoder::compress(
+        pixels,
+        width,
+        height,
+        pixel_format,
+        quality,
+        subsampling,
+        crate::common::types::DctMethod::IsLow,
+    )
 }
 
 /// Compress with optimized Huffman tables (2-pass encoding).

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -63,6 +63,27 @@ impl Subsampling {
     }
 }
 
+/// DCT/IDCT algorithm selection.
+///
+/// Controls which forward DCT algorithm the encoder uses. All three methods
+/// produce valid JPEG output that any decoder can read. They differ in speed
+/// and accuracy trade-offs, matching libjpeg-turbo's `JDCT_ISLOW`, `JDCT_IFAST`,
+/// and `JDCT_FLOAT`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DctMethod {
+    /// Accurate integer DCT (default). Uses 13-bit fixed-point arithmetic.
+    /// Matches libjpeg-turbo's `JDCT_ISLOW`.
+    #[default]
+    IsLow,
+    /// Fast integer DCT with reduced accuracy. Uses 8-bit fixed-point arithmetic
+    /// and the AA&N (Arai, Agui, Nakajima) algorithm with only 5 multiplies.
+    /// Matches libjpeg-turbo's `JDCT_IFAST`.
+    IsFast,
+    /// Floating-point DCT. Uses f64 arithmetic and the AA&N algorithm.
+    /// Matches libjpeg-turbo's `JDCT_FLOAT`.
+    Float,
+}
+
 /// Output pixel formats.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PixelFormat {

--- a/src/encode/fdct.rs
+++ b/src/encode/fdct.rs
@@ -139,6 +139,299 @@ pub fn fdct_islow(input: &[i16; 64], output: &mut [i32; 64]) {
     }
 }
 
+/// Forward DCT (fast integer, reduced accuracy) — AA&N algorithm.
+///
+/// Port of libjpeg-turbo's `jfdctfst.c`. Uses 8-bit fixed-point precision
+/// (CONST_BITS=8) instead of 13-bit. Fewer bits means fewer shift operations
+/// but reduced accuracy, especially at high quality settings.
+///
+/// The AA&N algorithm (Arai, Agui, Nakajima) uses only 5 multiplies and 29 adds
+/// per 1-D DCT pass. In libjpeg-turbo, the remaining scale factors are folded
+/// into the quantization tables, but here we apply them explicitly so the output
+/// matches `fdct_islow`'s scale (factor of 8) for use with the same quantization path.
+pub fn fdct_ifast(input: &[i16; 64], output: &mut [i32; 64]) {
+    // AA&N scale factors to convert from AAN-scaled output to islow-equivalent output.
+    // These are: aanscale[i] = cos(i*PI/16) * sqrt(2)  (for i=0, aanscale=1.0)
+    // Expressed as fixed-point with 12 bits of fraction.
+    const AAN_SCALE_BITS: i32 = 12;
+    #[rustfmt::skip]
+    const AAN_SCALES: [i32; 8] = [
+        4096, // 1.0 * 4096
+        5681, // 1.387039845 * 4096
+        5352, // 1.306562965 * 4096
+        4816, // 1.175875602 * 4096
+        4096, // 1.0 * 4096
+        3218, // 0.785694958 * 4096
+        2217, // 0.541196100 * 4096
+        1130, // 0.275899379 * 4096
+    ];
+
+    // IFAST constants for CONST_BITS = 8 (from jfdctfst.c)
+    const IFAST_CONST_BITS: i32 = 8;
+    const IFAST_FIX_0_382683433: i32 = 98;
+    const IFAST_FIX_0_541196100: i32 = 139;
+    const IFAST_FIX_0_707106781: i32 = 181;
+    const IFAST_FIX_1_306562965: i32 = 334;
+
+    // DESCALE without rounding for ifast (matches libjpeg-turbo's ifast behavior)
+    #[inline(always)]
+    fn ifast_descale(x: i32, n: i32) -> i32 {
+        x >> n
+    }
+
+    #[inline(always)]
+    fn multiply(var: i32, constant: i32) -> i32 {
+        ifast_descale(var * constant, IFAST_CONST_BITS)
+    }
+
+    // Work in i32 to avoid overflow
+    let mut workspace = [0i32; 64];
+    for i in 0..64 {
+        workspace[i] = input[i] as i32;
+    }
+
+    // Pass 1: process rows (AA&N algorithm from jfdctfst.c)
+    for row in 0..8 {
+        let base: usize = row * 8;
+
+        let tmp0: i32 = workspace[base] + workspace[base + 7];
+        let tmp7: i32 = workspace[base] - workspace[base + 7];
+        let tmp1: i32 = workspace[base + 1] + workspace[base + 6];
+        let tmp6: i32 = workspace[base + 1] - workspace[base + 6];
+        let tmp2: i32 = workspace[base + 2] + workspace[base + 5];
+        let tmp5: i32 = workspace[base + 2] - workspace[base + 5];
+        let tmp3: i32 = workspace[base + 3] + workspace[base + 4];
+        let tmp4: i32 = workspace[base + 3] - workspace[base + 4];
+
+        // Even part
+        let tmp10: i32 = tmp0 + tmp3;
+        let tmp13: i32 = tmp0 - tmp3;
+        let tmp11: i32 = tmp1 + tmp2;
+        let tmp12: i32 = tmp1 - tmp2;
+
+        workspace[base] = tmp10 + tmp11;
+        workspace[base + 4] = tmp10 - tmp11;
+
+        let z1: i32 = multiply(tmp12 + tmp13, IFAST_FIX_0_707106781);
+        workspace[base + 2] = tmp13 + z1;
+        workspace[base + 6] = tmp13 - z1;
+
+        // Odd part
+        let tmp10: i32 = tmp4 + tmp5;
+        let tmp11: i32 = tmp5 + tmp6;
+        let tmp12: i32 = tmp6 + tmp7;
+
+        let z5: i32 = multiply(tmp10 - tmp12, IFAST_FIX_0_382683433);
+        let z2: i32 = multiply(tmp10, IFAST_FIX_0_541196100) + z5;
+        let z4: i32 = multiply(tmp12, IFAST_FIX_1_306562965) + z5;
+        let z3: i32 = multiply(tmp11, IFAST_FIX_0_707106781);
+
+        let z11: i32 = tmp7 + z3;
+        let z13: i32 = tmp7 - z3;
+
+        workspace[base + 5] = z13 + z2;
+        workspace[base + 3] = z13 - z2;
+        workspace[base + 1] = z11 + z4;
+        workspace[base + 7] = z11 - z4;
+    }
+
+    // Pass 2: process columns
+    for col in 0..8 {
+        let tmp0: i32 = workspace[col] + workspace[col + 56];
+        let tmp7: i32 = workspace[col] - workspace[col + 56];
+        let tmp1: i32 = workspace[col + 8] + workspace[col + 48];
+        let tmp6: i32 = workspace[col + 8] - workspace[col + 48];
+        let tmp2: i32 = workspace[col + 16] + workspace[col + 40];
+        let tmp5: i32 = workspace[col + 16] - workspace[col + 40];
+        let tmp3: i32 = workspace[col + 24] + workspace[col + 32];
+        let tmp4: i32 = workspace[col + 24] - workspace[col + 32];
+
+        // Even part
+        let tmp10: i32 = tmp0 + tmp3;
+        let tmp13: i32 = tmp0 - tmp3;
+        let tmp11: i32 = tmp1 + tmp2;
+        let tmp12: i32 = tmp1 - tmp2;
+
+        workspace[col] = tmp10 + tmp11;
+        workspace[col + 32] = tmp10 - tmp11;
+
+        let z1: i32 = multiply(tmp12 + tmp13, IFAST_FIX_0_707106781);
+        workspace[col + 16] = tmp13 + z1;
+        workspace[col + 48] = tmp13 - z1;
+
+        // Odd part
+        let tmp10: i32 = tmp4 + tmp5;
+        let tmp11: i32 = tmp5 + tmp6;
+        let tmp12: i32 = tmp6 + tmp7;
+
+        let z5: i32 = multiply(tmp10 - tmp12, IFAST_FIX_0_382683433);
+        let z2: i32 = multiply(tmp10, IFAST_FIX_0_541196100) + z5;
+        let z4: i32 = multiply(tmp12, IFAST_FIX_1_306562965) + z5;
+        let z3: i32 = multiply(tmp11, IFAST_FIX_0_707106781);
+
+        let z11: i32 = tmp7 + z3;
+        let z13: i32 = tmp7 - z3;
+
+        workspace[col + 40] = z13 + z2;
+        workspace[col + 24] = z13 - z2;
+        workspace[col + 8] = z11 + z4;
+        workspace[col + 56] = z11 - z4;
+    }
+
+    // Apply AA&N scale factors so output matches fdct_islow's scale.
+    // The raw AA&N output for coefficient (row, col) is:
+    //   islow_val * aanscale[row] * aanscale[col]
+    // So we divide by the 2-D AA&N scale factor to get islow-equivalent output.
+    for row in 0..8 {
+        for col in 0..8 {
+            let idx: usize = row * 8 + col;
+            let scale: i64 = (AAN_SCALES[row] as i64) * (AAN_SCALES[col] as i64);
+            let raw: i64 = workspace[idx] as i64;
+            // output = raw * 4096^2 / scale (fixed-point division)
+            output[idx] = ((raw * (1i64 << (AAN_SCALE_BITS * 2))) / scale) as i32;
+        }
+    }
+}
+
+/// Forward DCT (floating-point) — AA&N algorithm.
+///
+/// Port of libjpeg-turbo's `jfdctflt.c`. Uses f64 arithmetic for maximum
+/// accuracy, then converts to i32 output matching `fdct_islow`'s output
+/// format for use with the same quantization path.
+pub fn fdct_float(input: &[i16; 64], output: &mut [i32; 64]) {
+    // AA&N scale factors: aanscale[k] = cos(k*PI/16) * sqrt(2), aanscale[0] = 1.0
+    #[rustfmt::skip]
+    const AAN_SCALES: [f64; 8] = [
+        1.0,
+        1.387039845,
+        1.306562965,
+        1.175875602,
+        1.0,
+        0.785694958,
+        0.541196100,
+        0.275899379,
+    ];
+
+    let mut workspace = [0.0f64; 64];
+    for i in 0..64 {
+        workspace[i] = input[i] as f64;
+    }
+
+    // Pass 1: process rows (AA&N algorithm from jfdctflt.c)
+    for row in 0..8 {
+        let base: usize = row * 8;
+
+        let tmp0: f64 = workspace[base] + workspace[base + 7];
+        let tmp7: f64 = workspace[base] - workspace[base + 7];
+        let tmp1: f64 = workspace[base + 1] + workspace[base + 6];
+        let tmp6: f64 = workspace[base + 1] - workspace[base + 6];
+        let tmp2: f64 = workspace[base + 2] + workspace[base + 5];
+        let tmp5: f64 = workspace[base + 2] - workspace[base + 5];
+        let tmp3: f64 = workspace[base + 3] + workspace[base + 4];
+        let tmp4: f64 = workspace[base + 3] - workspace[base + 4];
+
+        // Even part
+        let tmp10: f64 = tmp0 + tmp3;
+        let tmp13: f64 = tmp0 - tmp3;
+        let tmp11: f64 = tmp1 + tmp2;
+        let tmp12: f64 = tmp1 - tmp2;
+
+        workspace[base] = tmp10 + tmp11;
+        workspace[base + 4] = tmp10 - tmp11;
+
+        let z1: f64 = (tmp12 + tmp13) * 0.707106781;
+        workspace[base + 2] = tmp13 + z1;
+        workspace[base + 6] = tmp13 - z1;
+
+        // Odd part
+        let tmp10: f64 = tmp4 + tmp5;
+        let tmp11: f64 = tmp5 + tmp6;
+        let tmp12: f64 = tmp6 + tmp7;
+
+        let z5: f64 = (tmp10 - tmp12) * 0.382683433;
+        let z2: f64 = 0.541196100 * tmp10 + z5;
+        let z4: f64 = 1.306562965 * tmp12 + z5;
+        let z3: f64 = tmp11 * 0.707106781;
+
+        let z11: f64 = tmp7 + z3;
+        let z13: f64 = tmp7 - z3;
+
+        workspace[base + 5] = z13 + z2;
+        workspace[base + 3] = z13 - z2;
+        workspace[base + 1] = z11 + z4;
+        workspace[base + 7] = z11 - z4;
+    }
+
+    // Pass 2: process columns
+    for col in 0..8 {
+        let tmp0: f64 = workspace[col] + workspace[col + 56];
+        let tmp7: f64 = workspace[col] - workspace[col + 56];
+        let tmp1: f64 = workspace[col + 8] + workspace[col + 48];
+        let tmp6: f64 = workspace[col + 8] - workspace[col + 48];
+        let tmp2: f64 = workspace[col + 16] + workspace[col + 40];
+        let tmp5: f64 = workspace[col + 16] - workspace[col + 40];
+        let tmp3: f64 = workspace[col + 24] + workspace[col + 32];
+        let tmp4: f64 = workspace[col + 24] - workspace[col + 32];
+
+        // Even part
+        let tmp10: f64 = tmp0 + tmp3;
+        let tmp13: f64 = tmp0 - tmp3;
+        let tmp11: f64 = tmp1 + tmp2;
+        let tmp12: f64 = tmp1 - tmp2;
+
+        workspace[col] = tmp10 + tmp11;
+        workspace[col + 32] = tmp10 - tmp11;
+
+        let z1: f64 = (tmp12 + tmp13) * 0.707106781;
+        workspace[col + 16] = tmp13 + z1;
+        workspace[col + 48] = tmp13 - z1;
+
+        // Odd part
+        let tmp10: f64 = tmp4 + tmp5;
+        let tmp11: f64 = tmp5 + tmp6;
+        let tmp12: f64 = tmp6 + tmp7;
+
+        let z5: f64 = (tmp10 - tmp12) * 0.382683433;
+        let z2: f64 = 0.541196100 * tmp10 + z5;
+        let z4: f64 = 1.306562965 * tmp12 + z5;
+        let z3: f64 = tmp11 * 0.707106781;
+
+        let z11: f64 = tmp7 + z3;
+        let z13: f64 = tmp7 - z3;
+
+        workspace[col + 40] = z13 + z2;
+        workspace[col + 24] = z13 - z2;
+        workspace[col + 8] = z11 + z4;
+        workspace[col + 56] = z11 - z4;
+    }
+
+    // Convert to i32 output, dividing by AA&N scale factors to match
+    // fdct_islow's output format.
+    for row in 0..8 {
+        for col in 0..8 {
+            let idx: usize = row * 8 + col;
+            let scale: f64 = AAN_SCALES[row] * AAN_SCALES[col];
+            // Divide by the 2-D AA&N scale factor to get islow-equivalent output.
+            let val: f64 = workspace[idx] / scale;
+            // Round to nearest integer (matching libjpeg behavior)
+            output[idx] = if val >= 0.0 {
+                (val + 0.5) as i32
+            } else {
+                (val - 0.5) as i32
+            };
+        }
+    }
+}
+
+/// Returns the appropriate FDCT function for the given DCT method.
+pub fn select_fdct(method: crate::common::types::DctMethod) -> fn(&[i16; 64], &mut [i32; 64]) {
+    match method {
+        crate::common::types::DctMethod::IsLow => fdct_islow,
+        crate::common::types::DctMethod::IsFast => fdct_ifast,
+        crate::common::types::DctMethod::Float => fdct_float,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -233,5 +526,179 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn fdct_ifast_all_zeros_produces_zeros() {
+        let input = [0i16; 64];
+        let mut output = [0i32; 64];
+        fdct_ifast(&input, &mut output);
+        for (i, &v) in output.iter().enumerate() {
+            assert_eq!(v, 0, "ifast: expected 0 at index {i}, got {v}");
+        }
+    }
+
+    #[test]
+    fn fdct_ifast_dc_only_block() {
+        // Uniform block: all AC should be zero (or very close), DC should be close to islow
+        let input = [-28i16; 64];
+        let mut output_ifast = [0i32; 64];
+        let mut output_islow = [0i32; 64];
+        fdct_ifast(&input, &mut output_ifast);
+        fdct_islow(&input, &mut output_islow);
+
+        // DC should be within 5% of islow's DC
+        let dc_diff: i32 = (output_ifast[0] - output_islow[0]).abs();
+        assert!(
+            dc_diff < (output_islow[0].abs() / 20).max(2),
+            "ifast DC {} too far from islow DC {} (diff={})",
+            output_ifast[0],
+            output_islow[0],
+            dc_diff
+        );
+
+        // AC coefficients should be zero for a uniform block
+        for i in 1..64 {
+            assert!(
+                output_ifast[i].abs() <= 1,
+                "ifast AC[{i}] should be ~0, got {}",
+                output_ifast[i]
+            );
+        }
+    }
+
+    #[test]
+    fn fdct_ifast_produces_nonzero_ac_for_gradient() {
+        let mut input = [0i16; 64];
+        for row in 0..8 {
+            for col in 0..8 {
+                input[row * 8 + col] = (row * 8 + col) as i16 - 32;
+            }
+        }
+        let mut output = [0i32; 64];
+        fdct_ifast(&input, &mut output);
+        assert_ne!(output[0], 0, "DC should be non-zero for gradient");
+        let has_ac = output[1..].iter().any(|&v| v != 0);
+        assert!(has_ac, "gradient should have non-zero AC in ifast");
+    }
+
+    #[test]
+    fn fdct_float_all_zeros_produces_zeros() {
+        let input = [0i16; 64];
+        let mut output = [0i32; 64];
+        fdct_float(&input, &mut output);
+        for (i, &v) in output.iter().enumerate() {
+            assert_eq!(v, 0, "float: expected 0 at index {i}, got {v}");
+        }
+    }
+
+    #[test]
+    fn fdct_float_dc_only_block() {
+        // Uniform block: DC should be close to islow, all AC should be ~0
+        let input = [-28i16; 64];
+        let mut output_float = [0i32; 64];
+        let mut output_islow = [0i32; 64];
+        fdct_float(&input, &mut output_float);
+        fdct_islow(&input, &mut output_islow);
+
+        // Float should be very close to islow for DC
+        let dc_diff: i32 = (output_float[0] - output_islow[0]).abs();
+        assert!(
+            dc_diff <= 1,
+            "float DC {} should match islow DC {} (diff={})",
+            output_float[0],
+            output_islow[0],
+            dc_diff
+        );
+
+        // AC should be zero for a uniform block
+        for i in 1..64 {
+            assert!(
+                output_float[i].abs() <= 1,
+                "float AC[{i}] should be ~0, got {}",
+                output_float[i]
+            );
+        }
+    }
+
+    #[test]
+    fn fdct_float_produces_nonzero_ac_for_gradient() {
+        let mut input = [0i16; 64];
+        for row in 0..8 {
+            for col in 0..8 {
+                input[row * 8 + col] = (row * 8 + col) as i16 - 32;
+            }
+        }
+        let mut output = [0i32; 64];
+        fdct_float(&input, &mut output);
+        assert_ne!(output[0], 0, "DC should be non-zero for gradient");
+        let has_ac = output[1..].iter().any(|&v| v != 0);
+        assert!(has_ac, "gradient should have non-zero AC in float");
+    }
+
+    #[test]
+    fn fdct_float_close_to_islow_for_gradient() {
+        // Float should generally produce values close to islow
+        let mut input = [0i16; 64];
+        for row in 0..8 {
+            for col in 0..8 {
+                input[row * 8 + col] = (row * 8 + col) as i16 - 32;
+            }
+        }
+        let mut output_float = [0i32; 64];
+        let mut output_islow = [0i32; 64];
+        fdct_float(&input, &mut output_float);
+        fdct_islow(&input, &mut output_islow);
+
+        // Allow up to 10% relative error or absolute error of 2
+        for i in 0..64 {
+            let diff: i32 = (output_float[i] - output_islow[i]).abs();
+            let tolerance: i32 = (output_islow[i].abs() / 10).max(2);
+            assert!(
+                diff <= tolerance,
+                "float[{i}]={} vs islow[{i}]={} differ by {} (tolerance={})",
+                output_float[i],
+                output_islow[i],
+                diff,
+                tolerance
+            );
+        }
+    }
+
+    #[test]
+    fn select_fdct_returns_correct_variant() {
+        use crate::common::types::DctMethod;
+        let input = [-28i16; 64];
+
+        let mut out_islow = [0i32; 64];
+        let mut out_selected = [0i32; 64];
+
+        fdct_islow(&input, &mut out_islow);
+        let f = select_fdct(DctMethod::IsLow);
+        f(&input, &mut out_selected);
+        assert_eq!(
+            out_islow, out_selected,
+            "select_fdct(IsLow) should return fdct_islow"
+        );
+
+        let mut out_ifast = [0i32; 64];
+        let mut out_selected2 = [0i32; 64];
+        fdct_ifast(&input, &mut out_ifast);
+        let f = select_fdct(DctMethod::IsFast);
+        f(&input, &mut out_selected2);
+        assert_eq!(
+            out_ifast, out_selected2,
+            "select_fdct(IsFast) should return fdct_ifast"
+        );
+
+        let mut out_float = [0i32; 64];
+        let mut out_selected3 = [0i32; 64];
+        fdct_float(&input, &mut out_float);
+        let f = select_fdct(DctMethod::Float);
+        f(&input, &mut out_selected3);
+        assert_eq!(
+            out_float, out_selected3,
+            "select_fdct(Float) should return fdct_float"
+        );
     }
 }

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -4,7 +4,7 @@
 /// and marker writing to produce a valid baseline JPEG file.
 use crate::api::encoder::HuffmanTableDef;
 use crate::common::error::{JpegError, Result};
-use crate::common::types::{PixelFormat, ScanScript, Subsampling};
+use crate::common::types::{DctMethod, PixelFormat, ScanScript, Subsampling};
 use crate::encode::color;
 use crate::encode::fdct;
 use crate::encode::huffman_encode::{build_huff_table, BitWriter, HuffTable, HuffmanEncoder};
@@ -32,6 +32,7 @@ pub fn compress(
     pixel_format: PixelFormat,
     quality: u8,
     subsampling: Subsampling,
+    dct_method: DctMethod,
 ) -> Result<Vec<u8>> {
     // Validate inputs
     if width == 0 || height == 0 {
@@ -49,7 +50,7 @@ pub fn compress(
         });
     }
 
-    // CMYK: 4-component path, no color conversion
+    // CMYK: 4-component path, no color conversion (ignores dct_method for now)
     if pixel_format == PixelFormat::Cmyk {
         return compress_cmyk(pixels, width, height, quality);
     }
@@ -94,6 +95,9 @@ pub fn compress(
     let mcus_x = (width + mcu_w - 1) / mcu_w;
     let mcus_y = (height + mcu_h - 1) / mcu_h;
 
+    // Select the forward DCT function based on the configured method
+    let fdct_fn: fn(&[i16; 64], &mut [i32; 64]) = fdct::select_fdct(dct_method);
+
     // Entropy encode all MCUs
     let mut bit_writer = BitWriter::new(width * height);
     let mut prev_dc_y: i16 = 0;
@@ -117,6 +121,7 @@ pub fn compress(
                     &ac_luma_table,
                     &mut bit_writer,
                     &mut prev_dc_y,
+                    fdct_fn,
                 );
             } else {
                 encode_color_mcu(
@@ -138,6 +143,7 @@ pub fn compress(
                     &mut prev_dc_y,
                     &mut prev_dc_cb,
                     &mut prev_dc_cr,
+                    fdct_fn,
                 );
             }
         }
@@ -356,6 +362,7 @@ pub fn compress_custom_huffman(
                     &ac_luma_table,
                     &mut bit_writer,
                     &mut prev_dc_y,
+                    fdct::fdct_islow,
                 );
             } else {
                 encode_color_mcu(
@@ -377,6 +384,7 @@ pub fn compress_custom_huffman(
                     &mut prev_dc_y,
                     &mut prev_dc_cb,
                     &mut prev_dc_cr,
+                    fdct::fdct_islow,
                 );
             }
         }
@@ -477,6 +485,7 @@ pub fn compress_custom_quant(
     let is_grayscale = pixel_format == PixelFormat::Grayscale;
 
     // Use custom tables when provided, otherwise fall back to quality-scaled defaults
+    // compress_custom_quant: resolve quant tables
     let luma_quant = match custom_quant[0] {
         Some(table) => table,
         None => tables::quality_scale_quant_table(&tables::STD_LUMINANCE_QUANT_TABLE, quality),
@@ -542,6 +551,7 @@ pub fn compress_custom_quant(
                     &ac_luma_table,
                     &mut bit_writer,
                     &mut prev_dc_y,
+                    fdct::fdct_islow,
                 );
             } else {
                 encode_color_mcu(
@@ -563,6 +573,7 @@ pub fn compress_custom_quant(
                     &mut prev_dc_y,
                     &mut prev_dc_cb,
                     &mut prev_dc_cr,
+                    fdct::fdct_islow,
                 );
             }
         }
@@ -758,6 +769,7 @@ pub fn compress_with_restart(
                     &ac_luma_table,
                     &mut bit_writer,
                     &mut prev_dc_y,
+                    fdct::fdct_islow,
                 );
             } else {
                 encode_color_mcu(
@@ -779,6 +791,7 @@ pub fn compress_with_restart(
                     &mut prev_dc_y,
                     &mut prev_dc_cb,
                     &mut prev_dc_cr,
+                    fdct::fdct_islow,
                 );
             }
 
@@ -885,7 +898,15 @@ pub fn compress_with_metadata(
     icc_profile: Option<&[u8]>,
     exif_data: Option<&[u8]>,
 ) -> Result<Vec<u8>> {
-    let base = compress(pixels, width, height, pixel_format, quality, subsampling)?;
+    let base = compress(
+        pixels,
+        width,
+        height,
+        pixel_format,
+        quality,
+        subsampling,
+        DctMethod::IsLow,
+    )?;
     inject_metadata(&base, icc_profile, exif_data)
 }
 
@@ -988,6 +1009,7 @@ fn compress_cmyk(pixels: &[u8], width: usize, height: usize, quality: u8) -> Res
                     &ac_table,
                     &mut bit_writer,
                     &mut prev_dc[c],
+                    fdct::fdct_islow,
                 );
             }
         }
@@ -2980,6 +3002,7 @@ fn encode_single_block(
     ac_table: &HuffTable,
     writer: &mut BitWriter,
     prev_dc: &mut i16,
+    fdct_fn: fn(&[i16; 64], &mut [i32; 64]),
 ) {
     let mut block = [0i16; 64];
     extract_block(
@@ -2992,7 +3015,7 @@ fn encode_single_block(
     );
 
     let mut dct_output = [0i32; 64];
-    fdct::fdct_islow(&block, &mut dct_output);
+    fdct_fn(&block, &mut dct_output);
 
     let mut quantized = [0i16; 64];
     quant::quantize_block(&dct_output, quant_table, &mut quantized);
@@ -3021,6 +3044,7 @@ fn encode_color_mcu(
     prev_dc_y: &mut i16,
     prev_dc_cb: &mut i16,
     prev_dc_cr: &mut i16,
+    fdct_fn: fn(&[i16; 64], &mut [i32; 64]),
 ) {
     match subsampling {
         Subsampling::S444 => {
@@ -3036,6 +3060,7 @@ fn encode_color_mcu(
                 ac_luma_table,
                 writer,
                 prev_dc_y,
+                fdct_fn,
             );
             encode_single_block(
                 cb_plane,
@@ -3048,6 +3073,7 @@ fn encode_color_mcu(
                 ac_chroma_table,
                 writer,
                 prev_dc_cb,
+                fdct_fn,
             );
             encode_single_block(
                 cr_plane,
@@ -3060,6 +3086,7 @@ fn encode_color_mcu(
                 ac_chroma_table,
                 writer,
                 prev_dc_cr,
+                fdct_fn,
             );
         }
         Subsampling::S422 => {
@@ -3075,6 +3102,7 @@ fn encode_color_mcu(
                 ac_luma_table,
                 writer,
                 prev_dc_y,
+                fdct_fn,
             );
             encode_single_block(
                 y_plane,
@@ -3087,6 +3115,7 @@ fn encode_color_mcu(
                 ac_luma_table,
                 writer,
                 prev_dc_y,
+                fdct_fn,
             );
             // Downsample chroma: 2x1 box filter
             encode_downsampled_chroma_block(
@@ -3102,6 +3131,7 @@ fn encode_color_mcu(
                 ac_chroma_table,
                 writer,
                 prev_dc_cb,
+                fdct_fn,
             );
             encode_downsampled_chroma_block(
                 cr_plane,
@@ -3116,6 +3146,7 @@ fn encode_color_mcu(
                 ac_chroma_table,
                 writer,
                 prev_dc_cr,
+                fdct_fn,
             );
         }
         Subsampling::S420 => {
@@ -3132,6 +3163,7 @@ fn encode_color_mcu(
                 ac_luma_table,
                 writer,
                 prev_dc_y,
+                fdct_fn,
             );
             encode_single_block(
                 y_plane,
@@ -3144,6 +3176,7 @@ fn encode_color_mcu(
                 ac_luma_table,
                 writer,
                 prev_dc_y,
+                fdct_fn,
             );
             encode_single_block(
                 y_plane,
@@ -3156,6 +3189,7 @@ fn encode_color_mcu(
                 ac_luma_table,
                 writer,
                 prev_dc_y,
+                fdct_fn,
             );
             encode_single_block(
                 y_plane,
@@ -3168,6 +3202,7 @@ fn encode_color_mcu(
                 ac_luma_table,
                 writer,
                 prev_dc_y,
+                fdct_fn,
             );
             // Downsample chroma: 2x2 box filter
             encode_downsampled_chroma_block(
@@ -3183,6 +3218,7 @@ fn encode_color_mcu(
                 ac_chroma_table,
                 writer,
                 prev_dc_cb,
+                fdct_fn,
             );
             encode_downsampled_chroma_block(
                 cr_plane,
@@ -3197,6 +3233,7 @@ fn encode_color_mcu(
                 ac_chroma_table,
                 writer,
                 prev_dc_cr,
+                fdct_fn,
             );
         }
         Subsampling::S440 => {
@@ -3212,6 +3249,7 @@ fn encode_color_mcu(
                 ac_luma_table,
                 writer,
                 prev_dc_y,
+                fdct_fn,
             );
             encode_single_block(
                 y_plane,
@@ -3224,6 +3262,7 @@ fn encode_color_mcu(
                 ac_luma_table,
                 writer,
                 prev_dc_y,
+                fdct_fn,
             );
             // Cb/Cr downsampled 1x2
             encode_downsampled_chroma_block(
@@ -3239,6 +3278,7 @@ fn encode_color_mcu(
                 ac_chroma_table,
                 writer,
                 prev_dc_cb,
+                fdct_fn,
             );
             encode_downsampled_chroma_block(
                 cr_plane,
@@ -3253,6 +3293,7 @@ fn encode_color_mcu(
                 ac_chroma_table,
                 writer,
                 prev_dc_cr,
+                fdct_fn,
             );
         }
         Subsampling::S411 => {
@@ -3269,6 +3310,7 @@ fn encode_color_mcu(
                     ac_luma_table,
                     writer,
                     prev_dc_y,
+                    fdct_fn,
                 );
             }
             // Cb/Cr downsampled 4x1
@@ -3285,6 +3327,7 @@ fn encode_color_mcu(
                 ac_chroma_table,
                 writer,
                 prev_dc_cb,
+                fdct_fn,
             );
             encode_downsampled_chroma_block(
                 cr_plane,
@@ -3299,6 +3342,7 @@ fn encode_color_mcu(
                 ac_chroma_table,
                 writer,
                 prev_dc_cr,
+                fdct_fn,
             );
         }
     }
@@ -3319,6 +3363,7 @@ fn encode_downsampled_chroma_block(
     ac_table: &HuffTable,
     writer: &mut BitWriter,
     prev_dc: &mut i16,
+    fdct_fn: fn(&[i16; 64], &mut [i32; 64]),
 ) {
     let mut block = [0i16; 64];
     downsample_chroma_block(
@@ -3333,7 +3378,7 @@ fn encode_downsampled_chroma_block(
     );
 
     let mut dct_output = [0i32; 64];
-    fdct::fdct_islow(&block, &mut dct_output);
+    fdct_fn(&block, &mut dct_output);
 
     let mut quantized = [0i16; 64];
     quant::quantize_block(&dct_output, quant_table, &mut quantized);
@@ -3929,7 +3974,15 @@ mod tests {
     fn compress_grayscale_1x1() {
         // Minimal 1x1 grayscale image
         let pixels = [128u8];
-        let result = compress(&pixels, 1, 1, PixelFormat::Grayscale, 75, Subsampling::S444);
+        let result = compress(
+            &pixels,
+            1,
+            1,
+            PixelFormat::Grayscale,
+            75,
+            Subsampling::S444,
+            DctMethod::IsLow,
+        );
         assert!(result.is_ok());
         let jpeg = result.unwrap();
         // Check SOI marker
@@ -3949,7 +4002,15 @@ mod tests {
             pixels[i * 3 + 1] = 0; // G
             pixels[i * 3 + 2] = 0; // B
         }
-        let result = compress(&pixels, 8, 8, PixelFormat::Rgb, 75, Subsampling::S444);
+        let result = compress(
+            &pixels,
+            8,
+            8,
+            PixelFormat::Rgb,
+            75,
+            Subsampling::S444,
+            DctMethod::IsLow,
+        );
         assert!(result.is_ok());
         let jpeg = result.unwrap();
         assert_eq!(jpeg[0], 0xFF);
@@ -3967,7 +4028,15 @@ mod tests {
             pixels[i * 3 + 1] = 255;
             pixels[i * 3 + 2] = 0;
         }
-        let result = compress(&pixels, 16, 8, PixelFormat::Rgb, 75, Subsampling::S422);
+        let result = compress(
+            &pixels,
+            16,
+            8,
+            PixelFormat::Rgb,
+            75,
+            Subsampling::S422,
+            DctMethod::IsLow,
+        );
         assert!(result.is_ok());
     }
 
@@ -3980,7 +4049,15 @@ mod tests {
             pixels[i * 3 + 1] = 0;
             pixels[i * 3 + 2] = 255;
         }
-        let result = compress(&pixels, 16, 16, PixelFormat::Rgb, 75, Subsampling::S420);
+        let result = compress(
+            &pixels,
+            16,
+            16,
+            PixelFormat::Rgb,
+            75,
+            Subsampling::S420,
+            DctMethod::IsLow,
+        );
         assert!(result.is_ok());
     }
 
@@ -3988,7 +4065,15 @@ mod tests {
     fn compress_non_multiple_of_8() {
         // 10x6 image (not a multiple of 8 in either dimension)
         let pixels = vec![128u8; 10 * 6 * 3];
-        let result = compress(&pixels, 10, 6, PixelFormat::Rgb, 50, Subsampling::S444);
+        let result = compress(
+            &pixels,
+            10,
+            6,
+            PixelFormat::Rgb,
+            50,
+            Subsampling::S444,
+            DctMethod::IsLow,
+        );
         assert!(result.is_ok());
     }
 
@@ -3996,42 +4081,90 @@ mod tests {
     fn compress_non_multiple_of_16_420() {
         // 13x11 image with 4:2:0 (MCU = 16x16)
         let pixels = vec![200u8; 13 * 11 * 3];
-        let result = compress(&pixels, 13, 11, PixelFormat::Rgb, 90, Subsampling::S420);
+        let result = compress(
+            &pixels,
+            13,
+            11,
+            PixelFormat::Rgb,
+            90,
+            Subsampling::S420,
+            DctMethod::IsLow,
+        );
         assert!(result.is_ok());
     }
 
     #[test]
     fn compress_rgba_input() {
         let pixels = vec![128u8; 8 * 8 * 4];
-        let result = compress(&pixels, 8, 8, PixelFormat::Rgba, 75, Subsampling::S444);
+        let result = compress(
+            &pixels,
+            8,
+            8,
+            PixelFormat::Rgba,
+            75,
+            Subsampling::S444,
+            DctMethod::IsLow,
+        );
         assert!(result.is_ok());
     }
 
     #[test]
     fn compress_bgr_input() {
         let pixels = vec![128u8; 8 * 8 * 3];
-        let result = compress(&pixels, 8, 8, PixelFormat::Bgr, 75, Subsampling::S444);
+        let result = compress(
+            &pixels,
+            8,
+            8,
+            PixelFormat::Bgr,
+            75,
+            Subsampling::S444,
+            DctMethod::IsLow,
+        );
         assert!(result.is_ok());
     }
 
     #[test]
     fn compress_bgra_input() {
         let pixels = vec![128u8; 8 * 8 * 4];
-        let result = compress(&pixels, 8, 8, PixelFormat::Bgra, 75, Subsampling::S444);
+        let result = compress(
+            &pixels,
+            8,
+            8,
+            PixelFormat::Bgra,
+            75,
+            Subsampling::S444,
+            DctMethod::IsLow,
+        );
         assert!(result.is_ok());
     }
 
     #[test]
     fn compress_rejects_zero_dimensions() {
         let pixels = vec![128u8; 64];
-        let result = compress(&pixels, 0, 8, PixelFormat::Grayscale, 75, Subsampling::S444);
+        let result = compress(
+            &pixels,
+            0,
+            8,
+            PixelFormat::Grayscale,
+            75,
+            Subsampling::S444,
+            DctMethod::IsLow,
+        );
         assert!(result.is_err());
     }
 
     #[test]
     fn compress_rejects_buffer_too_small() {
         let pixels = vec![128u8; 10];
-        let result = compress(&pixels, 8, 8, PixelFormat::Rgb, 75, Subsampling::S444);
+        let result = compress(
+            &pixels,
+            8,
+            8,
+            PixelFormat::Rgb,
+            75,
+            Subsampling::S444,
+            DctMethod::IsLow,
+        );
         assert!(result.is_err());
     }
 
@@ -4039,10 +4172,26 @@ mod tests {
     fn compress_quality_extremes() {
         let pixels = vec![128u8; 8 * 8 * 3];
         // Quality 1 (worst)
-        let result1 = compress(&pixels, 8, 8, PixelFormat::Rgb, 1, Subsampling::S444);
+        let result1 = compress(
+            &pixels,
+            8,
+            8,
+            PixelFormat::Rgb,
+            1,
+            Subsampling::S444,
+            DctMethod::IsLow,
+        );
         assert!(result1.is_ok());
         // Quality 100 (best)
-        let result100 = compress(&pixels, 8, 8, PixelFormat::Rgb, 100, Subsampling::S444);
+        let result100 = compress(
+            &pixels,
+            8,
+            8,
+            PixelFormat::Rgb,
+            100,
+            Subsampling::S444,
+            DctMethod::IsLow,
+        );
         assert!(result100.is_ok());
         // Higher quality should generally produce larger output
         assert!(result100.unwrap().len() >= result1.unwrap().len());
@@ -4061,6 +4210,7 @@ mod tests {
             PixelFormat::Grayscale,
             100,
             Subsampling::S444,
+            DctMethod::IsLow,
         )
         .unwrap();
 
@@ -4096,6 +4246,7 @@ mod tests {
             PixelFormat::Rgb,
             100,
             Subsampling::S444,
+            DctMethod::IsLow,
         )
         .unwrap();
 
@@ -4119,7 +4270,15 @@ mod tests {
     #[test]
     fn compress_cmyk_produces_valid_jpeg() {
         let pixels = vec![128u8; 8 * 8 * 4];
-        let result = compress(&pixels, 8, 8, PixelFormat::Cmyk, 75, Subsampling::S444);
+        let result = compress(
+            &pixels,
+            8,
+            8,
+            PixelFormat::Cmyk,
+            75,
+            Subsampling::S444,
+            DctMethod::IsLow,
+        );
         assert!(result.is_ok());
     }
 

--- a/tests/dct_method.rs
+++ b/tests/dct_method.rs
@@ -1,0 +1,117 @@
+use libjpeg_turbo_rs::{decompress, DctMethod, Encoder, PixelFormat};
+
+#[test]
+fn dct_islow_roundtrip() {
+    let pixels: Vec<u8> = vec![128u8; 16 * 16 * 3];
+    let jpeg: Vec<u8> = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .quality(75)
+        .dct_method(DctMethod::IsLow)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 16);
+    assert_eq!(img.height, 16);
+}
+
+#[test]
+fn dct_ifast_roundtrip() {
+    let pixels: Vec<u8> = vec![128u8; 16 * 16 * 3];
+    let jpeg: Vec<u8> = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .quality(75)
+        .dct_method(DctMethod::IsFast)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 16);
+    assert_eq!(img.height, 16);
+}
+
+#[test]
+fn dct_float_roundtrip() {
+    let pixels: Vec<u8> = vec![128u8; 16 * 16 * 3];
+    let jpeg: Vec<u8> = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .quality(75)
+        .dct_method(DctMethod::Float)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 16);
+    assert_eq!(img.height, 16);
+}
+
+#[test]
+fn dct_methods_produce_different_output() {
+    // Use a non-uniform pattern to trigger different DCT behavior across methods
+    let mut pixels: Vec<u8> = vec![0u8; 32 * 32 * 3];
+    for (i, p) in pixels.iter_mut().enumerate() {
+        *p = ((i * 37 + 13) % 256) as u8;
+    }
+
+    let slow: Vec<u8> = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(75)
+        .dct_method(DctMethod::IsLow)
+        .encode()
+        .unwrap();
+    let fast: Vec<u8> = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(75)
+        .dct_method(DctMethod::IsFast)
+        .encode()
+        .unwrap();
+
+    // Both decode successfully
+    let img_slow = decompress(&slow).unwrap();
+    let img_fast = decompress(&fast).unwrap();
+    assert_eq!(img_slow.width, 32);
+    assert_eq!(img_fast.width, 32);
+}
+
+#[test]
+fn dct_default_is_islow() {
+    // Encoding without specifying dct_method should produce identical output to IsLow
+    let pixels: Vec<u8> = vec![200u8; 8 * 8 * 3];
+    let default_jpeg: Vec<u8> = Encoder::new(&pixels, 8, 8, PixelFormat::Rgb)
+        .quality(90)
+        .encode()
+        .unwrap();
+    let islow_jpeg: Vec<u8> = Encoder::new(&pixels, 8, 8, PixelFormat::Rgb)
+        .quality(90)
+        .dct_method(DctMethod::IsLow)
+        .encode()
+        .unwrap();
+    assert_eq!(default_jpeg, islow_jpeg);
+}
+
+#[test]
+fn dct_float_larger_image_roundtrip() {
+    // Verify float DCT works with a larger, more realistic image
+    let mut pixels: Vec<u8> = vec![0u8; 64 * 64 * 3];
+    for row in 0..64 {
+        for col in 0..64 {
+            let idx: usize = (row * 64 + col) * 3;
+            pixels[idx] = (row * 4) as u8;
+            pixels[idx + 1] = (col * 4) as u8;
+            pixels[idx + 2] = 128;
+        }
+    }
+    let jpeg: Vec<u8> = Encoder::new(&pixels, 64, 64, PixelFormat::Rgb)
+        .quality(85)
+        .dct_method(DctMethod::Float)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 64);
+    assert_eq!(img.height, 64);
+}
+
+#[test]
+fn dct_ifast_grayscale_roundtrip() {
+    let pixels: Vec<u8> = vec![100u8; 16 * 16];
+    let jpeg: Vec<u8> = Encoder::new(&pixels, 16, 16, PixelFormat::Grayscale)
+        .quality(75)
+        .dct_method(DctMethod::IsFast)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 16);
+    assert_eq!(img.height, 16);
+}


### PR DESCRIPTION
## Summary
- `DctMethod` enum: `IsLow` (default, accurate), `IsFast` (AA&N 8-bit fixed-point), `Float` (f64)
- `fdct_ifast()` and `fdct_float()` FDCT implementations ported from libjpeg-turbo
- `select_fdct()` dispatch function
- `Encoder::dct_method()` builder API
- Wired through baseline compress path

## Test plan
- [x] Roundtrip for each DCT method (IsLow, IsFast, Float)
- [x] Different methods both produce decodable output
- [x] Grayscale with IsFast
- [x] Larger image with Float
- [x] Default is IsLow
- [x] 8 FDCT unit tests (zeros, DC-only, gradient, accuracy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)