### PR TITLE
feat: implement raw data encode/decode

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod coefficient;
 pub mod encoder;
 pub mod high_level;
+pub mod raw_data;
 pub mod scanline;
 pub mod streaming;

--- a/src/api/raw_data.rs
+++ b/src/api/raw_data.rs
@@ -1,0 +1,87 @@
+/// Raw data encode/decode API.
+///
+/// Provides functions to encode JPEG from pre-downsampled component planes
+/// and decode JPEG to raw component planes, bypassing color conversion
+/// and chroma upsampling/downsampling. This matches libjpeg-turbo's
+/// `jpeg_write_raw_data()` / `jpeg_read_raw_data()` functionality.
+use crate::common::error::Result;
+use crate::common::types::Subsampling;
+use crate::decode::pipeline::Decoder;
+use crate::encode::pipeline as encoder;
+
+/// Decoded raw component plane data.
+///
+/// Contains separate planes for each component at their native
+/// (potentially subsampled) resolution. For a 4:2:0 YCbCr JPEG,
+/// the Y plane is at full resolution while Cb and Cr are at half
+/// resolution in each dimension.
+#[derive(Debug, Clone)]
+pub struct RawImage {
+    /// Component plane data. planes[0] is Y (or the single grayscale component),
+    /// planes[1] is Cb, planes[2] is Cr.
+    pub planes: Vec<Vec<u8>>,
+    /// Width of each plane in samples (MCU-aligned).
+    pub plane_widths: Vec<usize>,
+    /// Height of each plane in rows (MCU-aligned).
+    pub plane_heights: Vec<usize>,
+    /// Original image width in pixels.
+    pub width: usize,
+    /// Original image height in pixels.
+    pub height: usize,
+    /// Number of color components (1 for grayscale, 3 for YCbCr).
+    pub num_components: usize,
+}
+
+/// Encode JPEG from raw downsampled component data.
+///
+/// Each plane is a separate component at its native (subsampled) resolution.
+/// This bypasses color conversion and downsampling — the caller provides
+/// data already in the YCbCr color space at the correct subsampled dimensions.
+///
+/// # Arguments
+/// * `planes` - Component plane data (Y, Cb, Cr for color; just Y for grayscale)
+/// * `plane_widths` - Width of each plane in samples
+/// * `plane_heights` - Height of each plane in rows
+/// * `image_width` - Full image width in pixels
+/// * `image_height` - Full image height in pixels
+/// * `quality` - JPEG quality factor (1-100)
+/// * `subsampling` - Chroma subsampling mode
+///
+/// # Errors
+/// Returns error if plane counts or dimensions are inconsistent with the
+/// subsampling mode, or if plane data is too small for the declared dimensions.
+pub fn compress_raw(
+    planes: &[&[u8]],
+    plane_widths: &[usize],
+    plane_heights: &[usize],
+    image_width: usize,
+    image_height: usize,
+    quality: u8,
+    subsampling: Subsampling,
+) -> Result<Vec<u8>> {
+    encoder::compress_raw(
+        planes,
+        plane_widths,
+        plane_heights,
+        image_width,
+        image_height,
+        quality,
+        subsampling,
+    )
+}
+
+/// Decompress JPEG to raw downsampled component planes.
+///
+/// Returns separate planes for each component at their native resolution.
+/// For subsampled JPEGs, chroma planes will be smaller than the luma plane.
+/// No color conversion or upsampling is performed.
+///
+/// # Arguments
+/// * `data` - Complete JPEG file data
+///
+/// # Returns
+/// A `RawImage` containing the decoded component planes and their dimensions.
+pub fn decompress_raw(data: &[u8]) -> Result<RawImage> {
+    let decoder = Decoder::new(data)?;
+    decoder.decode_raw()
+}

--- a/src/decode/pipeline.rs
+++ b/src/decode/pipeline.rs
@@ -70,6 +70,13 @@ impl Image {
             .as_ref()
             .and_then(|d| crate::common::exif::parse_orientation(d))
     }
+
+    /// Returns all saved markers (APP and COM) collected during decoding.
+    ///
+    /// Only populated when the decoder was configured with `save_markers()`.
+    pub fn markers(&self) -> &[SavedMarker] {
+        &self.saved_markers
+    }
 }
 
 /// JPEG decoder. Orchestrates the full decoding pipeline.
