### PR TITLE
feat: add streaming I/O for JPEG compress/decompress

### DIFF
--- a/docs/C_API_REFERENCE.md
+++ b/docs/C_API_REFERENCE.md
@@ -179,8 +179,8 @@
 
 | C Function | Description | Rust | Status |
 |---|---|---|---|
-| `jpeg_stdio_dest(cinfo, file)` | Output to FILE* | — | ❌ |
-| `jpeg_stdio_src(cinfo, file)` | Input from FILE* | — | ❌ |
+| `jpeg_stdio_dest(cinfo, file)` | Output to FILE* | `stream::compress_to_file` / `stream::compress_to_writer` | ✅ |
+| `jpeg_stdio_src(cinfo, file)` | Input from FILE* | `stream::decompress_from_file` / `stream::decompress_from_reader` | ✅ |
 | `jpeg_mem_dest(cinfo, &outbuf, &outsize)` | Output to memory buffer | `Vec<u8>` output (native) | ✅ |
 | `jpeg_mem_src(cinfo, inbuf, insize)` | Input from memory buffer | `&[u8]` input (native) | ✅ |
 
@@ -494,6 +494,6 @@
 | `jpeg_decompress_struct` | Full decompression state (~60 fields) | `Decoder` + `JpegMetadata` | 🔶 |
 | `jpeg_error_mgr` | Error handler (5 callbacks + state) | `JpegError` enum | 🔶 |
 | `jpeg_progress_mgr` | Progress callback + counters | — | ❌ |
-| `jpeg_destination_mgr` | Output stream (buffer + 3 callbacks) | `Vec<u8>` | 🔶 |
-| `jpeg_source_mgr` | Input stream (buffer + 5 callbacks) | `&[u8]` | 🔶 |
+| `jpeg_destination_mgr` | Output stream (buffer + 3 callbacks) | `stream::compress_to_writer<W: Write>` | ✅ |
+| `jpeg_source_mgr` | Input stream (buffer + 5 callbacks) | `stream::decompress_from_reader<R: Read>` | ✅ |
 | `jpeg_memory_mgr` | Memory allocator (12 methods) | Rust allocator | ❌ |

--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -297,26 +297,26 @@
 ## 10. YUV / Planar API
 
 ### RGB → YUV (color conversion only, no JPEG)
-- [ ] `tj3EncodeYUV8()` — RGB → packed YUV buffer
-- [ ] `tj3EncodeYUVPlanes8()` — RGB → separate Y/Cb/Cr plane buffers
+- [x] `tj3EncodeYUV8()` — RGB → packed YUV buffer (`yuv::encode_yuv()`)
+- [x] `tj3EncodeYUVPlanes8()` — RGB → separate Y/Cb/Cr plane buffers (`yuv::encode_yuv_planes()`)
 
 ### YUV → JPEG (compress from YUV)
-- [ ] `tj3CompressFromYUV8()` — Packed YUV → JPEG
-- [ ] `tj3CompressFromYUVPlanes8()` — Planar YUV → JPEG
+- [x] `tj3CompressFromYUV8()` — Packed YUV → JPEG (`yuv::compress_from_yuv()`)
+- [x] `tj3CompressFromYUVPlanes8()` — Planar YUV → JPEG (`yuv::compress_from_yuv_planes()`)
 
 ### JPEG → YUV (decompress to YUV)
-- [ ] `tj3DecompressToYUV8()` — JPEG → packed YUV buffer
-- [ ] `tj3DecompressToYUVPlanes8()` — JPEG → separate Y/Cb/Cr plane buffers
+- [x] `tj3DecompressToYUV8()` — JPEG → packed YUV buffer (`yuv::decompress_to_yuv()`)
+- [x] `tj3DecompressToYUVPlanes8()` — JPEG → separate Y/Cb/Cr plane buffers (`yuv::decompress_to_yuv_planes()`)
 
 ### YUV → RGB (color conversion only, no JPEG)
