### PR TITLE
feat: implement marker preservation / configurable marker saving

### DIFF
--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -208,11 +208,11 @@
 - [x] EXIF extraction + orientation (APP1)
 - [x] Adobe APP14 detection (CMYK/YCCK)
 - [x] Restart marker (DRI/RST) handling
-- [ ] `TJPARAM_SAVEMARKERS` — Configurable marker saving (0-4 levels)
-- [ ] `jpeg_save_markers()` — Per-marker-type save control
+- [x] `TJPARAM_SAVEMARKERS` — Configurable marker saving (`MarkerSaveConfig` enum: None/All/AppOnly/Specific)
+- [x] `jpeg_save_markers()` — Per-marker-type save control (`Decoder::save_markers()`)
 - [ ] `jpeg_set_marker_processor()` — Custom marker parser callback
 - [x] COM (comment) marker read/expose (`Image.comment`)
-- [ ] Arbitrary marker access via `marker_list` linked list
+- [x] Arbitrary marker access via `marker_list` linked list (`Image.markers()` / `Image.saved_markers`)
 - [x] JFIF version / density read (`Image.density`)
 
 ### Multi-Scan / Progressive Output
@@ -253,11 +253,11 @@
 - [x] APP2 ICC profile — Read (multi-chunk reassembly) / write (multi-chunk)
 - [x] APP14 Adobe — Read / write (CMYK/YCCK signaling)
 - [x] COM (comment) — Read (`Image.comment`) / Write (`Encoder::comment()`)
-- [ ] Arbitrary APP markers — Read (`jpeg_save_markers` + `marker_list`)
-- [x] Arbitrary markers — Write (`marker_writer::write_marker()`)
+- [x] Arbitrary APP markers — Read (`Decoder::save_markers()` + `Image.markers()`)
+- [x] Arbitrary markers — Write (`marker_writer::write_marker()`, `Encoder::saved_marker()`)
 - [x] DPI/density — Read (`Image.density`) / Write (`DensityInfo`)
 - [ ] JFIF thumbnail extraction
-- [ ] Marker preservation across transform/re-encode
+- [x] Marker preservation across transform/re-encode (`TransformOptions.copy_markers`)
 
 ---
 
@@ -280,7 +280,7 @@
 - [ ] TJXOPT_GRAY (8) — Convert to grayscale during transform
 - [ ] TJXOPT_NOOUTPUT (16) — Dry run (no output image)
 - [ ] TJXOPT_PROGRESSIVE (32) — Output as progressive JPEG
-- [ ] TJXOPT_COPYNONE (64) — Discard all non-essential markers
+- [x] TJXOPT_COPYNONE (64) — Discard all non-essential markers (`TransformOptions.copy_markers = false`)
 - [ ] TJXOPT_ARITHMETIC (128) — Output with arithmetic coding
 - [ ] TJXOPT_OPTIMIZE (256) — Output with optimized Huffman
 

--- a/src/api/coefficient.rs
+++ b/src/api/coefficient.rs
@@ -4,9 +4,11 @@
 /// similar to libjpeg-turbo's jpegtran workflow.
 use crate::common::error::{JpegError, Result};
 use crate::common::quant_table::NATURAL_ORDER;
+use crate::common::types::{MarkerSaveConfig, SavedMarker};
 use crate::decode::marker::{JpegMetadata, MarkerReader};
 use crate::encode::huffman_encode::{build_huff_table, BitWriter, HuffmanEncoder};
 use crate::encode::marker_writer;
+use crate::encode::pipeline as encoder_pipeline;
 use crate::encode::tables;
 use crate::transform::spatial;
 use crate::transform::{TransformOp, TransformOptions};
