### PR TITLE
feat: add S441 (4:4:1) subsampling encode and decode

### DIFF
--- a/src/api/encoder.rs
+++ b/src/api/encoder.rs
@@ -237,7 +237,7 @@ impl<'a> Encoder<'a> {
                     8
                 } else {
                     match self.subsampling {
-                        Subsampling::S444 | Subsampling::S440 => 8,
+                        Subsampling::S444 | Subsampling::S440 | Subsampling::S441 => 8,
                         Subsampling::S422 | Subsampling::S420 => 16,
                         Subsampling::S411 => 32,
                     }

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -31,13 +31,15 @@ pub enum Subsampling {
     S440,
     /// 4:1:1 — horizontal 4x, vertical 1x
     S411,
+    /// 4:4:1 — horizontal 1x, vertical 4x
+    S441,
 }
 
 impl Subsampling {
     /// Max horizontal sampling factor (luma blocks per MCU row).
     pub fn mcu_width_blocks(self) -> usize {
         match self {
-            Self::S444 | Self::S440 => 1,
+            Self::S444 | Self::S440 | Self::S441 => 1,
             Self::S422 | Self::S420 => 2,
             Self::S411 => 4,
         }
@@ -48,6 +50,7 @@ impl Subsampling {
         match self {
             Self::S444 | Self::S422 | Self::S411 => 1,
             Self::S420 | Self::S440 => 2,
+            Self::S441 => 4,
         }
     }
 
@@ -59,6 +62,7 @@ impl Subsampling {
             Self::S420 => (2, 2),
             Self::S440 => (1, 2),
             Self::S411 => (4, 1),
+            Self::S441 => (1, 4),
         }
     }
 }

--- a/src/decode/pipeline.rs
+++ b/src/decode/pipeline.rs
@@ -440,6 +440,49 @@ impl<'a> Decoder<'a> {
         }
     }
 
+    /// Fancy h1v4 upsample: vertical-only 4x (for S441).
+    /// Each input row produces four output rows using triangle filter vertically.
+    /// Horizontal samples are copied 1:1.
+    fn fancy_h1v4(
+        &self,
+        input: &[u8],
+        in_width: usize,
+        in_height: usize,
+        output: &mut [u8],
+        out_width: usize,
+    ) {
+        for y in 0..in_height {
+            let cur_row = &input[y * in_width..(y + 1) * in_width];
+            let above = if y > 0 {
+                &input[(y - 1) * in_width..y * in_width]
+            } else {
+                cur_row
+            };
+            let below = if y + 1 < in_height {
+                &input[(y + 1) * in_width..(y + 2) * in_width]
+            } else {
+                cur_row
+            };
+
+            // 4 output rows per input row, mirroring h4v1 interpolation positions
+            // Positions: -3/8, -1/8, +1/8, +3/8 relative to center
+            let out_row_0 = y * 4;
+            let out_row_1 = y * 4 + 1;
+            let out_row_2 = y * 4 + 2;
+            let out_row_3 = y * 4 + 3;
+
+            for i in 0..in_width {
+                let a = above[i] as u16;
+                let c = cur_row[i] as u16;
+                let b = below[i] as u16;
+                output[out_row_0 * out_width + i] = ((a * 3 + c * 5 + 4) >> 3) as u8;
+                output[out_row_1 * out_width + i] = ((a + c * 7 + 4) >> 3) as u8;
+                output[out_row_2 * out_width + i] = ((c * 7 + b + 4) >> 3) as u8;
+                output[out_row_3 * out_width + i] = ((c * 5 + b * 3 + 4) >> 3) as u8;
+            }
+        }
+    }
+
     /// Fancy h4v1 upsample: horizontal-only 4x (for S411).
     /// Each input sample produces 4 output samples using triangle filter horizontally.
     fn fancy_upsample_h4v1(input: &[u8], in_width: usize, output: &mut [u8]) {
@@ -1997,6 +2040,10 @@ impl<'a> Decoder<'a> {
                             &mut cr_full[row * full_width..],
                         );
                     }
+                } else if h_factor == 1 && v_factor == 4 {
+                    // S441: vertical-only 4x upsampling
+                    self.fancy_h1v4(&component_planes[1], cb_w, cb_h, &mut cb_full, full_width);
+                    self.fancy_h1v4(&component_planes[2], cb_w, cb_h, &mut cr_full, full_width);
                 } else {
                     return Err(JpegError::Unsupported(format!(
                         "subsampling {}x{} not yet supported",

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -89,6 +89,7 @@ pub fn compress(
             Subsampling::S420 => (16, 16),
             Subsampling::S440 => (8, 16),
             Subsampling::S411 => (32, 8),
+            Subsampling::S441 => (8, 32),
         }
     };
 
@@ -333,6 +334,7 @@ pub fn compress_custom_huffman(
             Subsampling::S420 => (16, 16),
             Subsampling::S440 => (8, 16),
             Subsampling::S411 => (32, 8),
+            Subsampling::S441 => (8, 32),
         }
     };
 
@@ -522,6 +524,7 @@ pub fn compress_custom_quant(
             Subsampling::S420 => (16, 16),
             Subsampling::S440 => (8, 16),
             Subsampling::S411 => (32, 8),
+            Subsampling::S441 => (8, 32),
         }
     };
 
@@ -726,6 +729,7 @@ pub fn compress_with_restart(
             Subsampling::S420 => (16, 16),
             Subsampling::S440 => (8, 16),
             Subsampling::S411 => (32, 8),
+            Subsampling::S441 => (8, 32),
         }
     };
 