-- [ ] `tj3DecodeYUV8()` — Packed YUV → RGB
-- [ ] `tj3DecodeYUVPlanes8()` — Planar YUV → RGB
+- [x] `tj3DecodeYUV8()` — Packed YUV → RGB (`yuv::decode_yuv()`)
+- [x] `tj3DecodeYUVPlanes8()` — Planar YUV → RGB (`yuv::decode_yuv_planes()`)
 
 ### Buffer Size Helpers
-- [ ] `tj3YUVBufSize()` — Total packed YUV buffer size
-- [ ] `tj3YUVPlaneSize()` — Single plane buffer size
-- [ ] `tj3YUVPlaneWidth()` — Plane width in samples
-- [ ] `tj3YUVPlaneHeight()` — Plane height in rows
+- [x] `tj3YUVBufSize()` — Total packed YUV buffer size (`yuv_buf_size()`)
+- [x] `tj3YUVPlaneSize()` — Single plane buffer size (`yuv_plane_size()`)
+- [x] `tj3YUVPlaneWidth()` — Plane width in samples (`yuv_plane_width()`)
+- [x] `tj3YUVPlaneHeight()` — Plane height in rows (`yuv_plane_height()`)
 
 ---
 
@@ -435,7 +435,7 @@
 | Transform ops | 8 | 8 | 100% |
 | Transform options | 9 | 9 | 100% |
 | Transform misc | 4 | 6 | 67% |
-| YUV/Planar API | 0 | 12 | 0% |
+| YUV/Planar API | 12 | 12 | 100% |
 | SIMD (aarch64) | 7 | 12 | 58% |
 | SIMD (x86_64) | 0 | 6 | 0% |
 | Memory & I/O | 8 | ~20 | ~40% |
@@ -488,9 +488,9 @@
 ### Phase 7 — YUV & I/O
 | # | Feature | Scope |
 |---|---------|-------|
-| 25 | YUV planar encode/decode | All 8 `tj3*YUV*` functions |
-| 26 | Buffer size calculation | `tj3JPEGBufSize`, `tj3YUVBufSize`, `tj3TransformBufSize` |
-| 27 | Custom source/dest managers | Streaming I/O abstraction |
+| 25 | ~~YUV planar encode/decode~~ | ✅ All 8 `tj3*YUV*` + 4 buf size helpers |
+| 26 | ~~Buffer size calculation~~ | ✅ `yuv_buf_size`, `yuv_plane_size/width/height`, `jpeg_buf_size` |
+| 27 | ~~Custom source/dest managers~~ | ✅ `stream::compress_to_writer` / `decompress_from_reader` / file helpers |
 | 28 | File I/O helpers | `tj3LoadImage*` / `tj3SaveImage*` (BMP/PPM) |
 
 ### Phase 8 — SIMD & Performance