@@ -358,6 +360,20 @@ pub fn transform_jpeg(data: &[u8], op: TransformOp) -> Result<Vec<u8>> {
 /// Supports all 9 flags from libjpeg-turbo: perfect, trim, crop, grayscale,
 /// no_output, progressive, arithmetic, optimize, and copy_markers.
 pub fn transform_jpeg_with_options(data: &[u8], options: &TransformOptions) -> Result<Vec<u8>> {
+    // Read saved markers from the source if copy_markers is enabled.
+    let saved_markers: Vec<SavedMarker> = if options.copy_markers {
+        let mut reader: MarkerReader<'_> = MarkerReader::new(data);
+        reader.set_marker_save_config(MarkerSaveConfig::All);
+        let meta: JpegMetadata = reader.read_markers()?;
+        // Filter out JFIF APP0 since write_coefficients writes its own.
+        meta.saved_markers
+            .into_iter()
+            .filter(|m| m.code != 0xE0)
+            .collect()
+    } else {
+        Vec::new()
+    };
+
     let mut coeffs = read_coefficients(data)?;
     let op: TransformOp = options.op;
 
@@ -581,10 +597,20 @@ pub fn transform_jpeg_with_options(data: &[u8], options: &TransformOptions) -> R
     }
 
     // Write output with the appropriate encoding.
-    if options.optimize {
-        write_coefficients_optimized(&coeffs)
+    let output: Vec<u8> = if options.optimize {
+        write_coefficients_optimized(&coeffs)?
     } else {
-        write_coefficients(&coeffs)
+        write_coefficients(&coeffs)?
+    };
+
+    // Inject saved markers from the source if copy_markers is enabled.
+    if !saved_markers.is_empty() {
+        Ok(encoder_pipeline::inject_saved_markers(
+            &output,
+            &saved_markers,
+        ))
+    } else {
+        Ok(output)
     }
 }
 

--- a/src/api/encoder.rs
+++ b/src/api/encoder.rs
@@ -1,5 +1,5 @@
 use crate::common::error::Result;
-use crate::common::types::{DctMethod, PixelFormat, ScanScript, Subsampling};
+use crate::common::types::{DctMethod, PixelFormat, SavedMarker, ScanScript, Subsampling};
 use crate::encode::pipeline as encoder;
 use crate::encode::tables;
 
@@ -49,6 +49,7 @@ pub struct Encoder<'a> {
     custom_huffman_dc: [Option<HuffmanTableDef>; 4],
     custom_huffman_ac: [Option<HuffmanTableDef>; 4],
     dct_method: DctMethod,
+    saved_markers: Vec<SavedMarker>,
 }
 
 impl<'a> Encoder<'a> {
@@ -78,6 +79,7 @@ impl<'a> Encoder<'a> {
             custom_huffman_dc: [None, None, None, None],
             custom_huffman_ac: [None, None, None, None],
             dct_method: DctMethod::IsLow,
+            saved_markers: Vec::new(),
         }
     }
 