@@ -169,6 +176,21 @@ impl<'a> Decoder<'a> {
     /// Set maximum number of progressive scans before error.
     pub fn set_scan_limit(&mut self, limit: u32) {
         self.scan_limit = Some(limit);
+    }
+
+    /// Configure which markers to save during decoding.
+    ///
+    /// By default, the decoder only parses known markers (JFIF, ICC, EXIF, Adobe, COM)
+    /// and discards unknown APP markers. Call this to preserve arbitrary APP/COM markers
+    /// in the decoded `Image.saved_markers` field.
+    ///
+    /// This re-parses the JPEG header with the new configuration.
+    pub fn save_markers(&mut self, config: MarkerSaveConfig) {
+        let mut reader: MarkerReader<'_> = MarkerReader::new(self.raw_data);
+        reader.set_marker_save_config(config);
+        if let Ok(metadata) = reader.read_markers() {
+            self.metadata = metadata;
+        }
     }
 
     pub fn decode(data: &'a [u8]) -> Result<Image> {
@@ -1612,7 +1634,7 @@ impl<'a> Decoder<'a> {
                 exif_data,
                 comment: self.metadata.comment.clone(),
                 density: self.metadata.density,
-                saved_markers: Vec::new(),
+                saved_markers: self.metadata.saved_markers.clone(),
                 warnings: Vec::new(),
             })
         } else {
@@ -1667,7 +1689,7 @@ impl<'a> Decoder<'a> {
                 exif_data,
                 comment: self.metadata.comment.clone(),
                 density: self.metadata.density,
-                saved_markers: Vec::new(),
+                saved_markers: self.metadata.saved_markers.clone(),
                 warnings: Vec::new(),
             })
         }
@@ -1757,7 +1779,7 @@ impl<'a> Decoder<'a> {
             exif_data,
             comment: self.metadata.comment.clone(),
             density: self.metadata.density,
-            saved_markers: Vec::new(),
+            saved_markers: self.metadata.saved_markers.clone(),
             warnings: Vec::new(),
         })
     }
@@ -1902,7 +1924,7 @@ impl<'a> Decoder<'a> {
                     exif_data: exif_data.clone(),
                     comment: self.metadata.comment.clone(),
                     density: self.metadata.density,
-                    saved_markers: Vec::new(),
+                    saved_markers: self.metadata.saved_markers.clone(),
                     warnings: warnings.clone(),
                 })
             } else {
@@ -1962,7 +1984,7 @@ impl<'a> Decoder<'a> {
                     exif_data: exif_data.clone(),
                     comment: self.metadata.comment.clone(),
                     density: self.metadata.density,
-                    saved_markers: Vec::new(),
+                    saved_markers: self.metadata.saved_markers.clone(),
                     warnings: warnings.clone(),
                 })
             }
@@ -2079,7 +2101,7 @@ impl<'a> Decoder<'a> {
                     exif_data: exif_data.clone(),
                     comment: self.metadata.comment.clone(),
                     density: self.metadata.density,
-                    saved_markers: Vec::new(),
+                    saved_markers: self.metadata.saved_markers.clone(),
                     warnings: warnings.clone(),
                 });
             }
@@ -2109,7 +2131,7 @@ impl<'a> Decoder<'a> {
                 exif_data: exif_data.clone(),
                 comment: self.metadata.comment.clone(),
                 density: self.metadata.density,
-                saved_markers: Vec::new(),
+                saved_markers: self.metadata.saved_markers.clone(),
                 warnings: warnings.clone(),
             })
         } else if num_components == 4 {
@@ -2135,6 +2157,110 @@ impl<'a> Decoder<'a> {
                 num_components
             )))
         }