@@ -1696,6 +1700,7 @@ fn compress_progressive_with_scans(
             Subsampling::S420 => (16, 16),
             Subsampling::S440 => (8, 16),
             Subsampling::S411 => (32, 8),
+            Subsampling::S441 => (8, 32),
         }
     };
 
@@ -2008,6 +2013,7 @@ pub fn compress_arithmetic(
             Subsampling::S420 => (16, 16),
             Subsampling::S440 => (8, 16),
             Subsampling::S411 => (32, 8),
+            Subsampling::S441 => (8, 32),
         }
     };
 
@@ -2129,6 +2135,27 @@ pub fn compress_arithmetic(
                             all_blocks.push(q);
                         }
                     }
+                    Subsampling::S441 => {
+                        // 4 Y blocks vertically
+                        for dy in [0, 8, 16, 24] {
+                            let mut block = [0i16; 64];
+                            extract_block(&y_plane, width, height, x0, y0 + dy, &mut block);
+                            let mut dct = [0i32; 64];
+                            fdct::fdct_islow(&block, &mut dct);
+                            let mut q = [0i16; 64];
+                            quant::quantize_block(&dct, &luma_divisors, &mut q);
+                            all_blocks.push(q);
+                        }
+                        for plane in [&cb_plane, &cr_plane] {
+                            let mut block = [0i16; 64];
+                            downsample_chroma_block(plane, width, height, x0, y0, 1, 4, &mut block);
+                            let mut dct = [0i32; 64];
+                            fdct::fdct_islow(&block, &mut dct);
+                            let mut q = [0i16; 64];
+                            quant::quantize_block(&dct, &chroma_divisors, &mut q);
+                            all_blocks.push(q);
+                        }
+                    }
                 }
             }
         }
@@ -2150,7 +2177,7 @@ pub fn compress_arithmetic(
                     Subsampling::S422 => 2,
                     Subsampling::S420 => 4,
                     Subsampling::S440 => 2,
-                    Subsampling::S411 => 4,
+                    Subsampling::S411 | Subsampling::S441 => 4,
                 };
                 for _ in 0..y_blocks {
                     arith_enc.encode_dc_sequential(&all_blocks[block_idx], 0, 0);
@@ -2269,6 +2296,7 @@ pub fn compress_arithmetic_progressive(
             Subsampling::S420 => (16, 16),
             Subsampling::S440 => (8, 16),
             Subsampling::S411 => (32, 8),
+            Subsampling::S441 => (8, 32),
         }
     };
 
@@ -3375,6 +3403,55 @@ fn encode_color_mcu(
                 fdct_fn,
             );
         }
+        Subsampling::S441 => {
+            // 4 Y blocks vertically
+            for i in 0..4 {
+                encode_single_block(
+                    y_plane,
+                    width,
+                    height,
+                    x0,
+                    y0 + i * 8,
+                    luma_quant,
+                    dc_luma_table,
+                    ac_luma_table,
+                    writer,
+                    prev_dc_y,
+                    fdct_fn,
+                );
+            }
+            // Cb/Cr downsampled 1x4
+            encode_downsampled_chroma_block(
+                cb_plane,
+                width,
+                height,
+                x0,
+                y0,
+                1,
+                4,
+                chroma_quant,
+                dc_chroma_table,
+                ac_chroma_table,
+                writer,
+                prev_dc_cb,
+                fdct_fn,
+            );
+            encode_downsampled_chroma_block(
+                cr_plane,
+                width,
+                height,
+                x0,
+                y0,
+                1,
+                4,
+                chroma_quant,
+                dc_chroma_table,
+                ac_chroma_table,
+                writer,
+                prev_dc_cr,
+                fdct_fn,
+            );
+        }
     }
 }
 
@@ -3467,6 +3544,7 @@ pub fn compress_optimized(
             Subsampling::S420 => (16, 16),
             Subsampling::S440 => (8, 16),
             Subsampling::S411 => (32, 8),
+            Subsampling::S441 => (8, 32),
         }
     };
 
@@ -3704,6 +3782,49 @@ pub fn compress_optimized(
                         huff_opt::gather_ac_symbols(&crq, &mut ac_chroma_freq);
                         all_blocks.push(crq);
                     }