@@ -198,6 +200,15 @@ impl<'a> Encoder<'a> {
     /// Set a COM (comment) marker in the JPEG output.
     pub fn comment(mut self, text: &'a str) -> Self {
         self.comment = Some(text);
+        self
+    }
+
+    /// Add a saved marker (APP or COM) to the JPEG output.
+    ///
+    /// Multiple markers of the same type can be added; they will appear
+    /// in the order added, after JFIF/ICC/EXIF but before DQT/SOF/SOS.
+    pub fn saved_marker(mut self, marker: SavedMarker) -> Self {
+        self.saved_markers.push(marker);
         self
     }
 
@@ -491,10 +502,19 @@ impl<'a> Encoder<'a> {
             base
         };
 
-        if let Some(text) = self.comment {
-            Ok(encoder::inject_comment(&with_meta, text))
+        let with_comment: Vec<u8> = if let Some(text) = self.comment {
+            encoder::inject_comment(&with_meta, text)
         } else {
-            Ok(with_meta)
+            with_meta
+        };
+
+        if self.saved_markers.is_empty() {
+            Ok(with_comment)
+        } else {
+            Ok(encoder::inject_saved_markers(
+                &with_comment,
+                &self.saved_markers,
+            ))
         }
     }
 }

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -301,8 +301,32 @@ pub enum DensityUnit {
 /// A saved JPEG marker (APP or COM).
 #[derive(Debug, Clone)]
 pub struct SavedMarker {
+    /// Marker code (e.g., 0xE0 for APP0, 0xFE for COM).
     pub code: u8,
+    /// Raw marker data (after the 2-byte length field).
     pub data: Vec<u8>,
+}
+
+/// Configuration for which markers the decoder should save.
+///
+/// Controls which APP and COM markers are preserved during decoding,
+/// matching libjpeg-turbo's `jpeg_save_markers()` / `TJPARAM_SAVEMARKERS`.
+#[derive(Debug, Clone)]
+pub enum MarkerSaveConfig {
+    /// Do not save any markers (default).
+    None,
+    /// Save all APP (0xE0-0xEF) and COM (0xFE) markers.
+    All,
+    /// Save only APP markers (0xE0-0xEF), not COM.
+    AppOnly,
+    /// Save only the specified marker codes.
+    Specific(Vec<u8>),
+}
+
+impl Default for MarkerSaveConfig {
+    fn default() -> Self {
+        MarkerSaveConfig::None
+    }
 }
 
 /// Progressive scan script entry.

--- a/src/decode/marker.rs
+++ b/src/decode/marker.rs
@@ -72,17 +72,52 @@ pub struct JpegMetadata {
     pub arith_dc_params: [(u8, u8); 4],
     /// DAC conditioning: AC parameter (Kx) per table.
     pub arith_ac_params: [u8; 4],
+    /// Saved APP/COM markers according to the marker save configuration.
+    pub saved_markers: Vec<SavedMarker>,
 }
 
 /// Reads and parses JPEG markers from a byte slice.
 pub struct MarkerReader<'a> {
     data: &'a [u8],
     pos: usize,
+    marker_save_config: MarkerSaveConfig,
 }
 
 impl<'a> MarkerReader<'a> {
     pub fn new(data: &'a [u8]) -> Self {
-        Self { data, pos: 0 }
+        Self {
+            data,
+            pos: 0,
+            marker_save_config: MarkerSaveConfig::None,
+        }
+    }
+
+    /// Set the marker save configuration.
+    pub fn set_marker_save_config(&mut self, config: MarkerSaveConfig) {
+        self.marker_save_config = config;
+    }
+
+    /// Check whether a given marker code should be saved according to config.
+    fn should_save_marker(&self, code: u8) -> bool {
+        match &self.marker_save_config {
+            MarkerSaveConfig::None => false,
+            MarkerSaveConfig::All => (0xE0..=0xEF).contains(&code) || code == COM,
+            MarkerSaveConfig::AppOnly => (0xE0..=0xEF).contains(&code),
+            MarkerSaveConfig::Specific(codes) => codes.contains(&code),
+        }
+    }
+
+    /// Read a marker segment's raw data without advancing pos.
+    /// Returns the data portion (after the 2-byte length field).
+    fn peek_marker_data(&self) -> Option<Vec<u8>> {
+        if self.pos + 2 > self.data.len() {
+            return None;
+        }
+        let length = u16::from_be_bytes([self.data[self.pos], self.data[self.pos + 1]]) as usize;
+        if length < 2 || self.pos + length > self.data.len() {
+            return None;
+        }
+        Some(self.data[self.pos + 2..self.pos + length].to_vec())
     }
 
     /// Parse all markers. For baseline, stops after first SOS.
@@ -105,6 +140,7 @@ impl<'a> MarkerReader<'a> {
         let mut arith_ac_params: [u8; 4] = [5; 4];
         let mut comment: Option<String> = None;
         let mut density: DensityInfo = DensityInfo::default();
+        let mut saved_markers: Vec<SavedMarker> = Vec::new();
 
         loop {
             let marker = self.read_marker()?;
@@ -170,26 +206,71 @@ impl<'a> MarkerReader<'a> {
                 }
                 // APP1 (EXIF) — parse for EXIF metadata
                 0xE1 => {
+                    if self.should_save_marker(0xE1) {
+                        if let Some(raw) = self.peek_marker_data() {
+                            saved_markers.push(SavedMarker {
+                                code: 0xE1,
+                                data: raw,
+                            });
+                        }
+                    }
                     self.read_app1(&mut exif_data)?;
                 }
                 // APP2 (ICC profile) — parse for ICC profile chunks
                 0xE2 => {
+                    if self.should_save_marker(0xE2) {
+                        if let Some(raw) = self.peek_marker_data() {
+                            saved_markers.push(SavedMarker {
+                                code: 0xE2,
+                                data: raw,
+                            });
+                        }
+                    }
                     self.read_app2(&mut icc_chunks)?;
                 }
                 // APP14 (Adobe marker) — parse for color transform info
                 0xEE => {
+                    if self.should_save_marker(0xEE) {
+                        if let Some(raw) = self.peek_marker_data() {
+                            saved_markers.push(SavedMarker {
+                                code: 0xEE,
+                                data: raw,
+                            });
+                        }
+                    }
                     self.read_app14(&mut saw_adobe_marker, &mut adobe_transform)?;
                 }
                 // APP0 (JFIF) — parse for density info
                 0xE0 => {
+                    if self.should_save_marker(0xE0) {
+                        if let Some(raw) = self.peek_marker_data() {
+                            saved_markers.push(SavedMarker {
+                                code: 0xE0,
+                                data: raw,
+                            });
+                        }
+                    }
                     self.read_app0(&mut density)?;
                 }
                 // COM marker — parse comment text
                 COM => {
+                    if self.should_save_marker(COM) {
+                        if let Some(raw) = self.peek_marker_data() {
+                            saved_markers.push(SavedMarker {
+                                code: COM,
+                                data: raw,
+                            });
+                        }
+                    }
                     self.read_com(&mut comment)?;
                 }
-                // Skip other APPn markers
+                // Other APPn markers — save if configured, then skip
                 m if (0xE3..=0xEF).contains(&m) => {
+                    if self.should_save_marker(m) {
+                        if let Some(raw) = self.peek_marker_data() {
+                            saved_markers.push(SavedMarker { code: m, data: raw });
+                        }
+                    }
                     self.skip_marker_segment()?;
                 }
                 // Skip other markers with length
@@ -228,6 +309,7 @@ impl<'a> MarkerReader<'a> {
             is_arithmetic,
             arith_dc_params,
             arith_ac_params,
+            saved_markers,
         })
     }
 

--- a/src/decode/pipeline.rs
+++ b/src/decode/pipeline.rs
@@ -70,6 +70,13 @@ impl Image {
             .as_ref()
             .and_then(|d| crate::common::exif::parse_orientation(d))
     }
+
+    /// Returns all saved markers (APP and COM) collected during decoding.
+    ///
+    /// Only populated when the decoder was configured with `save_markers()`.
+    pub fn markers(&self) -> &[SavedMarker] {
+        &self.saved_markers
+    }
 }
 
 /// JPEG decoder. Orchestrates the full decoding pipeline.
