### PR TITLE
feat: add 7 new pixel formats (Rgbx, Bgrx, Xrgb, Xbgr, Argb, Abgr, Rgb565)

### DIFF
--- a/src/api/encoder.rs
+++ b/src/api/encoder.rs
@@ -296,7 +296,27 @@ impl<'a> Encoder<'a> {
                     );
                 }
             }
+            PixelFormat::Rgbx
+            | PixelFormat::Xrgb
+            | PixelFormat::Argb
+            | PixelFormat::Bgrx
+            | PixelFormat::Xbgr
+            | PixelFormat::Abgr => {
+                let r_off: usize = pf.red_offset().unwrap();
+                let g_off: usize = pf.green_offset().unwrap();
+                let b_off: usize = pf.blue_offset().unwrap();
+                for c in pixels[..n * 4].chunks_exact(4) {
+                    y.push(
+                        ((19595 * c[r_off] as u32
+                            + 38470 * c[g_off] as u32
+                            + 7471 * c[b_off] as u32
+                            + 32768)
+                            >> 16) as u8,
+                    );
+                }
+            }
             PixelFormat::Cmyk => y.resize(n, 128),
+            PixelFormat::Rgb565 => y.resize(n, 128),
         }
         y
     }

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -94,14 +94,73 @@ pub enum PixelFormat {
     Bgra,
     /// Raw CMYK output (4 bytes per pixel: C, M, Y, K).
     Cmyk,
+    /// RGB + padding byte (4bpp, padding ignored).
+    Rgbx,
+    /// BGR + padding byte (4bpp, padding ignored).
+    Bgrx,
+    /// Padding + RGB (4bpp, padding byte first).
+    Xrgb,
+    /// Padding + BGR (4bpp, padding byte first).
+    Xbgr,
+    /// Alpha + RGB (4bpp, alpha byte first).
+    Argb,
+    /// Alpha + BGR (4bpp, alpha byte first).
+    Abgr,
+    /// 5-6-5 packed RGB (2bpp, decode output only).
+    Rgb565,
 }
 
 impl PixelFormat {
     pub fn bytes_per_pixel(self) -> usize {
         match self {
             Self::Grayscale => 1,
+            Self::Rgb565 => 2,
             Self::Rgb | Self::Bgr => 3,
-            Self::Rgba | Self::Bgra | Self::Cmyk => 4,
+            Self::Rgba
+            | Self::Bgra
+            | Self::Cmyk
+            | Self::Rgbx
+            | Self::Bgrx
+            | Self::Xrgb
+            | Self::Xbgr
+            | Self::Argb
+            | Self::Abgr => 4,
+        }
+    }
+
+    /// Channel byte offset for red within one pixel.
+    /// Returns `None` for Grayscale, Cmyk, and Rgb565.
+    pub fn red_offset(self) -> Option<usize> {
+        match self {
+            Self::Rgb | Self::Rgba | Self::Rgbx => Some(0),
+            Self::Bgr | Self::Bgra | Self::Bgrx => Some(2),
+            Self::Xrgb | Self::Argb => Some(1),
+            Self::Xbgr | Self::Abgr => Some(3),
+            _ => None,
+        }
+    }
+
+    /// Channel byte offset for green within one pixel.
+    /// Returns `None` for Grayscale, Cmyk, and Rgb565.
+    pub fn green_offset(self) -> Option<usize> {
+        match self {
+            Self::Rgb | Self::Rgba | Self::Rgbx => Some(1),
+            Self::Bgr | Self::Bgra | Self::Bgrx => Some(1),
+            Self::Xrgb | Self::Argb => Some(2),
+            Self::Xbgr | Self::Abgr => Some(2),
+            _ => None,
+        }
+    }
+
+    /// Channel byte offset for blue within one pixel.
+    /// Returns `None` for Grayscale, Cmyk, and Rgb565.
+    pub fn blue_offset(self) -> Option<usize> {
+        match self {
+            Self::Rgb | Self::Rgba | Self::Rgbx => Some(2),
+            Self::Bgr | Self::Bgra | Self::Bgrx => Some(0),
+            Self::Xrgb | Self::Argb => Some(3),
+            Self::Xbgr | Self::Abgr => Some(1),
+            _ => None,
         }
     }
 }