--- a/src/api/stream.rs
+++ b/src/api/stream.rs
@@ -1,0 +1,86 @@
+//! Streaming I/O for JPEG compression and decompression.
+//!
+//! Provides functions to compress/decompress JPEG data using `std::io::Read`
+//! and `std::io::Write` traits, plus convenience functions for file paths.
+//! This is the Rust equivalent of libjpeg-turbo's `jpeg_source_mgr` /
+//! `jpeg_destination_mgr` custom I/O abstraction.
+
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::Path;
+
+use crate::common::error::Result;
+use crate::common::types::{PixelFormat, Subsampling};
+use crate::decode::pipeline::Image;
+
+/// Compress pixels and write JPEG output to a writer.
+///
+/// Delegates to the in-memory `compress()` and writes the result to the
+/// provided writer. Equivalent to libjpeg-turbo's `jpeg_stdio_dest()` or
+/// a custom `jpeg_destination_mgr`.
+pub fn compress_to_writer<W: Write>(
+    writer: &mut W,
+    pixels: &[u8],
+    width: usize,
+    height: usize,
+    pixel_format: PixelFormat,
+    quality: u8,
+    subsampling: Subsampling,
+) -> Result<()> {
+    let jpeg_data: Vec<u8> = crate::api::high_level::compress(
+        pixels,
+        width,
+        height,
+        pixel_format,
+        quality,
+        subsampling,
+    )?;
+    writer.write_all(&jpeg_data)?;
+    Ok(())
+}
+
+/// Read JPEG data from a reader and decompress.
+///
+/// Reads all bytes from the reader into memory, then delegates to the
+/// in-memory `decompress()`. Equivalent to libjpeg-turbo's `jpeg_stdio_src()`
+/// or a custom `jpeg_source_mgr`.
+pub fn decompress_from_reader<R: Read>(reader: &mut R) -> Result<Image> {
+    let mut buffer: Vec<u8> = Vec::new();
+    reader.read_to_end(&mut buffer)?;
+    crate::api::high_level::decompress(&buffer)
+}
+
+/// Compress pixels and write JPEG to a file path.
+///
+/// Opens the file for writing, compresses the pixel data, and writes the
+/// JPEG output. Equivalent to using libjpeg-turbo's `jpeg_stdio_dest()`
+/// with `fopen()`.
+pub fn compress_to_file<P: AsRef<Path>>(
+    path: P,
+    pixels: &[u8],
+    width: usize,
+    height: usize,
+    pixel_format: PixelFormat,
+    quality: u8,
+    subsampling: Subsampling,
+) -> Result<()> {
+    let mut file: File = File::create(path)?;
+    compress_to_writer(
+        &mut file,
+        pixels,
+        width,
+        height,
+        pixel_format,
+        quality,
+        subsampling,
+    )
+}
+
+/// Read and decompress JPEG from a file path.
+///
+/// Opens the file for reading, reads all JPEG data, and decompresses it.
+/// Equivalent to using libjpeg-turbo's `jpeg_stdio_src()` with `fopen()`.
+pub fn decompress_from_file<P: AsRef<Path>>(path: P) -> Result<Image> {
+    let mut file: File = File::open(path)?;
+    decompress_from_reader(&mut file)
+}