@@ -169,6 +176,21 @@ impl<'a> Decoder<'a> {
     /// Set maximum number of progressive scans before error.
     pub fn set_scan_limit(&mut self, limit: u32) {
         self.scan_limit = Some(limit);
+    }
+
+    /// Configure which markers to save during decoding.
+    ///
+    /// By default, the decoder only parses known markers (JFIF, ICC, EXIF, Adobe, COM)
+    /// and discards unknown APP markers. Call this to preserve arbitrary APP/COM markers
+    /// in the decoded `Image.saved_markers` field.
+    ///
+    /// This re-parses the JPEG header with the new configuration.
+    pub fn save_markers(&mut self, config: MarkerSaveConfig) {
+        let mut reader: MarkerReader<'_> = MarkerReader::new(self.raw_data);
+        reader.set_marker_save_config(config);
+        if let Ok(metadata) = reader.read_markers() {
+            self.metadata = metadata;
+        }
     }
 
     pub fn decode(data: &'a [u8]) -> Result<Image> {
@@ -1612,7 +1634,7 @@ impl<'a> Decoder<'a> {
                 exif_data,
                 comment: self.metadata.comment.clone(),
                 density: self.metadata.density,
-                saved_markers: Vec::new(),
+                saved_markers: self.metadata.saved_markers.clone(),
                 warnings: Vec::new(),
             })
         } else {
@@ -1667,7 +1689,7 @@ impl<'a> Decoder<'a> {
                 exif_data,
                 comment: self.metadata.comment.clone(),
                 density: self.metadata.density,
-                saved_markers: Vec::new(),
+                saved_markers: self.metadata.saved_markers.clone(),
                 warnings: Vec::new(),
             })
         }