+    }
+
+    /// Decode JPEG to raw downsampled component planes.
+    ///
+    /// Returns component planes at their native (potentially subsampled)
+    /// resolution, without performing color conversion or upsampling.
+    /// This matches libjpeg-turbo's `jpeg_read_raw_data()` functionality.
+    pub fn decode_raw(self) -> Result<crate::api::raw_data::RawImage> {
+        let frame = &self.metadata.frame;
+        let width: usize = frame.width as usize;
+        let height: usize = frame.height as usize;
+        if frame.precision != 8 {
+            return Err(JpegError::Unsupported(format!(
+                "sample precision {} (only 8-bit supported)",
+                frame.precision
+            )));
+        }
+        let num_components: usize = frame.components.len();
+        let max_h: usize = frame
+            .components
+            .iter()
+            .map(|c| c.horizontal_sampling as usize)
+            .max()
+            .unwrap_or(1);
+        let max_v: usize = frame
+            .components
+            .iter()
+            .map(|c| c.vertical_sampling as usize)
+            .max()
+            .unwrap_or(1);
+        let block_size: usize = 8;
+        let mcu_width: usize = max_h * 8;
+        let mcu_height: usize = max_v * 8;
+        let mcus_x: usize = (width + mcu_width - 1) / mcu_width;
+        let mcus_y: usize = (height + mcu_height - 1) / mcu_height;
+        let quant_tables: Vec<&crate::common::quant_table::QuantTable> = frame
+            .components
+            .iter()
+            .map(|comp| {
+                self.metadata.quant_tables[comp.quant_table_index as usize]
+                    .as_ref()
+                    .ok_or_else(|| {
+                        JpegError::CorruptData(format!(
+                            "missing quant table {}",
+                            comp.quant_table_index
+                        ))
+                    })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let (component_planes, _warnings) = if self.metadata.is_arithmetic && frame.is_progressive {
+            self.decode_arithmetic_progressive_planes(
+                frame,
+                &quant_tables,
+                num_components,
+                mcus_x,
+                mcus_y,
+                max_h,
+                max_v,
+                block_size,
+            )?
+        } else if self.metadata.is_arithmetic {
+            self.decode_arithmetic_planes(
+                frame,
+                &quant_tables,
+                num_components,
+                mcus_x,
+                mcus_y,
+                block_size,
+            )?
+        } else if frame.is_progressive {
+            self.decode_progressive_planes(
+                frame,
+                &quant_tables,
+                num_components,
+                mcus_x,
+                mcus_y,
+                max_h,
+                max_v,
+                block_size,
+            )?
+        } else {
+            self.decode_baseline_planes(
+                frame,
+                &quant_tables,
+                num_components,
+                mcus_x,
+                mcus_y,
+                block_size,
+            )?
+        };
+        let mut plane_widths: Vec<usize> = Vec::with_capacity(num_components);
+        let mut plane_heights: Vec<usize> = Vec::with_capacity(num_components);
+        for comp in &frame.components {
+            plane_widths.push(mcus_x * comp.horizontal_sampling as usize * block_size);
+            plane_heights.push(mcus_y * comp.vertical_sampling as usize * block_size);
+        }
+        Ok(crate::api::raw_data::RawImage {
+            planes: component_planes,
+            plane_widths,
+            plane_heights,
+            width,
+            height,
+            num_components,
+        })
     }
 
     /// Determine the JPEG color space from component count and Adobe marker.
@@ -2477,7 +2603,7 @@ impl<'a> Decoder<'a> {
             exif_data,
             comment: self.metadata.comment.clone(),
             density: self.metadata.density,
-            saved_markers: Vec::new(),
+            saved_markers: self.metadata.saved_markers.clone(),
             warnings,
         })
     }

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -4,7 +4,7 @@
 /// and marker writing to produce a valid baseline JPEG file.
 use crate::api::encoder::HuffmanTableDef;
 use crate::common::error::{JpegError, Result};
-use crate::common::types::{DctMethod, PixelFormat, ScanScript, Subsampling};
+use crate::common::types::{DctMethod, PixelFormat, SavedMarker, ScanScript, Subsampling};
 use crate::encode::color;
 use crate::encode::fdct;
 use crate::encode::huffman_encode::{build_huff_table, BitWriter, HuffTable, HuffmanEncoder};
@@ -959,6 +959,33 @@ pub fn inject_comment(base: &[u8], text: &str) -> Vec<u8> {
     let mut out = Vec::with_capacity(base.len() + text.len() + 6);
     out.extend_from_slice(&base[..insert_pos]);
     marker_writer::write_com(&mut out, text);
+    out.extend_from_slice(&base[insert_pos..]);
+    out
+}
+
+/// Inject saved markers (APP/COM) into an existing JPEG byte stream.
+///
+/// Markers are inserted after SOI + APP0 (and any existing metadata markers),
+/// preserving the same insertion point pattern as `inject_metadata`/`inject_comment`.
+pub fn inject_saved_markers(base: &[u8], markers: &[SavedMarker]) -> Vec<u8> {
+    if markers.is_empty() {
+        return base.to_vec();
+    }
+
+    // Find insertion point after APP0 JFIF marker (SOI + APP0)
+    let insert_pos: usize = if base.len() >= 4 && base[2] == 0xFF && base[3] == 0xE0 {
+        let app0_len: usize = u16::from_be_bytes([base[4], base[5]]) as usize;
+        2 + 2 + app0_len
+    } else {
+        2
+    };
+
+    let extra: usize = markers.iter().map(|m| m.data.len() + 4).sum();
+    let mut out: Vec<u8> = Vec::with_capacity(base.len() + extra);
+    out.extend_from_slice(&base[..insert_pos]);
+    for marker in markers {
+        marker_writer::write_marker(&mut out, marker.code, &marker.data);
+    }
     out.extend_from_slice(&base[insert_pos..]);
     out
 }