--- a/src/decode/color.rs
+++ b/src/decode/color.rs
@@ -58,6 +58,42 @@ pub fn ycbcr_to_bgra_row(y: &[u8], cb: &[u8], cr: &[u8], bgra: &mut [u8], width:
     }
 }
 
+/// Convert a row of YCbCr pixels to an output format using explicit channel offsets.
+///
+/// Places R, G, B at `r_off`, `g_off`, `b_off` within each `bpp`-byte pixel.
+/// The remaining byte (padding/alpha) is set to 255.
+pub fn ycbcr_to_generic_4bpp_row(
+    y: &[u8],
+    cb: &[u8],
+    cr: &[u8],
+    out: &mut [u8],
+    width: usize,
+    r_off: usize,
+    g_off: usize,
+    b_off: usize,
+    pad_off: usize,
+) {
+    for x in 0..width {
+        let (r, g, b) = ycbcr_to_rgb_pixel(y[x], cb[x], cr[x]);
+        let base: usize = x * 4;
+        out[base + r_off] = r;
+        out[base + g_off] = g;
+        out[base + b_off] = b;
+        out[base + pad_off] = 255;
+    }
+}
+
+/// Convert a row of YCbCr pixels to Rgb565 (5-6-5 packed, native endian).
+pub fn ycbcr_to_rgb565_row(y: &[u8], cb: &[u8], cr: &[u8], out: &mut [u8], width: usize) {
+    for x in 0..width {
+        let (r, g, b) = ycbcr_to_rgb_pixel(y[x], cb[x], cr[x]);
+        let packed: u16 = ((r as u16 >> 3) << 11) | ((g as u16 >> 2) << 5) | (b as u16 >> 3);
+        let bytes: [u8; 2] = packed.to_ne_bytes();
+        out[x * 2] = bytes[0];
+        out[x * 2 + 1] = bytes[1];
+    }
+}
+
 /// Copy grayscale values directly (no color conversion needed).
 pub fn grayscale_row(y: &[u8], output: &mut [u8], width: usize) {
     output[..width].copy_from_slice(&y[..width]);

--- a/src/decode/pipeline.rs
+++ b/src/decode/pipeline.rs
@@ -310,6 +310,25 @@ impl<'a> Decoder<'a> {
             PixelFormat::Rgba => self.ycbcr_to_rgba_row(y, cb, cr, out, width),
             PixelFormat::Bgr => self.ycbcr_to_bgr_row(y, cb, cr, out, width),
             PixelFormat::Bgra => self.ycbcr_to_bgra_row(y, cb, cr, out, width),
+            PixelFormat::Rgbx => {
+                crate::decode::color::ycbcr_to_generic_4bpp_row(y, cb, cr, out, width, 0, 1, 2, 3)
+            }
+            PixelFormat::Bgrx => {
+                crate::decode::color::ycbcr_to_generic_4bpp_row(y, cb, cr, out, width, 2, 1, 0, 3)
+            }
+            PixelFormat::Xrgb => {
+                crate::decode::color::ycbcr_to_generic_4bpp_row(y, cb, cr, out, width, 1, 2, 3, 0)
+            }
+            PixelFormat::Xbgr => {
+                crate::decode::color::ycbcr_to_generic_4bpp_row(y, cb, cr, out, width, 3, 2, 1, 0)
+            }
+            PixelFormat::Argb => {
+                crate::decode::color::ycbcr_to_generic_4bpp_row(y, cb, cr, out, width, 1, 2, 3, 0)
+            }
+            PixelFormat::Abgr => {
+                crate::decode::color::ycbcr_to_generic_4bpp_row(y, cb, cr, out, width, 3, 2, 1, 0)
+            }
+            PixelFormat::Rgb565 => crate::decode::color::ycbcr_to_rgb565_row(y, cb, cr, out, width),
             PixelFormat::Grayscale | PixelFormat::Cmyk => {
                 unreachable!("grayscale/cmyk handled separately")
             }
@@ -1567,11 +1586,30 @@ impl<'a> Decoder<'a> {
                         data.push(val);
                         data.push(val);
                     }
-                    PixelFormat::Rgba | PixelFormat::Bgra => {
+                    PixelFormat::Rgba
+                    | PixelFormat::Bgra
+                    | PixelFormat::Rgbx
+                    | PixelFormat::Bgrx
+                    | PixelFormat::Argb
+                    | PixelFormat::Abgr => {
                         data.push(val);
                         data.push(val);
                         data.push(val);
                         data.push(255);
+                    }
+                    PixelFormat::Xrgb | PixelFormat::Xbgr => {
+                        data.push(255);
+                        data.push(val);
+                        data.push(val);
+                        data.push(val);
+                    }
+                    PixelFormat::Rgb565 => {
+                        let packed: u16 = ((val as u16 >> 3) << 11)
+                            | ((val as u16 >> 2) << 5)
+                            | (val as u16 >> 3);
+                        let bytes: [u8; 2] = packed.to_ne_bytes();
+                        data.push(bytes[0]);
+                        data.push(bytes[1]);
                     }
                     _ => unreachable!(),
                 }
@@ -1627,17 +1665,36 @@ impl<'a> Decoder<'a> {
                     data.push(g);
                     data.push(r);
                 }
-                PixelFormat::Rgba => {
+                PixelFormat::Rgba | PixelFormat::Rgbx => {
                     data.push(r);
                     data.push(g);
                     data.push(b);
                     data.push(255);
                 }
-                PixelFormat::Bgra => {
+                PixelFormat::Bgra | PixelFormat::Bgrx => {
                     data.push(b);
                     data.push(g);
                     data.push(r);
                     data.push(255);
+                }
+                PixelFormat::Xrgb | PixelFormat::Argb => {
+                    data.push(255);
+                    data.push(r);
+                    data.push(g);
+                    data.push(b);
+                }
+                PixelFormat::Xbgr | PixelFormat::Abgr => {
+                    data.push(255);
+                    data.push(b);
+                    data.push(g);
+                    data.push(r);
+                }
+                PixelFormat::Rgb565 => {
+                    let packed: u16 =
+                        ((r as u16 >> 3) << 11) | ((g as u16 >> 2) << 5) | (b as u16 >> 3);
+                    let bytes: [u8; 2] = packed.to_ne_bytes();
+                    data.push(bytes[0]);
+                    data.push(bytes[1]);
                 }
                 _ => {
                     return Err(JpegError::Unsupported(
@@ -1817,27 +1874,36 @@ impl<'a> Decoder<'a> {
                     for x in 0..out_width {
                         let v = row[x];
                         match out_format {
-                            PixelFormat::Rgb => {
+                            PixelFormat::Rgb | PixelFormat::Bgr => {
                                 out_row[x * 3] = v;
                                 out_row[x * 3 + 1] = v;
                                 out_row[x * 3 + 2] = v;
                             }
-                            PixelFormat::Rgba => {
+                            PixelFormat::Rgba
+                            | PixelFormat::Bgra
+                            | PixelFormat::Rgbx
+                            | PixelFormat::Bgrx
+                            | PixelFormat::Argb
+                            | PixelFormat::Abgr => {
                                 out_row[x * 4] = v;
                                 out_row[x * 4 + 1] = v;
                                 out_row[x * 4 + 2] = v;
                                 out_row[x * 4 + 3] = 255;
                             }
-                            PixelFormat::Bgr => {
-                                out_row[x * 3] = v;
-                                out_row[x * 3 + 1] = v;
-                                out_row[x * 3 + 2] = v;
-                            }
-                            PixelFormat::Bgra => {
-                                out_row[x * 4] = v;
+                            PixelFormat::Xrgb | PixelFormat::Xbgr => {
+                                out_row[x * 4] = 255;
                                 out_row[x * 4 + 1] = v;
                                 out_row[x * 4 + 2] = v;
-                                out_row[x * 4 + 3] = 255;
+                                out_row[x * 4 + 3] = v;
+                            }
+                            PixelFormat::Rgb565 => {
+                                // Grayscale v → pack as R=G=B=v
+                                let packed: u16 = ((v as u16 >> 3) << 11)
+                                    | ((v as u16 >> 2) << 5)
+                                    | (v as u16 >> 3);
+                                let bytes: [u8; 2] = packed.to_ne_bytes();
+                                out_row[x * 2] = bytes[0];
+                                out_row[x * 2 + 1] = bytes[1];
                             }
                             PixelFormat::Grayscale | PixelFormat::Cmyk => unreachable!(),
                         }
@@ -2290,6 +2356,59 @@ impl<'a> Decoder<'a> {
                         out[x * 4 + 1] = g;
                         out[x * 4 + 2] = r;
                         out[x * 4 + 3] = 255;
+                    }
+                }
+                // CMYK → 4bpp offset-based formats
+                (
+                    ColorSpace::Cmyk,
+                    PixelFormat::Rgbx
+                    | PixelFormat::Bgrx
+                    | PixelFormat::Xrgb
+                    | PixelFormat::Xbgr
+                    | PixelFormat::Argb
+                    | PixelFormat::Abgr,
+                ) => {
+                    let r_off: usize = out_format.red_offset().unwrap();
+                    let g_off: usize = out_format.green_offset().unwrap();
+                    let b_off: usize = out_format.blue_offset().unwrap();
+                    // The remaining offset is 0+1+2+3=6 minus the other three
+                    let pad_off: usize = 6 - r_off - g_off - b_off;
+                    for x in 0..width {
+                        let ki = 255 - p3[x] as u16;
+                        let r = (((255 - p0[x] as u16) * ki + 127) / 255) as u8;
+                        let g = (((255 - p1[x] as u16) * ki + 127) / 255) as u8;
+                        let b = (((255 - p2[x] as u16) * ki + 127) / 255) as u8;
+                        out[x * 4 + r_off] = r;
+                        out[x * 4 + g_off] = g;
+                        out[x * 4 + b_off] = b;
+                        out[x * 4 + pad_off] = 255;
+                    }
+                }
+                // YCCK → 4bpp offset-based formats
+                (
+                    ColorSpace::Ycck,
+                    PixelFormat::Rgbx
+                    | PixelFormat::Bgrx
+                    | PixelFormat::Xrgb
+                    | PixelFormat::Xbgr
+                    | PixelFormat::Argb
+                    | PixelFormat::Abgr,
+                ) => {
+                    let r_off: usize = out_format.red_offset().unwrap();
+                    let g_off: usize = out_format.green_offset().unwrap();
+                    let b_off: usize = out_format.blue_offset().unwrap();
+                    let pad_off: usize = 6 - r_off - g_off - b_off;
+                    let mut cmyk_buf = vec![0u8; width * 4];
+                    color::ycck_to_cmyk_row(p0, p1, p2, p3, &mut cmyk_buf, width);
+                    for x in 0..width {
+                        let ki = 255 - cmyk_buf[x * 4 + 3] as u16;
+                        let r = (((255 - cmyk_buf[x * 4] as u16) * ki + 127) / 255) as u8;
+                        let g = (((255 - cmyk_buf[x * 4 + 1] as u16) * ki + 127) / 255) as u8;
+                        let b = (((255 - cmyk_buf[x * 4 + 2] as u16) * ki + 127) / 255) as u8;
+                        out[x * 4 + r_off] = r;
+                        out[x * 4 + g_off] = g;
+                        out[x * 4 + b_off] = b;
+                        out[x * 4 + pad_off] = 255;
                     }
                 }
                 _ => {

--- a/src/encode/color.rs
+++ b/src/encode/color.rs
@@ -74,6 +74,33 @@ pub fn rgba_to_ycbcr_row(rgba: &[u8], y: &mut [u8], cb: &mut [u8], cr: &mut [u8]
     }
 }
 
+/// Convert a row of pixels to Y, Cb, Cr planes using explicit channel offsets.
+///
+/// Supports any pixel format where R, G, B channels are at known byte offsets
+/// within each `bpp`-byte pixel (Rgbx, Bgrx, Xrgb, Xbgr, Argb, Abgr, etc.).
+pub fn generic_to_ycbcr_row(
+    pixels: &[u8],
+    y: &mut [u8],
+    cb: &mut [u8],
+    cr: &mut [u8],
+    width: usize,
+    bpp: usize,
+    r_off: usize,
+    g_off: usize,
+    b_off: usize,
+) {
+    for i in 0..width {
+        let base: usize = i * bpp;
+        let r = pixels[base + r_off] as i32;
+        let g = pixels[base + g_off] as i32;
+        let b = pixels[base + b_off] as i32;
+        let (y_val, cb_val, cr_val) = rgb_to_ycbcr(r, g, b);
+        y[i] = y_val;
+        cb[i] = cb_val;
+        cr[i] = cr_val;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -2928,9 +2928,39 @@ fn convert_to_ycbcr(
                 );
             }
         }
+        PixelFormat::Rgbx
+        | PixelFormat::Bgrx
+        | PixelFormat::Xrgb
+        | PixelFormat::Xbgr
+        | PixelFormat::Argb
+        | PixelFormat::Abgr => {
+            let r_off: usize = pixel_format.red_offset().unwrap();
+            let g_off: usize = pixel_format.green_offset().unwrap();
+            let b_off: usize = pixel_format.blue_offset().unwrap();
+            for row in 0..height {
+                let src_offset: usize = row * width * bpp;
+                let dst_offset: usize = row * width;
+                color::generic_to_ycbcr_row(
+                    &pixels[src_offset..src_offset + width * bpp],
+                    &mut y_plane[dst_offset..dst_offset + width],
+                    &mut cb_plane[dst_offset..dst_offset + width],
+                    &mut cr_plane[dst_offset..dst_offset + width],
+                    width,
+                    bpp,
+                    r_off,
+                    g_off,
+                    b_off,
+                );
+            }
+        }
         PixelFormat::Cmyk => {
             return Err(JpegError::Unsupported(
                 "CMYK pixel format not supported for encoding".to_string(),
+            ));
+        }
+        PixelFormat::Rgb565 => {
+            return Err(JpegError::Unsupported(
+                "Rgb565 pixel format is decode-only and not supported for encoding".to_string(),
             ));
         }
     }

--- a/tests/pixel_formats.rs
+++ b/tests/pixel_formats.rs
@@ -1,0 +1,356 @@
+use libjpeg_turbo_rs::{decompress, decompress_to, Encoder, PixelFormat};
+
+#[test]
+fn pixel_format_bytes_per_pixel() {
+    assert_eq!(PixelFormat::Rgbx.bytes_per_pixel(), 4);
+    assert_eq!(PixelFormat::Bgrx.bytes_per_pixel(), 4);
+    assert_eq!(PixelFormat::Xrgb.bytes_per_pixel(), 4);
+    assert_eq!(PixelFormat::Xbgr.bytes_per_pixel(), 4);
+    assert_eq!(PixelFormat::Argb.bytes_per_pixel(), 4);
+    assert_eq!(PixelFormat::Abgr.bytes_per_pixel(), 4);
+    assert_eq!(PixelFormat::Rgb565.bytes_per_pixel(), 2);
+}
+
+#[test]
+fn pixel_format_channel_offsets() {
+    // Rgbx: R=0, G=1, B=2
+    assert_eq!(PixelFormat::Rgbx.red_offset(), Some(0));
+    assert_eq!(PixelFormat::Rgbx.green_offset(), Some(1));
+    assert_eq!(PixelFormat::Rgbx.blue_offset(), Some(2));
+
+    // Bgrx: R=2, G=1, B=0
+    assert_eq!(PixelFormat::Bgrx.red_offset(), Some(2));
+    assert_eq!(PixelFormat::Bgrx.green_offset(), Some(1));
+    assert_eq!(PixelFormat::Bgrx.blue_offset(), Some(0));
+
+    // Xrgb: R=1, G=2, B=3
+    assert_eq!(PixelFormat::Xrgb.red_offset(), Some(1));
+    assert_eq!(PixelFormat::Xrgb.green_offset(), Some(2));
+    assert_eq!(PixelFormat::Xrgb.blue_offset(), Some(3));
+
+    // Xbgr: R=3, G=2, B=1
+    assert_eq!(PixelFormat::Xbgr.red_offset(), Some(3));
+    assert_eq!(PixelFormat::Xbgr.green_offset(), Some(2));
+    assert_eq!(PixelFormat::Xbgr.blue_offset(), Some(1));
+
+    // Argb: R=1, G=2, B=3
+    assert_eq!(PixelFormat::Argb.red_offset(), Some(1));
+    assert_eq!(PixelFormat::Argb.green_offset(), Some(2));
+    assert_eq!(PixelFormat::Argb.blue_offset(), Some(3));
+
+    // Abgr: R=3, G=2, B=1
+    assert_eq!(PixelFormat::Abgr.red_offset(), Some(3));
+    assert_eq!(PixelFormat::Abgr.green_offset(), Some(2));
+    assert_eq!(PixelFormat::Abgr.blue_offset(), Some(1));
+
+    // Grayscale, Cmyk, Rgb565 have no channel offsets
+    assert_eq!(PixelFormat::Grayscale.red_offset(), None);
+    assert_eq!(PixelFormat::Cmyk.red_offset(), None);
+    assert_eq!(PixelFormat::Rgb565.red_offset(), None);
+}
+
+#[test]
+fn encode_rgbx_roundtrip() {
+    let mut pixels = vec![0u8; 16 * 16 * 4];
+    for i in 0..16 * 16 {
+        pixels[i * 4] = 128;
+        pixels[i * 4 + 1] = 64;
+        pixels[i * 4 + 2] = 32;
+        pixels[i * 4 + 3] = 0; // padding
+    }
+    let jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Rgbx)
+        .quality(90)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 16);
+    assert_eq!(img.height, 16);
+}
+
+#[test]
+fn encode_bgrx_roundtrip() {
+    let mut pixels = vec![0u8; 8 * 8 * 4];
+    for i in 0..64 {
+        pixels[i * 4] = 32; // B
+        pixels[i * 4 + 1] = 64; // G
+        pixels[i * 4 + 2] = 128; // R
+        pixels[i * 4 + 3] = 0; // padding
+    }
+    let jpeg = Encoder::new(&pixels, 8, 8, PixelFormat::Bgrx)
+        .quality(90)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 8);
+}
+
+#[test]
+fn encode_xrgb_roundtrip() {
+    let mut pixels = vec![0u8; 8 * 8 * 4];
+    for i in 0..64 {
+        pixels[i * 4] = 0; // padding
+        pixels[i * 4 + 1] = 128; // R
+        pixels[i * 4 + 2] = 64; // G
+        pixels[i * 4 + 3] = 32; // B
+    }
+    let jpeg = Encoder::new(&pixels, 8, 8, PixelFormat::Xrgb)
+        .quality(90)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 8);
+}
+
+#[test]
+fn encode_xbgr_roundtrip() {
+    let mut pixels = vec![0u8; 8 * 8 * 4];
+    for i in 0..64 {
+        pixels[i * 4] = 0; // padding
+        pixels[i * 4 + 1] = 32; // B
+        pixels[i * 4 + 2] = 64; // G
+        pixels[i * 4 + 3] = 128; // R
+    }
+    let jpeg = Encoder::new(&pixels, 8, 8, PixelFormat::Xbgr)
+        .quality(90)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 8);
+}
+
+#[test]
+fn encode_argb_roundtrip() {
+    let pixels = vec![128u8; 16 * 16 * 4];
+    let jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Argb)
+        .quality(90)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 16);
+}
+
+#[test]
+fn encode_abgr_roundtrip() {
+    let pixels = vec![128u8; 16 * 16 * 4];
+    let jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Abgr)
+        .quality(90)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 16);
+}
+
+#[test]
+fn encode_rgb565_rejected() {
+    let pixels = vec![0u8; 8 * 8 * 2];
+    let result = Encoder::new(&pixels, 8, 8, PixelFormat::Rgb565)
+        .quality(90)
+        .encode();
+    assert!(result.is_err(), "Rgb565 encoding should fail");
+}
+
+#[test]
+fn decode_to_rgbx() {
+    let pixels = vec![128u8; 8 * 8 * 3];
+    let jpeg = Encoder::new(&pixels, 8, 8, PixelFormat::Rgb)
+        .quality(90)
+        .encode()
+        .unwrap();
+    let img = decompress_to(&jpeg, PixelFormat::Rgbx).unwrap();
+    assert_eq!(img.pixel_format, PixelFormat::Rgbx);
+    assert_eq!(img.data.len(), 8 * 8 * 4);
+    // The 4th byte (padding) in each pixel should be 255
+    for i in 0..64 {
+        assert_eq!(img.data[i * 4 + 3], 255);
+    }
+}
+
+#[test]
+fn decode_to_bgrx() {
+    let pixels = vec![128u8; 8 * 8 * 3];
+    let jpeg = Encoder::new(&pixels, 8, 8, PixelFormat::Rgb)
+        .quality(90)
+        .encode()
+        .unwrap();
+    let img = decompress_to(&jpeg, PixelFormat::Bgrx).unwrap();
+    assert_eq!(img.pixel_format, PixelFormat::Bgrx);
+    assert_eq!(img.data.len(), 8 * 8 * 4);
+    // The 4th byte (padding) in each pixel should be 255
+    for i in 0..64 {
+        assert_eq!(img.data[i * 4 + 3], 255);
+    }
+}
+
+#[test]
+fn decode_to_xrgb() {
+    let pixels = vec![128u8; 8 * 8 * 3];
+    let jpeg = Encoder::new(&pixels, 8, 8, PixelFormat::Rgb)
+        .quality(90)
+        .encode()
+        .unwrap();
+    let img = decompress_to(&jpeg, PixelFormat::Xrgb).unwrap();
+    assert_eq!(img.pixel_format, PixelFormat::Xrgb);
+    assert_eq!(img.data.len(), 8 * 8 * 4);
+    // The 1st byte (padding) in each pixel should be 255
+    for i in 0..64 {
+        assert_eq!(img.data[i * 4], 255);
+    }
+}
+
+#[test]
+fn decode_to_xbgr() {
+    let pixels = vec![128u8; 8 * 8 * 3];
+    let jpeg = Encoder::new(&pixels, 8, 8, PixelFormat::Rgb)
+        .quality(90)
+        .encode()
+        .unwrap();
+    let img = decompress_to(&jpeg, PixelFormat::Xbgr).unwrap();
+    assert_eq!(img.pixel_format, PixelFormat::Xbgr);
+    assert_eq!(img.data.len(), 8 * 8 * 4);
+    // The 1st byte (padding) in each pixel should be 255
+    for i in 0..64 {
+        assert_eq!(img.data[i * 4], 255);
+    }
+}
+
+#[test]
+fn decode_to_argb() {
+    let pixels = vec![128u8; 8 * 8 * 3];
+    let jpeg = Encoder::new(&pixels, 8, 8, PixelFormat::Rgb)
+        .quality(90)
+        .encode()
+        .unwrap();
+    let img = decompress_to(&jpeg, PixelFormat::Argb).unwrap();
+    assert_eq!(img.pixel_format, PixelFormat::Argb);
+    assert_eq!(img.data.len(), 8 * 8 * 4);
+    // The 1st byte (alpha) in each pixel should be 255
+    for i in 0..64 {
+        assert_eq!(img.data[i * 4], 255);
+    }
+}
+
+#[test]
+fn decode_to_abgr() {
+    let pixels = vec![128u8; 8 * 8 * 3];
+    let jpeg = Encoder::new(&pixels, 8, 8, PixelFormat::Rgb)
+        .quality(90)
+        .encode()
+        .unwrap();
+    let img = decompress_to(&jpeg, PixelFormat::Abgr).unwrap();
+    assert_eq!(img.pixel_format, PixelFormat::Abgr);
+    assert_eq!(img.data.len(), 8 * 8 * 4);
+    // The 1st byte (alpha) in each pixel should be 255
+    for i in 0..64 {
+        assert_eq!(img.data[i * 4], 255);
+    }
+}
+
+#[test]
+fn decode_to_rgb565() {
+    let pixels = vec![128u8; 8 * 8 * 3];
+    let jpeg = Encoder::new(&pixels, 8, 8, PixelFormat::Rgb)
+        .quality(90)
+        .encode()
+        .unwrap();
+    let img = decompress_to(&jpeg, PixelFormat::Rgb565).unwrap();
+    assert_eq!(img.pixel_format, PixelFormat::Rgb565);
+    assert_eq!(img.data.len(), 8 * 8 * 2);
+}
+
+/// Verify that encoding with Rgbx and decoding back to Rgbx preserves pixel data
+/// within JPEG compression tolerance.
+#[test]
+fn rgbx_encode_decode_color_accuracy() {
+    let size: usize = 16;
+    let mut pixels = vec![0u8; size * size * 4];
+    for i in 0..size * size {
+        pixels[i * 4] = 200; // R
+        pixels[i * 4 + 1] = 100; // G
+        pixels[i * 4 + 2] = 50; // B
+        pixels[i * 4 + 3] = 0; // padding
+    }
+    let jpeg = Encoder::new(&pixels, size, size, PixelFormat::Rgbx)
+        .quality(100)
+        .encode()
+        .unwrap();
+    let img = decompress_to(&jpeg, PixelFormat::Rgbx).unwrap();
+    assert_eq!(img.data.len(), size * size * 4);
+    // Check color accuracy within JPEG tolerance (lossy compression)
+    for i in 0..size * size {
+        let r = img.data[i * 4] as i16;
+        let g = img.data[i * 4 + 1] as i16;
+        let b = img.data[i * 4 + 2] as i16;
+        assert!((r - 200).abs() < 5, "R channel deviation too large: {r}");
+        assert!((g - 100).abs() < 5, "G channel deviation too large: {g}");
+        assert!((b - 50).abs() < 5, "B channel deviation too large: {b}");
+        assert_eq!(img.data[i * 4 + 3], 255, "padding should be 255");
+    }
+}
+
+/// Verify that Argb encode preserves the correct channel ordering through roundtrip.
+#[test]
+fn argb_channel_ordering_roundtrip() {
+    let size: usize = 8;
+    let mut pixels = vec![0u8; size * size * 4];
+    for i in 0..size * size {
+        pixels[i * 4] = 255; // A (alpha)
+        pixels[i * 4 + 1] = 200; // R
+        pixels[i * 4 + 2] = 100; // G
+        pixels[i * 4 + 3] = 50; // B
+    }
+    let jpeg = Encoder::new(&pixels, size, size, PixelFormat::Argb)
+        .quality(100)
+        .encode()
+        .unwrap();
+    let img = decompress_to(&jpeg, PixelFormat::Argb).unwrap();
+    for i in 0..size * size {
+        let a = img.data[i * 4];
+        let r = img.data[i * 4 + 1] as i16;
+        let g = img.data[i * 4 + 2] as i16;
+        let b = img.data[i * 4 + 3] as i16;
+        assert_eq!(a, 255, "alpha should be 255");
+        assert!((r - 200).abs() < 5, "R channel deviation too large: {r}");
+        assert!((g - 100).abs() < 5, "G channel deviation too large: {g}");
+        assert!((b - 50).abs() < 5, "B channel deviation too large: {b}");
+    }
+}
+
+/// Verify grayscale_from_color works with new formats.
+#[test]
+fn grayscale_from_rgbx() {
+    let mut pixels = vec![0u8; 8 * 8 * 4];
+    for i in 0..64 {
+        pixels[i * 4] = 128; // R
+        pixels[i * 4 + 1] = 128; // G
+        pixels[i * 4 + 2] = 128; // B
+        pixels[i * 4 + 3] = 0; // padding
+    }
+    let jpeg = Encoder::new(&pixels, 8, 8, PixelFormat::Rgbx)
+        .quality(90)
+        .grayscale_from_color(true)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.pixel_format, PixelFormat::Grayscale);
+    assert_eq!(img.width, 8);
+}
+
+/// Verify grayscale_from_color works with Argb.
+#[test]
+fn grayscale_from_argb() {
+    let mut pixels = vec![0u8; 8 * 8 * 4];
+    for i in 0..64 {
+        pixels[i * 4] = 255; // A
+        pixels[i * 4 + 1] = 128; // R
+        pixels[i * 4 + 2] = 128; // G
+        pixels[i * 4 + 3] = 128; // B
+    }
+    let jpeg = Encoder::new(&pixels, 8, 8, PixelFormat::Argb)
+        .quality(90)
+        .grayscale_from_color(true)
+        .encode()
+        .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.pixel_format, PixelFormat::Grayscale);
+    assert_eq!(img.width, 8);
+}


### PR DESCRIPTION
## Summary
- 7 new PixelFormat variants with encode and decode support
- Generic offset-based YCbCr conversion for all 4bpp formats
- Rgb565 decode-only (5-6-5 packed output)
- Channel offset helpers: `red_offset()`, `green_offset()`, `blue_offset()`

## Test plan
- [x] Encode roundtrips for all 6 encodable formats
- [x] Decode-to tests for all 7 formats
- [x] Rgb565 encode rejection
- [x] Color accuracy verification
- [x] grayscale_from_color integration (20 tests total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)