@@ -1757,7 +1779,7 @@ impl<'a> Decoder<'a> {
             exif_data,
             comment: self.metadata.comment.clone(),
             density: self.metadata.density,
-            saved_markers: Vec::new(),
+            saved_markers: self.metadata.saved_markers.clone(),
             warnings: Vec::new(),
         })
     }
@@ -1902,7 +1924,7 @@ impl<'a> Decoder<'a> {
                     exif_data: exif_data.clone(),
                     comment: self.metadata.comment.clone(),
                     density: self.metadata.density,
-                    saved_markers: Vec::new(),
+                    saved_markers: self.metadata.saved_markers.clone(),
                     warnings: warnings.clone(),
                 })
             } else {
@@ -1962,7 +1984,7 @@ impl<'a> Decoder<'a> {
                     exif_data: exif_data.clone(),
                     comment: self.metadata.comment.clone(),
                     density: self.metadata.density,
-                    saved_markers: Vec::new(),
+                    saved_markers: self.metadata.saved_markers.clone(),
                     warnings: warnings.clone(),
                 })
             }
@@ -2079,7 +2101,7 @@ impl<'a> Decoder<'a> {
                     exif_data: exif_data.clone(),
                     comment: self.metadata.comment.clone(),
                     density: self.metadata.density,
-                    saved_markers: Vec::new(),
+                    saved_markers: self.metadata.saved_markers.clone(),
                     warnings: warnings.clone(),
                 });
             }
@@ -2109,7 +2131,7 @@ impl<'a> Decoder<'a> {
                 exif_data: exif_data.clone(),
                 comment: self.metadata.comment.clone(),
                 density: self.metadata.density,
-                saved_markers: Vec::new(),
+                saved_markers: self.metadata.saved_markers.clone(),
                 warnings: warnings.clone(),
             })
         } else if num_components == 4 {
@@ -2477,7 +2499,7 @@ impl<'a> Decoder<'a> {
             exif_data,
             comment: self.metadata.comment.clone(),
             density: self.metadata.density,
-            saved_markers: Vec::new(),
+            saved_markers: self.metadata.saved_markers.clone(),
             warnings,
         })
     }

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -4,7 +4,7 @@
 /// and marker writing to produce a valid baseline JPEG file.
 use crate::api::encoder::HuffmanTableDef;
 use crate::common::error::{JpegError, Result};
-use crate::common::types::{DctMethod, PixelFormat, ScanScript, Subsampling};
+use crate::common::types::{DctMethod, PixelFormat, SavedMarker, ScanScript, Subsampling};
 use crate::encode::color;
 use crate::encode::fdct;
 use crate::encode::huffman_encode::{build_huff_table, BitWriter, HuffTable, HuffmanEncoder};
@@ -959,6 +959,33 @@ pub fn inject_comment(base: &[u8], text: &str) -> Vec<u8> {
     let mut out = Vec::with_capacity(base.len() + text.len() + 6);
     out.extend_from_slice(&base[..insert_pos]);
     marker_writer::write_com(&mut out, text);
+    out.extend_from_slice(&base[insert_pos..]);
+    out
+}
+
+/// Inject saved markers (APP/COM) into an existing JPEG byte stream.
+///
+/// Markers are inserted after SOI + APP0 (and any existing metadata markers),
+/// preserving the same insertion point pattern as `inject_metadata`/`inject_comment`.
+pub fn inject_saved_markers(base: &[u8], markers: &[SavedMarker]) -> Vec<u8> {
+    if markers.is_empty() {
+        return base.to_vec();
+    }
+
+    // Find insertion point after APP0 JFIF marker (SOI + APP0)
+    let insert_pos: usize = if base.len() >= 4 && base[2] == 0xFF && base[3] == 0xE0 {
+        let app0_len: usize = u16::from_be_bytes([base[4], base[5]]) as usize;
+        2 + 2 + app0_len
+    } else {
+        2
+    };
+
+    let extra: usize = markers.iter().map(|m| m.data.len() + 4).sum();
+    let mut out: Vec<u8> = Vec::with_capacity(base.len() + extra);
+    out.extend_from_slice(&base[..insert_pos]);
+    for marker in markers {
+        marker_writer::write_marker(&mut out, marker.code, &marker.data);
+    }
     out.extend_from_slice(&base[insert_pos..]);
     out
 }