@@ -4115,6 +4142,246 @@ fn gather_downsampled_block(
     let mut quantized = [0i16; 64];
     quant::quantize_block(&dct_output, quant_table, &mut quantized);
     quantized
+}
+
+/// Compress JPEG from raw downsampled component planes.
+///
+/// Bypasses color conversion and chroma downsampling — the caller provides
+/// data already in the YCbCr color space at the correct subsampled dimensions.
+/// This matches libjpeg-turbo's `jpeg_write_raw_data()` functionality.
+#[allow(clippy::too_many_arguments)]
+pub fn compress_raw(
+    planes: &[&[u8]],
+    plane_widths: &[usize],
+    plane_heights: &[usize],
+    image_width: usize,
+    image_height: usize,
+    quality: u8,
+    subsampling: Subsampling,
+) -> Result<Vec<u8>> {
+    if image_width == 0 || image_height == 0 {
+        return Err(JpegError::CorruptData(
+            "image dimensions must be non-zero".to_string(),
+        ));
+    }
+    if planes.len() != plane_widths.len() || planes.len() != plane_heights.len() {
+        return Err(JpegError::CorruptData(
+            "planes, plane_widths, and plane_heights must have the same length".to_string(),
+        ));
+    }
+    let is_grayscale: bool = planes.len() == 1;
+    if is_grayscale && subsampling != Subsampling::S444 {
+        return Err(JpegError::CorruptData(format!(
+            "1 plane (grayscale) is only valid with S444 subsampling, got {:?}",
+            subsampling
+        )));
+    }
+    if !is_grayscale && planes.len() != 3 {
+        return Err(JpegError::CorruptData(format!(
+            "expected 1 (grayscale) or 3 (YCbCr) planes, got {}",
+            planes.len()
+        )));
+    }
+    let (h_samp, v_samp): (u8, u8) = subsampling.sampling_factors();
+    if !is_grayscale {
+        let expected_cb_w: usize = (image_width + h_samp as usize - 1) / h_samp as usize;
+        let expected_cb_h: usize = (image_height + v_samp as usize - 1) / v_samp as usize;
+        if plane_widths[0] != image_width || plane_heights[0] != image_height {
+            return Err(JpegError::CorruptData(format!(
+                "Y plane dimensions {}x{} do not match image dimensions {}x{}",
+                plane_widths[0], plane_heights[0], image_width, image_height
+            )));
+        }
+        for comp_idx in 1..3 {
+            let comp_name: &str = if comp_idx == 1 { "Cb" } else { "Cr" };
+            if plane_widths[comp_idx] != expected_cb_w || plane_heights[comp_idx] != expected_cb_h {
+                return Err(JpegError::CorruptData(format!(
+                    "{} plane dimensions {}x{} do not match expected {}x{} for {:?} subsampling",
+                    comp_name,
+                    plane_widths[comp_idx],
+                    plane_heights[comp_idx],
+                    expected_cb_w,
+                    expected_cb_h,
+                    subsampling
+                )));
+            }
+        }
+    }
+    for (i, plane) in planes.iter().enumerate() {
+        let expected_size: usize = plane_widths[i] * plane_heights[i];
+        if plane.len() < expected_size {
+            return Err(JpegError::BufferTooSmall {
+                need: expected_size,
+                got: plane.len(),
+            });
+        }
+    }
+    let luma_quant: [u16; 64] =
+        tables::quality_scale_quant_table(&tables::STD_LUMINANCE_QUANT_TABLE, quality);
+    let chroma_quant: [u16; 64] =
+        tables::quality_scale_quant_table(&tables::STD_CHROMINANCE_QUANT_TABLE, quality);
+    let luma_divisors: [u16; 64] = scale_quant_for_fdct(&luma_quant);
+    let chroma_divisors: [u16; 64] = scale_quant_for_fdct(&chroma_quant);
+    let dc_luma_table: HuffTable =
+        build_huff_table(&tables::DC_LUMINANCE_BITS, &tables::DC_LUMINANCE_VALUES);
+    let ac_luma_table: HuffTable =
+        build_huff_table(&tables::AC_LUMINANCE_BITS, &tables::AC_LUMINANCE_VALUES);
+    let dc_chroma_table: HuffTable =
+        build_huff_table(&tables::DC_CHROMINANCE_BITS, &tables::DC_CHROMINANCE_VALUES);
+    let ac_chroma_table: HuffTable =
+        build_huff_table(&tables::AC_CHROMINANCE_BITS, &tables::AC_CHROMINANCE_VALUES);
+    let (mcu_w, mcu_h): (usize, usize) = if is_grayscale {
+        (8, 8)
+    } else {
+        match subsampling {
+            Subsampling::S444 => (8, 8),
+            Subsampling::S422 => (16, 8),
+            Subsampling::S420 => (16, 16),
+            Subsampling::S440 => (8, 16),
+            Subsampling::S411 => (32, 8),
+            Subsampling::S441 => (8, 32),
+        }
+    };
+    let mcus_x: usize = (image_width + mcu_w - 1) / mcu_w;
+    let mcus_y: usize = (image_height + mcu_h - 1) / mcu_h;
+    let fdct_fn: fn(&[i16; 64], &mut [i32; 64]) = fdct::fdct_islow;
+    let mut bit_writer: BitWriter = BitWriter::new(image_width * image_height);
+    let mut prev_dc_y: i16 = 0;
+    let mut prev_dc_cb: i16 = 0;
+    let mut prev_dc_cr: i16 = 0;
+    for mcu_row in 0..mcus_y {
+        for mcu_col in 0..mcus_x {
+            let x0: usize = mcu_col * mcu_w;
+            let y0: usize = mcu_row * mcu_h;
+            if is_grayscale {
+                encode_single_block(
+                    planes[0],
+                    plane_widths[0],
+                    plane_heights[0],
+                    x0,
+                    y0,
+                    &luma_divisors,
+                    &dc_luma_table,
+                    &ac_luma_table,
+                    &mut bit_writer,
+                    &mut prev_dc_y,
+                    fdct_fn,
+                );
+            } else {
+                let h: usize = h_samp as usize;
+                let v: usize = v_samp as usize;
+                for vy in 0..v {
+                    for hx in 0..h {
+                        encode_single_block(
+                            planes[0],
+                            plane_widths[0],
+                            plane_heights[0],
+                            x0 + hx * 8,
+                            y0 + vy * 8,
+                            &luma_divisors,
+                            &dc_luma_table,
+                            &ac_luma_table,
+                            &mut bit_writer,
+                            &mut prev_dc_y,
+                            fdct_fn,
+                        );
+                    }
+                }
+                let chroma_x: usize = x0 / h;
+                let chroma_y: usize = y0 / v;
+                encode_single_block(
+                    planes[1],
+                    plane_widths[1],
+                    plane_heights[1],
+                    chroma_x,
+                    chroma_y,
+                    &chroma_divisors,
+                    &dc_chroma_table,
+                    &ac_chroma_table,
+                    &mut bit_writer,
+                    &mut prev_dc_cb,
+                    fdct_fn,
+                );
+                encode_single_block(
+                    planes[2],
+                    plane_widths[2],
+                    plane_heights[2],
+                    chroma_x,
+                    chroma_y,
+                    &chroma_divisors,
+                    &dc_chroma_table,
+                    &ac_chroma_table,
+                    &mut bit_writer,
+                    &mut prev_dc_cr,
+                    fdct_fn,
+                );
+            }
+        }
+    }
+    bit_writer.flush();
+    let mut output: Vec<u8> = Vec::with_capacity(bit_writer.data().len() + 1024);
+    marker_writer::write_soi(&mut output);
+    marker_writer::write_app0_jfif(&mut output);
+    marker_writer::write_dqt(&mut output, 0, &luma_quant);
+    if !is_grayscale {
+        marker_writer::write_dqt(&mut output, 1, &chroma_quant);
+    }
+    if is_grayscale {
+        let components: Vec<(u8, u8, u8, u8)> = vec![(1, 1, 1, 0)];
+        marker_writer::write_sof0(
+            &mut output,
+            image_width as u16,
+            image_height as u16,
+            &components,
+        );
+    } else {
+        let components: Vec<(u8, u8, u8, u8)> =
+            vec![(1, h_samp, v_samp, 0), (2, 1, 1, 1), (3, 1, 1, 1)];
+        marker_writer::write_sof0(
+            &mut output,
+            image_width as u16,
+            image_height as u16,
+            &components,
+        );
+    }
+    marker_writer::write_dht(
+        &mut output,
+        0,
+        0,
+        &tables::DC_LUMINANCE_BITS,
+        &tables::DC_LUMINANCE_VALUES,
+    );
+    marker_writer::write_dht(
+        &mut output,
+        1,
+        0,
+        &tables::AC_LUMINANCE_BITS,
+        &tables::AC_LUMINANCE_VALUES,
+    );
+    if !is_grayscale {
+        marker_writer::write_dht(
+            &mut output,
+            0,
+            1,
+            &tables::DC_CHROMINANCE_BITS,
+            &tables::DC_CHROMINANCE_VALUES,
+        );
+        marker_writer::write_dht(
+            &mut output,
+            1,
+            1,
+            &tables::AC_CHROMINANCE_BITS,
+            &tables::AC_CHROMINANCE_VALUES,
+        );
+    }
+    if is_grayscale {
+        marker_writer::write_sos(&mut output, &vec![(1, 0, 0)]);
+    } else {
+        marker_writer::write_sos(&mut output, &vec![(1, 0, 0), (2, 1, 1), (3, 1, 1)]);
+    }
+    output.extend_from_slice(bit_writer.data());
+    marker_writer::write_eoi(&mut output);
+    Ok(output)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub use api::high_level::{
     compress_progressive, compress_with_metadata, decompress, decompress_cropped,
     decompress_lenient, decompress_to,
 };
+pub use api::raw_data::{compress_raw, decompress_raw, RawImage};
 pub use api::scanline::{ScanlineDecoder, ScanlineEncoder};
 pub use common::bufsize::{
     jpeg_buf_size, yuv_buf_size, yuv_plane_height, yuv_plane_size, yuv_plane_width,

--- a/tests/raw_data.rs
+++ b/tests/raw_data.rs
@@ -1,0 +1,344 @@
+/// Tests for raw data encode/decode (jpeg_write_raw_data / jpeg_read_raw_data equivalent).
+///
+/// Raw data mode encodes from / decodes to pre-downsampled component planes
+/// (e.g., separate Y, Cb, Cr at their native subsampled resolution),
+/// bypassing color conversion and chroma downsampling/upsampling.
+use libjpeg_turbo_rs::{
+    compress, compress_raw, decompress_raw, PixelFormat, RawImage, Subsampling,
+};
+
+/// Maximum per-pixel difference allowed in lossy roundtrip tests.
+/// JPEG DCT+quantization at quality 95 typically introduces up to ~6 error.
+const MAX_DIFF: i16 = 8;
+
+// ---------------------------------------------------------------------------
+// Grayscale roundtrip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn raw_grayscale_roundtrip() {
+    let width: usize = 32;
+    let height: usize = 24;
+    // Single Y plane with a gradient pattern
+    let y_plane: Vec<u8> = (0..width * height)
+        .map(|i| ((i * 7 + 13) % 256) as u8)
+        .collect();
+
+    let jpeg_data: Vec<u8> = compress_raw(
+        &[&y_plane],
+        &[width],
+        &[height],
+        width,
+        height,
+        95,
+        Subsampling::S444, // subsampling is irrelevant for grayscale
+    )
+    .expect("compress_raw grayscale should succeed");
+
+    // Verify it produces valid JPEG
+    assert!(jpeg_data.len() > 2);
+    assert_eq!(jpeg_data[0], 0xFF);
+    assert_eq!(jpeg_data[1], 0xD8); // SOI marker
+
+    // Decompress back to raw planes
+    let raw: RawImage = decompress_raw(&jpeg_data).expect("decompress_raw should succeed");
+
+    assert_eq!(raw.width, width);
+    assert_eq!(raw.height, height);
+    assert_eq!(raw.num_components, 1);
+    assert_eq!(raw.planes.len(), 1);
+    assert_eq!(raw.plane_widths.len(), 1);
+    assert_eq!(raw.plane_heights.len(), 1);
+    // Plane dimensions should match the original image dimensions (padded to MCU boundary)
+    assert!(raw.plane_widths[0] >= width);
+    assert!(raw.plane_heights[0] >= height);
+
+    // Check pixel values survive the roundtrip within JPEG lossy tolerance
+    for row in 0..height {
+        for col in 0..width {
+            let original: u8 = y_plane[row * width + col];
+            let decoded: u8 = raw.planes[0][row * raw.plane_widths[0] + col];
+            let diff: i16 = original as i16 - decoded as i16;
+            assert!(
+                diff.abs() <= MAX_DIFF,
+                "grayscale pixel ({},{}) differs: orig={} decoded={} diff={}",
+                col,
+                row,
+                original,
+                decoded,
+                diff
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// YCbCr 4:2:0 roundtrip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn raw_420_roundtrip() {
+    let image_width: usize = 48;
+    let image_height: usize = 32;
+
+    // Y plane: full resolution
+    let y_w: usize = image_width;
+    let y_h: usize = image_height;
+    let y_plane: Vec<u8> = (0..y_w * y_h).map(|i| ((i * 3 + 7) % 256) as u8).collect();
+
+    // Cb, Cr planes: half resolution in both dimensions
+    let c_w: usize = image_width / 2;
+    let c_h: usize = image_height / 2;
+    let cb_plane: Vec<u8> = (0..c_w * c_h)
+        .map(|i| ((i * 5 + 100) % 256) as u8)
+        .collect();
+    let cr_plane: Vec<u8> = (0..c_w * c_h)
+        .map(|i| ((i * 11 + 200) % 256) as u8)
+        .collect();
+
+    let jpeg_data: Vec<u8> = compress_raw(
+        &[&y_plane, &cb_plane, &cr_plane],
+        &[y_w, c_w, c_w],
+        &[y_h, c_h, c_h],
+        image_width,
+        image_height,
+        95,
+        Subsampling::S420,
+    )
+    .expect("compress_raw 4:2:0 should succeed");
+
+    let raw: RawImage = decompress_raw(&jpeg_data).expect("decompress_raw 4:2:0 should succeed");
+
+    assert_eq!(raw.width, image_width);
+    assert_eq!(raw.height, image_height);
+    assert_eq!(raw.num_components, 3);
+    assert_eq!(raw.planes.len(), 3);
+
+    // Y plane should be at full resolution (MCU-aligned)
+    assert!(raw.plane_widths[0] >= image_width);
+    assert!(raw.plane_heights[0] >= image_height);
+
+    // Cb/Cr planes should be at half resolution (MCU-aligned)
+    assert!(raw.plane_widths[1] >= c_w);
+    assert!(raw.plane_heights[1] >= c_h);
+    assert!(raw.plane_widths[2] >= c_w);
+    assert!(raw.plane_heights[2] >= c_h);
+
+    // Verify Y plane values survive roundtrip
+    for row in 0..y_h {
+        for col in 0..y_w {
+            let original: u8 = y_plane[row * y_w + col];
+            let decoded: u8 = raw.planes[0][row * raw.plane_widths[0] + col];
+            let diff: i16 = original as i16 - decoded as i16;
+            assert!(
+                diff.abs() <= MAX_DIFF,
+                "Y pixel ({},{}) differs: orig={} decoded={} diff={}",
+                col,
+                row,
+                original,
+                decoded,
+                diff
+            );
+        }
+    }
+
+    // Verify Cb plane values survive roundtrip
+    for row in 0..c_h {
+        for col in 0..c_w {
+            let original: u8 = cb_plane[row * c_w + col];
+            let decoded: u8 = raw.planes[1][row * raw.plane_widths[1] + col];
+            let diff: i16 = original as i16 - decoded as i16;
+            assert!(
+                diff.abs() <= MAX_DIFF,
+                "Cb pixel ({},{}) differs: orig={} decoded={} diff={}",
+                col,
+                row,
+                original,
+                decoded,
+                diff
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// YCbCr 4:4:4 roundtrip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn raw_444_roundtrip() {
+    let width: usize = 40;
+    let height: usize = 30;
+
+    // All three planes at full resolution
+    let y_plane: Vec<u8> = (0..width * height)
+        .map(|i| ((i * 3 + 50) % 256) as u8)
+        .collect();
+    let cb_plane: Vec<u8> = (0..width * height)
+        .map(|i| ((i * 7 + 120) % 256) as u8)
+        .collect();
+    let cr_plane: Vec<u8> = (0..width * height)
+        .map(|i| ((i * 11 + 180) % 256) as u8)
+        .collect();
+
+    let jpeg_data: Vec<u8> = compress_raw(
+        &[&y_plane, &cb_plane, &cr_plane],
+        &[width, width, width],
+        &[height, height, height],
+        width,
+        height,
+        95,
+        Subsampling::S444,
+    )
+    .expect("compress_raw 4:4:4 should succeed");
+
+    let raw: RawImage = decompress_raw(&jpeg_data).expect("decompress_raw 4:4:4 should succeed");
+
+    assert_eq!(raw.width, width);
+    assert_eq!(raw.height, height);
+    assert_eq!(raw.num_components, 3);
+
+    // All planes should be at full resolution (MCU-aligned)
+    assert!(raw.plane_widths[0] >= width);
+    assert!(raw.plane_heights[0] >= height);
+    assert!(raw.plane_widths[1] >= width);
+    assert!(raw.plane_heights[1] >= height);
+    assert!(raw.plane_widths[2] >= width);
+    assert!(raw.plane_heights[2] >= height);
+
+    // Verify roundtrip values
+    for row in 0..height {
+        for col in 0..width {
+            let orig_y: u8 = y_plane[row * width + col];
+            let dec_y: u8 = raw.planes[0][row * raw.plane_widths[0] + col];
+            let diff: i16 = orig_y as i16 - dec_y as i16;
+            assert!(
+                diff.abs() <= MAX_DIFF,
+                "Y pixel ({},{}) differs: {} vs {}",
+                col,
+                row,
+                orig_y,
+                dec_y
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// decompress_raw from a standard (non-raw) JPEG produces correct plane dimensions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn decompress_raw_from_standard_jpeg() {
+    // Create a standard JPEG from RGB pixels
+    let width: usize = 64;
+    let height: usize = 48;
+    let pixels: Vec<u8> = (0..width * height * 3)
+        .map(|i| ((i * 13 + 7) % 256) as u8)
+        .collect();
+
+    let jpeg_data: Vec<u8> = compress(
+        &pixels,
+        width,
+        height,
+        PixelFormat::Rgb,
+        85,
+        Subsampling::S420,
+    )
+    .expect("compress should succeed");
+
+    let raw: RawImage =
+        decompress_raw(&jpeg_data).expect("decompress_raw from standard JPEG should succeed");
+
+    assert_eq!(raw.width, width);
+    assert_eq!(raw.height, height);
+    assert_eq!(raw.num_components, 3);
+
+    // For 4:2:0: Y is full res, Cb/Cr are half in each dimension
+    // Plane widths/heights are MCU-aligned
+    assert!(raw.plane_widths[0] >= width);
+    assert!(raw.plane_heights[0] >= height);
+    assert!(raw.plane_widths[1] >= width / 2);
+    assert!(raw.plane_heights[1] >= height / 2);
+    assert!(raw.plane_widths[2] >= width / 2);
+    assert!(raw.plane_heights[2] >= height / 2);
+
+    // Y plane should have reasonable luminance values (not all zeros)
+    let y_sum: u64 = raw.planes[0].iter().map(|&v| v as u64).sum();
+    assert!(y_sum > 0, "Y plane should not be all zeros");
+}
+
+// ---------------------------------------------------------------------------
+// compress_raw with wrong plane sizes returns error
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compress_raw_wrong_plane_sizes_returns_error() {
+    let width: usize = 32;
+    let height: usize = 24;
+    let y_plane: Vec<u8> = vec![128u8; width * height];
+
+    // Cb/Cr planes are wrong size for 4:2:0 (should be 16x12 but we provide 32x24)
+    let cb_plane: Vec<u8> = vec![128u8; width * height]; // too big
+    let cr_plane: Vec<u8> = vec![128u8; width * height]; // too big
+
+    let result = compress_raw(
+        &[&y_plane, &cb_plane, &cr_plane],
+        &[width, width, width],    // Cb/Cr widths should be width/2 for 4:2:0
+        &[height, height, height], // Cb/Cr heights should be height/2 for 4:2:0
+        width,
+        height,
+        90,
+        Subsampling::S420,
+    );
+
+    assert!(
+        result.is_err(),
+        "compress_raw with wrong plane dimensions for 4:2:0 should fail"
+    );
+}
+
+#[test]
+fn compress_raw_wrong_plane_count_returns_error() {
+    let width: usize = 32;
+    let height: usize = 24;
+    let y_plane: Vec<u8> = vec![128u8; width * height];
+
+    // Only 1 plane for S420 (requires 3)
+    let result = compress_raw(
+        &[&y_plane],
+        &[width],
+        &[height],
+        width,
+        height,
+        90,
+        Subsampling::S420,
+    );
+
+    assert!(
+        result.is_err(),
+        "compress_raw with 1 plane for 4:2:0 should fail"
+    );
+}
+
+#[test]
+fn compress_raw_plane_data_too_small_returns_error() {
+    let width: usize = 32;
+    let height: usize = 24;
+    let y_plane: Vec<u8> = vec![128u8; 10]; // way too small
+
+    let result = compress_raw(
+        &[&y_plane],
+        &[width],
+        &[height],
+        width,
+        height,
+        90,
+        Subsampling::S444,
+    );
+
+    assert!(
+        result.is_err(),
+        "compress_raw with undersized plane data should fail"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `compress_raw()` to encode JPEG from pre-downsampled component planes (Y, Cb, Cr), bypassing color conversion and chroma downsampling. Matches libjpeg-turbo's `jpeg_write_raw_data()`.
- Add `decompress_raw()` to decode JPEG to raw component planes without upsampling or color conversion. Matches libjpeg-turbo's `jpeg_read_raw_data()`.
- Add `RawImage` struct containing decoded plane data, dimensions, and metadata.
- Validates plane count, dimensions, and buffer sizes against the specified subsampling mode.
- Supports grayscale (1 plane, S444) and YCbCr with all subsampling modes (S444, S422, S420, S440, S411, S441).
- Updates FEATURE_PARITY.md and C_API_REFERENCE.md checkboxes.

This is Phase 6 task #24 from the feature parity roadmap.

## Test plan
- [x] Grayscale raw encode -> decode roundtrip (verify pixel values within JPEG tolerance)
- [x] YCbCr 4:2:0 raw encode -> decode roundtrip (verify plane dimensions and pixel values)
- [x] YCbCr 4:4:4 raw encode -> decode roundtrip
- [x] decompress_raw from a standard JPEG produces correct plane dimensions
- [x] compress_raw with wrong plane dimensions returns error
- [x] compress_raw with wrong plane count returns error
- [x] compress_raw with undersized plane data returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)