+                    Subsampling::S441 => {
+                        // 4 Y blocks vertically
+                        for dy in [0usize, 8, 16, 24] {
+                            let yq =
+                                gather_block(&y_plane, width, height, x0, y0 + dy, &luma_divisors);
+                            let diff = yq[0] - prev_dc_y;
+                            prev_dc_y = yq[0];
+                            huff_opt::gather_dc_symbol(diff, &mut dc_luma_freq);
+                            huff_opt::gather_ac_symbols(&yq, &mut ac_luma_freq);
+                            all_blocks.push(yq);
+                        }
+                        let cbq = gather_downsampled_block(
+                            &cb_plane,
+                            width,
+                            height,
+                            x0,
+                            y0,
+                            1,
+                            4,
+                            &chroma_divisors,
+                        );
+                        let diff = cbq[0] - prev_dc_cb;
+                        prev_dc_cb = cbq[0];
+                        huff_opt::gather_dc_symbol(diff, &mut dc_chroma_freq);
+                        huff_opt::gather_ac_symbols(&cbq, &mut ac_chroma_freq);
+                        all_blocks.push(cbq);
+
+                        let crq = gather_downsampled_block(
+                            &cr_plane,
+                            width,
+                            height,
+                            x0,
+                            y0,
+                            1,
+                            4,
+                            &chroma_divisors,
+                        );
+                        let diff = crq[0] - prev_dc_cr;
+                        prev_dc_cr = crq[0];
+                        huff_opt::gather_dc_symbol(diff, &mut dc_chroma_freq);
+                        huff_opt::gather_ac_symbols(&crq, &mut ac_chroma_freq);
+                        all_blocks.push(crq);
+                    }
                 }
             }
         }
@@ -3857,7 +3978,7 @@ pub fn compress_optimized(
                         );
                         block_idx += 1;
                     }
-                    Subsampling::S411 => {
+                    Subsampling::S411 | Subsampling::S441 => {
                         for _ in 0..4 {
                             HuffmanEncoder::encode_block(
                                 &mut bit_writer,

--- a/tests/s441_encode.rs
+++ b/tests/s441_encode.rs
@@ -1,0 +1,58 @@
+use libjpeg_turbo_rs::{compress, decompress, PixelFormat, Subsampling};
+
+#[test]
+fn encode_s441_roundtrip() {
+    let pixels = vec![128u8; 32 * 32 * 3];
+    let jpeg = compress(&pixels, 32, 32, PixelFormat::Rgb, 75, Subsampling::S441).unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 32);
+    assert_eq!(img.height, 32);
+}
+
+#[test]
+fn encode_s441_gradient() {
+    let (w, h) = (16, 32);
+    let mut pixels = vec![0u8; w * h * 3];
+    for y in 0..h {
+        for x in 0..w {
+            let i = (y * w + x) * 3;
+            pixels[i] = (x * 16) as u8;
+            pixels[i + 1] = (y * 8) as u8;
+            pixels[i + 2] = 128;
+        }
+    }
+    let jpeg = compress(&pixels, w, h, PixelFormat::Rgb, 95, Subsampling::S441).unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.data.len(), w * h * 3);
+}
+
+#[test]
+fn encode_s441_non_mcu_aligned() {
+    // Image height not a multiple of 32 (MCU height for S441)
+    let (w, h) = (8, 20);
+    let pixels = vec![100u8; w * h * 3];
+    let jpeg = compress(&pixels, w, h, PixelFormat::Rgb, 80, Subsampling::S441).unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, w);
+    assert_eq!(img.height, h);
+}
+
+#[test]
+fn encode_s441_large_image() {
+    // Larger image to exercise multi-MCU rows
+    let (w, h) = (24, 64);
+    let mut pixels = vec![0u8; w * h * 3];
+    for y in 0..h {
+        for x in 0..w {
+            let i = (y * w + x) * 3;
+            pixels[i] = ((x * 10) % 256) as u8;
+            pixels[i + 1] = ((y * 4) % 256) as u8;
+            pixels[i + 2] = 200;
+        }
+    }
+    let jpeg = compress(&pixels, w, h, PixelFormat::Rgb, 90, Subsampling::S441).unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, w);
+    assert_eq!(img.height, h);
+    assert_eq!(img.data.len(), w * h * 3);
+}


### PR DESCRIPTION
## Summary
- S441 variant: MCU (8,32), 4 Y blocks vertically, chroma 1x4 downsample
- All encode paths (baseline, progressive, arithmetic, optimized) updated
- h1v4 triangle filter upsampling in decoder

## Test plan
- [x] Solid color roundtrip
- [x] Gradient pattern roundtrip
- [x] Non-MCU-aligned height
- [x] Multi-MCU-row image

🤖 Generated with [Claude Code](https://claude.com/claude-code)