--- a/tests/marker_preservation.rs
+++ b/tests/marker_preservation.rs
@@ -1,0 +1,246 @@
+use libjpeg_turbo_rs::{
+    compress, decompress, Encoder, PixelFormat, SavedMarker, Subsampling, TransformOp,
+    TransformOptions,
+};
+
+/// Helper: create a small test JPEG with custom markers embedded.
+fn make_jpeg_with_markers() -> Vec<u8> {
+    let pixels: Vec<u8> = vec![128u8; 16 * 16 * 3];
+    let mut encoder = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb);
+    encoder = encoder.quality(75);
+    encoder = encoder.saved_marker(SavedMarker {
+        code: 0xE3,
+        data: b"CustomAPP3Data".to_vec(),
+    });
+    encoder = encoder.saved_marker(SavedMarker {
+        code: 0xE5,
+        data: b"APP5-payload".to_vec(),
+    });
+    encoder = encoder.saved_marker(SavedMarker {
+        code: 0xFE,
+        data: b"saved-comment".to_vec(),
+    });
+    encoder.encode().unwrap()
+}
+
+#[allow(dead_code)]
+fn make_basic_jpeg() -> Vec<u8> {
+    let pixels: Vec<u8> = vec![128u8; 16 * 16 * 3];
+    compress(&pixels, 16, 16, PixelFormat::Rgb, 75, Subsampling::S444).unwrap()
+}
+
+#[test]
+fn roundtrip_saved_markers_through_encode_decode() {
+    let jpeg: Vec<u8> = make_jpeg_with_markers();
+    let mut decoder = libjpeg_turbo_rs::decode::pipeline::Decoder::new(&jpeg).unwrap();
+    decoder.save_markers(libjpeg_turbo_rs::MarkerSaveConfig::All);
+    let image = decoder.decode_image().unwrap();
+
+    let app3_markers: Vec<&SavedMarker> = image
+        .saved_markers
+        .iter()
+        .filter(|m| m.code == 0xE3)
+        .collect();
+    assert!(!app3_markers.is_empty(), "expected APP3 marker to be saved");
+    assert_eq!(app3_markers[0].data, b"CustomAPP3Data");
+
+    let app5_markers: Vec<&SavedMarker> = image
+        .saved_markers
+        .iter()
+        .filter(|m| m.code == 0xE5)
+        .collect();
+    assert!(!app5_markers.is_empty(), "expected APP5 marker to be saved");
+    assert_eq!(app5_markers[0].data, b"APP5-payload");
+}
+
+#[test]
+fn roundtrip_com_marker_via_saved_markers() {
+    let jpeg: Vec<u8> = make_jpeg_with_markers();
+    let mut decoder = libjpeg_turbo_rs::decode::pipeline::Decoder::new(&jpeg).unwrap();
+    decoder.save_markers(libjpeg_turbo_rs::MarkerSaveConfig::All);
+    let image = decoder.decode_image().unwrap();
+
+    let com_markers: Vec<&SavedMarker> = image
+        .saved_markers
+        .iter()
+        .filter(|m| m.code == 0xFE)
+        .collect();
+    assert!(
+        !com_markers.is_empty(),
+        "expected COM marker in saved_markers"
+    );
+    assert_eq!(com_markers[0].data, b"saved-comment");
+}
+
+#[test]
+fn default_decoder_does_not_save_unknown_app_markers() {
+    let jpeg: Vec<u8> = make_jpeg_with_markers();
+    let image = decompress(&jpeg).unwrap();
+
+    let app3_markers: Vec<&SavedMarker> = image
+        .saved_markers
+        .iter()
+        .filter(|m| m.code == 0xE3)
+        .collect();
+    assert!(
+        app3_markers.is_empty(),
+        "default decoder should not save APP3 markers"
+    );
+}
+
+#[test]
+fn save_specific_marker_type_only() {
+    let jpeg: Vec<u8> = make_jpeg_with_markers();
+    let mut decoder = libjpeg_turbo_rs::decode::pipeline::Decoder::new(&jpeg).unwrap();
+    decoder.save_markers(libjpeg_turbo_rs::MarkerSaveConfig::Specific(vec![0xE3]));
+    let image = decoder.decode_image().unwrap();
+
+    let app3: Vec<&SavedMarker> = image
+        .saved_markers
+        .iter()
+        .filter(|m| m.code == 0xE3)
+        .collect();
+    assert!(!app3.is_empty(), "APP3 should be saved");
+
+    let app5: Vec<&SavedMarker> = image
+        .saved_markers
+        .iter()
+        .filter(|m| m.code == 0xE5)
+        .collect();
+    assert!(app5.is_empty(), "APP5 should not be saved");
+}
+
+#[test]
+fn image_markers_accessor_returns_saved_markers() {
+    let jpeg: Vec<u8> = make_jpeg_with_markers();
+    let mut decoder = libjpeg_turbo_rs::decode::pipeline::Decoder::new(&jpeg).unwrap();
+    decoder.save_markers(libjpeg_turbo_rs::MarkerSaveConfig::All);
+    let image = decoder.decode_image().unwrap();
+
+    let markers: &[SavedMarker] = image.markers();
+    assert!(
+        markers.iter().any(|m| m.code == 0xE3),
+        "markers() should contain APP3"
+    );
+    assert!(
+        markers.iter().any(|m| m.code == 0xE5),
+        "markers() should contain APP5"
+    );
+}
+
+#[test]
+fn transform_with_copy_markers_preserves_markers() {
+    let jpeg: Vec<u8> = make_jpeg_with_markers();
+    let options = TransformOptions {
+        op: TransformOp::HFlip,
+        copy_markers: true,
+        ..TransformOptions::default()
+    };
+
+    let result: Vec<u8> = libjpeg_turbo_rs::transform_jpeg_with_options(&jpeg, &options).unwrap();
+
+    let mut decoder = libjpeg_turbo_rs::decode::pipeline::Decoder::new(&result).unwrap();
+    decoder.save_markers(libjpeg_turbo_rs::MarkerSaveConfig::All);
+    let image = decoder.decode_image().unwrap();
+
+    let app3: Vec<&SavedMarker> = image
+        .saved_markers
+        .iter()
+        .filter(|m| m.code == 0xE3)
+        .collect();
+    assert!(!app3.is_empty(), "copy_markers=true should preserve APP3");
+    assert_eq!(app3[0].data, b"CustomAPP3Data");
+
+    let app5: Vec<&SavedMarker> = image
+        .saved_markers
+        .iter()
+        .filter(|m| m.code == 0xE5)
+        .collect();
+    assert!(!app5.is_empty(), "copy_markers=true should preserve APP5");
+    assert_eq!(app5[0].data, b"APP5-payload");
+}
+
+#[test]
+fn transform_with_copy_markers_false_strips_markers() {
+    let jpeg: Vec<u8> = make_jpeg_with_markers();
+    let options = TransformOptions {
+        op: TransformOp::HFlip,
+        copy_markers: false,
+        ..TransformOptions::default()
+    };
+
+    let result: Vec<u8> = libjpeg_turbo_rs::transform_jpeg_with_options(&jpeg, &options).unwrap();
+
+    let mut decoder = libjpeg_turbo_rs::decode::pipeline::Decoder::new(&result).unwrap();
+    decoder.save_markers(libjpeg_turbo_rs::MarkerSaveConfig::All);
+    let image = decoder.decode_image().unwrap();
+
+    let custom_markers: Vec<&SavedMarker> = image
+        .saved_markers
+        .iter()
+        .filter(|m| m.code == 0xE3 || m.code == 0xE5 || m.code == 0xFE)
+        .collect();
+    assert!(
+        custom_markers.is_empty(),
+        "copy_markers=false should strip all APP/COM markers"
+    );
+}
+
+#[test]
+fn save_app_markers_only_excludes_com() {
+    let jpeg: Vec<u8> = make_jpeg_with_markers();
+    let mut decoder = libjpeg_turbo_rs::decode::pipeline::Decoder::new(&jpeg).unwrap();
+    decoder.save_markers(libjpeg_turbo_rs::MarkerSaveConfig::AppOnly);
+    let image = decoder.decode_image().unwrap();
+
+    let app3: Vec<&SavedMarker> = image
+        .saved_markers
+        .iter()
+        .filter(|m| m.code == 0xE3)
+        .collect();
+    assert!(!app3.is_empty(), "APP3 should be saved with AppOnly config");
+
+    let com: Vec<&SavedMarker> = image
+        .saved_markers
+        .iter()
+        .filter(|m| m.code == 0xFE)
+        .collect();
+    assert!(
+        com.is_empty(),
+        "COM should not be saved with AppOnly config"
+    );
+}
+
+#[test]
+fn multiple_markers_same_type_all_preserved() {
+    let pixels: Vec<u8> = vec![128u8; 16 * 16 * 3];
+    let mut encoder = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb);
+    encoder = encoder.quality(75);
+    encoder = encoder.saved_marker(SavedMarker {
+        code: 0xE4,
+        data: b"first".to_vec(),
+    });
+    encoder = encoder.saved_marker(SavedMarker {
+        code: 0xE4,
+        data: b"second".to_vec(),
+    });
+    encoder = encoder.saved_marker(SavedMarker {
+        code: 0xE4,
+        data: b"third".to_vec(),
+    });
+    let jpeg = encoder.encode().unwrap();
+
+    let mut decoder = libjpeg_turbo_rs::decode::pipeline::Decoder::new(&jpeg).unwrap();
+    decoder.save_markers(libjpeg_turbo_rs::MarkerSaveConfig::All);
+    let image = decoder.decode_image().unwrap();
+
+    let app4: Vec<&SavedMarker> = image
+        .saved_markers
+        .iter()
+        .filter(|m| m.code == 0xE4)
+        .collect();
+    assert_eq!(app4.len(), 3, "all three APP4 markers should be preserved");
+    assert_eq!(app4[0].data, b"first");
+    assert_eq!(app4[1].data, b"second");
+    assert_eq!(app4[2].data, b"third");
+}


### PR DESCRIPTION
## Summary
- Add `MarkerSaveConfig` enum and `Decoder::save_markers()` for configurable marker saving during decode, matching libjpeg-turbo's `jpeg_save_markers()` / `TJPARAM_SAVEMARKERS`
- Add `Encoder::saved_marker()` builder method for injecting custom APP/COM markers into encoded output
- Implement marker copy through `transform_jpeg_with_options()` when `copy_markers=true` (default), and strip when `false` (`TJXOPT_COPYNONE`)
- Add `Image::markers()` accessor for saved markers

## Test plan
- [x] Roundtrip: encode with custom markers -> decode with `save_markers(All)` -> verify markers present
- [x] COM marker roundtrip via `saved_markers`
- [x] Default decoder does NOT save unknown APP markers
- [x] Save specific marker types only (`Specific(vec![0xE3])`)
- [x] `Image::markers()` accessor returns saved markers
- [x] Transform with `copy_markers=true` preserves markers
- [x] Transform with `copy_markers=false` strips markers
- [x] `AppOnly` config saves APP markers but excludes COM
- [x] Multiple markers of the same type are all preserved in order
- [x] All existing tests pass (full suite green)

Related: Phase 6 task #19 from FEATURE_PARITY.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)