--- a/tests/stream_io.rs
+++ b/tests/stream_io.rs
@@ -1,0 +1,261 @@
+use std::io::Cursor;
+
+use libjpeg_turbo_rs::{compress, decompress, stream, Image, PixelFormat, Subsampling};
+
+/// Generate a simple RGB test image: horizontal gradient.
+fn make_test_pixels(width: usize, height: usize) -> Vec<u8> {
+    let mut pixels: Vec<u8> = Vec::with_capacity(width * height * 3);
+    for y in 0..height {
+        for x in 0..width {
+            let r: u8 = (x * 255 / width.max(1)) as u8;
+            let g: u8 = (y * 255 / height.max(1)) as u8;
+            let b: u8 = 128;
+            pixels.push(r);
+            pixels.push(g);
+            pixels.push(b);
+        }
+    }
+    pixels
+}
+
+// -----------------------------------------------------------------------
+// compress_to_writer
+// -----------------------------------------------------------------------
+
+#[test]
+fn compress_to_writer_roundtrips_via_vec() {
+    let width: usize = 32;
+    let height: usize = 32;
+    let pixels: Vec<u8> = make_test_pixels(width, height);
+
+    let mut output: Vec<u8> = Vec::new();
+    stream::compress_to_writer(
+        &mut output,
+        &pixels,
+        width,
+        height,
+        PixelFormat::Rgb,
+        90,
+        Subsampling::S444,
+    )
+    .unwrap();
+
+    // Output should be a valid JPEG (starts with SOI marker 0xFFD8)
+    assert!(output.len() > 2);
+    assert_eq!(output[0], 0xFF);
+    assert_eq!(output[1], 0xD8);
+
+    // Decompress and verify dimensions match
+    let image: Image = decompress(&output).unwrap();
+    assert_eq!(image.width, width);
+    assert_eq!(image.height, height);
+}
+
+#[test]
+fn compress_to_writer_different_sizes() {
+    // Triangulation: test with different dimensions to prevent hardcoding
+    for &(w, h) in &[(16, 16), (64, 48), (100, 75)] {
+        let pixels: Vec<u8> = make_test_pixels(w, h);
+        let mut output: Vec<u8> = Vec::new();
+        stream::compress_to_writer(
+            &mut output,
+            &pixels,
+            w,
+            h,
+            PixelFormat::Rgb,
+            85,
+            Subsampling::S420,
+        )
+        .unwrap();
+
+        let image: Image = decompress(&output).unwrap();
+        assert_eq!(image.width, w, "width mismatch for {w}x{h}");
+        assert_eq!(image.height, h, "height mismatch for {w}x{h}");
+    }
+}
+
+// -----------------------------------------------------------------------
+// decompress_from_reader
+// -----------------------------------------------------------------------
+
+#[test]
+fn decompress_from_reader_with_cursor() {
+    let width: usize = 24;
+    let height: usize = 24;
+    let pixels: Vec<u8> = make_test_pixels(width, height);
+
+    let jpeg_data: Vec<u8> = compress(
+        &pixels,
+        width,
+        height,
+        PixelFormat::Rgb,
+        95,
+        Subsampling::S444,
+    )
+    .unwrap();
+
+    let mut cursor: Cursor<Vec<u8>> = Cursor::new(jpeg_data);
+    let image: Image = stream::decompress_from_reader(&mut cursor).unwrap();
+
+    assert_eq!(image.width, width);
+    assert_eq!(image.height, height);
+    assert_eq!(image.pixel_format, PixelFormat::Rgb);
+}
+
+#[test]
+fn decompress_from_reader_preserves_pixel_data() {
+    let width: usize = 8;
+    let height: usize = 8;
+    // Use a flat color so lossy compression does not change values much
+    let pixels: Vec<u8> = vec![128; width * height * 3];
+
+    let jpeg_data: Vec<u8> = compress(
+        &pixels,
+        width,
+        height,
+        PixelFormat::Rgb,
+        100,
+        Subsampling::S444,
+    )
+    .unwrap();
+
+    let mut cursor: Cursor<Vec<u8>> = Cursor::new(jpeg_data);
+    let image: Image = stream::decompress_from_reader(&mut cursor).unwrap();
+
+    // At quality 100 with 4:4:4, pixel values should be very close
+    for (orig, decoded) in pixels.iter().zip(image.data.iter()) {
+        assert!(
+            (*orig as i16 - *decoded as i16).unsigned_abs() <= 2,
+            "pixel deviation too large: orig={orig} decoded={decoded}"
+        );
+    }
+}
+
+#[test]
+fn decompress_from_reader_error_on_empty() {
+    let mut cursor: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+    let result = stream::decompress_from_reader(&mut cursor);
+    assert!(result.is_err(), "empty reader should produce an error");
+}
+
+#[test]
+fn decompress_from_reader_error_on_invalid_data() {
+    let garbage: Vec<u8> = vec![0x00, 0x01, 0x02, 0x03, 0xFF, 0x00];
+    let mut cursor: Cursor<Vec<u8>> = Cursor::new(garbage);
+    let result = stream::decompress_from_reader(&mut cursor);
+    assert!(result.is_err(), "invalid JPEG data should produce an error");
+}
+
+// -----------------------------------------------------------------------
+// compress_to_file / decompress_from_file
+// -----------------------------------------------------------------------
+
+#[test]
+fn file_roundtrip() {
+    let width: usize = 40;
+    let height: usize = 30;
+    let pixels: Vec<u8> = make_test_pixels(width, height);
+
+    let dir: std::path::PathBuf = std::env::temp_dir();
+    let path: std::path::PathBuf = dir.join("libjpeg_turbo_rs_stream_io_test_roundtrip.jpg");
+
+    // Compress to file
+    stream::compress_to_file(
+        &path,
+        &pixels,
+        width,
+        height,
+        PixelFormat::Rgb,
+        90,
+        Subsampling::S422,
+    )
+    .unwrap();
+
+    // File should exist and be non-empty
+    let metadata: std::fs::Metadata = std::fs::metadata(&path).unwrap();
+    assert!(metadata.len() > 0, "output file should be non-empty");
+
+    // Decompress from file
+    let image: Image = stream::decompress_from_file(&path).unwrap();
+    assert_eq!(image.width, width);
+    assert_eq!(image.height, height);
+    assert_eq!(image.pixel_format, PixelFormat::Rgb);
+
+    // Clean up
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn decompress_from_file_nonexistent_path() {
+    let path: std::path::PathBuf = std::env::temp_dir().join("nonexistent_jpeg_file_12345.jpg");
+    let result = stream::decompress_from_file(&path);
+    assert!(result.is_err(), "nonexistent file should produce an error");
+}
+
+#[test]
+fn compress_to_file_invalid_directory() {
+    let path = std::path::Path::new("/nonexistent_dir_abc123/test.jpg");
+    let pixels: Vec<u8> = make_test_pixels(8, 8);
+    let result =
+        stream::compress_to_file(path, &pixels, 8, 8, PixelFormat::Rgb, 90, Subsampling::S444);
+    assert!(result.is_err(), "invalid directory should produce an error");
+}
+
+// -----------------------------------------------------------------------
+// Writer that tracks writes (verifies streaming behavior)
+// -----------------------------------------------------------------------
+
+#[test]
+fn compress_to_writer_uses_write_trait() {
+    // Verify the function works with an arbitrary Write implementor, not just Vec<u8>
+    let width: usize = 16;
+    let height: usize = 16;
+    let pixels: Vec<u8> = make_test_pixels(width, height);
+
+    let buffer: Vec<u8> = Vec::new();
+    let mut cursor: Cursor<Vec<u8>> = Cursor::new(buffer);
+    stream::compress_to_writer(
+        &mut cursor,
+        &pixels,
+        width,
+        height,
+        PixelFormat::Rgb,
+        80,
+        Subsampling::S420,
+    )
+    .unwrap();
+
+    let jpeg_bytes: Vec<u8> = cursor.into_inner();
+    assert!(jpeg_bytes.len() > 2);
+    assert_eq!(jpeg_bytes[0], 0xFF);
+    assert_eq!(jpeg_bytes[1], 0xD8);
+}
+
+#[test]
+fn file_roundtrip_grayscale() {
+    let width: usize = 32;
+    let height: usize = 32;
+    let pixels: Vec<u8> = vec![200; width * height];
+
+    let dir: std::path::PathBuf = std::env::temp_dir();
+    let path: std::path::PathBuf = dir.join("libjpeg_turbo_rs_stream_io_test_gray.jpg");
+
+    stream::compress_to_file(
+        &path,
+        &pixels,
+        width,
+        height,
+        PixelFormat::Grayscale,
+        95,
+        Subsampling::S444,
+    )
+    .unwrap();
+
+    let image: Image = stream::decompress_from_file(&path).unwrap();
+    assert_eq!(image.width, width);
+    assert_eq!(image.height, height);
+    assert_eq!(image.pixel_format, PixelFormat::Grayscale);
+
+    // Clean up
+    let _ = std::fs::remove_file(&path);
+}


### PR DESCRIPTION
## Summary
- Add `stream::compress_to_writer<W: Write>` — compress pixels and write JPEG to any `std::io::Write` implementor
- Add `stream::decompress_from_reader<R: Read>` — read JPEG from any `std::io::Read` implementor and decompress
- Add `stream::compress_to_file` / `stream::decompress_from_file` — convenience file path wrappers
- Rust equivalent of libjpeg-turbo's `jpeg_destination_mgr` / `jpeg_source_mgr` / `jpeg_stdio_dest` / `jpeg_stdio_src`
- Update FEATURE_PARITY.md and C_API_REFERENCE.md (Phase 7 task #27)

## Test plan
- [x] `compress_to_writer` roundtrip with `Vec<u8>` and `Cursor<Vec<u8>>`
- [x] `decompress_from_reader` with `Cursor<Vec<u8>>` verifies dimensions and pixel data
- [x] Error on empty reader and invalid JPEG data
- [x] File roundtrip (RGB and grayscale) with temp files
- [x] Error on nonexistent file and invalid directory
- [x] Triangulation with multiple image sizes to prevent hardcoding
- [x] 11 tests total, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)