### PR TITLE
feat: implement 12-bit and 16-bit sample precision

### DIFF
--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -28,8 +28,8 @@
 ## 2. Sample Precision
 
 - [x] 8-bit (`JSAMPLE` / `u8`)
-- [ ] 12-bit (`J12SAMPLE` / `i16`) — `tj3Compress12`, `tj3Decompress12`, `jpeg12_write_scanlines`, `jpeg12_read_scanlines`
-- [ ] 16-bit (`J16SAMPLE` / `u16`, lossless only) — `tj3Compress16`, `tj3Decompress16`, `jpeg16_write_scanlines`, `jpeg16_read_scanlines`
+- [x] 12-bit (`J12SAMPLE` / `i16`) — `tj3Compress12`, `tj3Decompress12`, `jpeg12_write_scanlines`, `jpeg12_read_scanlines`
+- [x] 16-bit (`J16SAMPLE` / `u16`, lossless only) — `tj3Compress16`, `tj3Decompress16`, `jpeg16_write_scanlines`, `jpeg16_read_scanlines`
 
 ---
 
@@ -425,7 +425,7 @@
 |----------|------|-------|---|
 | Frame types (encode) | 6 | 6 | 100% |
 | Frame types (decode) | 6 | 6 | 100% |
-| Sample precision | 1 | 3 | 33% |
+| Sample precision | 3 | 3 | 100% |
 | Pixel formats | 13 | 13 | 100% |
 | Chroma subsampling | 7 | 8 | 88% |
 | Color spaces | 5 | 6 | 83% |
@@ -461,11 +461,11 @@
 | 7 | ~~Configurable DPI/density~~ | #17 |
 | 8 | ~~Arbitrary marker write~~ | #17 |
 
-### Phase 5 — Extended Formats (PARTIAL — 6/8 done)
+### Phase 5 — Extended Formats ✅ COMPLETE
 | # | Feature | Status |
 |---|---------|--------|
-| 9 | 12-bit precision | ⬜ Pending (Sample trait ready) |
-| 10 | 16-bit precision (lossless) | ⬜ Pending (Sample trait ready) |
+| 9 | 12-bit precision | ✅ |
+| 10 | 16-bit precision (lossless) | ✅ |
 | 11 | ~~Custom quantization tables~~ | ✅ #19 |
 | 12 | ~~Custom Huffman tables~~ | ✅ #23 |
 | 13 | ~~Custom progressive scan scripts~~ | ✅ #24 |

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,6 +2,7 @@ pub mod coefficient;
 pub mod encoder;
 pub mod high_level;
 pub mod image_io;
+pub mod precision;
 pub mod progressive_output;
 pub mod quantize;
 pub mod raw_data;

--- a/src/api/precision.rs
+++ b/src/api/precision.rs
@@ -1,0 +1,937 @@
+/// 12-bit and 16-bit sample precision support for JPEG encoding/decoding.
+///
+/// - 12-bit (J12SAMPLE / i16): DCT-based encode/decode with values 0-4095,
+///   used in medical imaging (DICOM).
+/// - 16-bit (J16SAMPLE / u16): lossless-only (SOF3) with values 0-65535.
+use crate::common::error::{JpegError, Result};
+use crate::common::types::Subsampling;
+use crate::decode::bitstream::BitReader;
+use crate::decode::huffman;
+use crate::decode::lossless;
+use crate::decode::marker::MarkerReader;
+use crate::encode::huffman_encode::{build_huff_table, BitWriter, HuffmanEncoder};
+use crate::encode::marker_writer;
+use crate::encode::quant;
+use crate::encode::tables;
+
+/// Decoded 12-bit JPEG image.
+#[derive(Debug)]
+pub struct Image12 {
+    /// Pixel data as 12-bit samples (0-4095).
+    pub data: Vec<i16>,
+    pub width: usize,
+    pub height: usize,
+    pub num_components: usize,
+}
+
+/// Decoded 16-bit JPEG image.
+#[derive(Debug)]
+pub struct Image16 {
+    /// Pixel data as 16-bit samples (0-65535).
+    pub data: Vec<u16>,
+    pub width: usize,
+    pub height: usize,
+    pub num_components: usize,
+}
+
+// ============================================================
+// Extended DC Huffman tables for 16-bit lossless (categories 0-16)
+// ============================================================
+
+/// Extended DC luminance Huffman table bits (categories 0-16).
+/// bits[1..16] = 0,1,5,1,1,1,1,1,1,1,1,1,1,1,0,0 => sum=17
+static DC_LUMA_EXT_BITS: [u8; 17] = [0, 0, 1, 5, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0];
+
+/// Extended DC luminance Huffman table values (categories 0-16).
+static DC_LUMA_EXT_VALUES: [u8; 17] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+
+/// Extended DC chrominance Huffman table bits (categories 0-16).
+/// Same structure as luminance extended: sum=17
+static DC_CHROMA_EXT_BITS: [u8; 17] = [0, 0, 1, 5, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0];
+
+/// Extended DC chrominance Huffman table values (categories 0-16).
+static DC_CHROMA_EXT_VALUES: [u8; 17] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+
+// ============================================================
+// 12-bit FDCT with PASS1_BITS=1 to avoid i32 overflow
+// ============================================================
+
+const FDCT12_CONST_BITS: i32 = 13;
+const FDCT12_PASS1_BITS: i32 = 1;
+const FDCT12_FIX_0_298631336: i32 = 2446;
+const FDCT12_FIX_0_390180644: i32 = 3196;
+const FDCT12_FIX_0_541196100: i32 = 4433;
+const FDCT12_FIX_0_765366865: i32 = 6270;
+const FDCT12_FIX_0_899976223: i32 = 7373;
+const FDCT12_FIX_1_175875602: i32 = 9633;
+const FDCT12_FIX_1_501321110: i32 = 12299;
+const FDCT12_FIX_1_847759065: i32 = 15137;
+const FDCT12_FIX_1_961570560: i32 = 16069;
+const FDCT12_FIX_2_053119869: i32 = 16819;
+const FDCT12_FIX_2_562915447: i32 = 20995;
+const FDCT12_FIX_3_072711026: i32 = 25172;
+
+#[inline(always)]
+fn descale(x: i32, n: i32) -> i32 {
+    (x + (1 << (n - 1))) >> n
+}
+
+/// Forward DCT for 12-bit samples (PASS1_BITS=1 to prevent i32 overflow).
+fn fdct_12bit(input: &[i16; 64], output: &mut [i32; 64]) {
+    let mut workspace: [i32; 64] = [0i32; 64];
+    for i in 0..64 {
+        workspace[i] = input[i] as i32;
+    }
+    for row in 0..8 {
+        let b: usize = row * 8;
+        let tmp0 = workspace[b] + workspace[b + 7];
+        let tmp7 = workspace[b] - workspace[b + 7];
+        let tmp1 = workspace[b + 1] + workspace[b + 6];
+        let tmp6 = workspace[b + 1] - workspace[b + 6];
+        let tmp2 = workspace[b + 2] + workspace[b + 5];
+        let tmp5 = workspace[b + 2] - workspace[b + 5];
+        let tmp3 = workspace[b + 3] + workspace[b + 4];
+        let tmp4 = workspace[b + 3] - workspace[b + 4];
+        let tmp10 = tmp0 + tmp3;
+        let tmp13 = tmp0 - tmp3;
+        let tmp11 = tmp1 + tmp2;
+        let tmp12 = tmp1 - tmp2;
+        workspace[b] = (tmp10 + tmp11) << FDCT12_PASS1_BITS;
+        workspace[b + 4] = (tmp10 - tmp11) << FDCT12_PASS1_BITS;
+        let z1 = (tmp12 + tmp13) * FDCT12_FIX_0_541196100;
+        workspace[b + 2] = descale(
+            z1 + tmp13 * FDCT12_FIX_0_765366865,
+            FDCT12_CONST_BITS - FDCT12_PASS1_BITS,
+        );
+        workspace[b + 6] = descale(
+            z1 + tmp12 * (-FDCT12_FIX_1_847759065),
+            FDCT12_CONST_BITS - FDCT12_PASS1_BITS,
+        );
+        let z1 = tmp4 + tmp7;
+        let z2 = tmp5 + tmp6;
+        let z3 = tmp4 + tmp6;
+        let z4 = tmp5 + tmp7;
+        let z5 = (z3 + z4) * FDCT12_FIX_1_175875602;
+        let tmp4 = tmp4 * FDCT12_FIX_0_298631336;
+        let tmp5 = tmp5 * FDCT12_FIX_2_053119869;
+        let tmp6 = tmp6 * FDCT12_FIX_3_072711026;
+        let tmp7 = tmp7 * FDCT12_FIX_1_501321110;
+        let z1 = z1 * (-FDCT12_FIX_0_899976223);
+        let z2 = z2 * (-FDCT12_FIX_2_562915447);
+        let z3 = z3 * (-FDCT12_FIX_1_961570560) + z5;
+        let z4 = z4 * (-FDCT12_FIX_0_390180644) + z5;
+        workspace[b + 7] = descale(tmp4 + z1 + z3, FDCT12_CONST_BITS - FDCT12_PASS1_BITS);
+        workspace[b + 5] = descale(tmp5 + z2 + z4, FDCT12_CONST_BITS - FDCT12_PASS1_BITS);
+        workspace[b + 3] = descale(tmp6 + z2 + z3, FDCT12_CONST_BITS - FDCT12_PASS1_BITS);
+        workspace[b + 1] = descale(tmp7 + z1 + z4, FDCT12_CONST_BITS - FDCT12_PASS1_BITS);
+    }
+    for col in 0..8 {
+        let tmp0 = workspace[col] + workspace[col + 56];
+        let tmp7 = workspace[col] - workspace[col + 56];
+        let tmp1 = workspace[col + 8] + workspace[col + 48];
+        let tmp6 = workspace[col + 8] - workspace[col + 48];
+        let tmp2 = workspace[col + 16] + workspace[col + 40];
+        let tmp5 = workspace[col + 16] - workspace[col + 40];
+        let tmp3 = workspace[col + 24] + workspace[col + 32];
+        let tmp4 = workspace[col + 24] - workspace[col + 32];
+        let tmp10 = tmp0 + tmp3;
+        let tmp13 = tmp0 - tmp3;
+        let tmp11 = tmp1 + tmp2;
+        let tmp12 = tmp1 - tmp2;
+        output[col] = descale(tmp10 + tmp11, FDCT12_PASS1_BITS);
+        output[col + 32] = descale(tmp10 - tmp11, FDCT12_PASS1_BITS);
+        let z1 = (tmp12 + tmp13) * FDCT12_FIX_0_541196100;
+        output[col + 16] = descale(
+            z1 + tmp13 * FDCT12_FIX_0_765366865,
+            FDCT12_CONST_BITS + FDCT12_PASS1_BITS,
+        );
+        output[col + 48] = descale(
+            z1 + tmp12 * (-FDCT12_FIX_1_847759065),
+            FDCT12_CONST_BITS + FDCT12_PASS1_BITS,
+        );
+        let z1 = tmp4 + tmp7;
+        let z2 = tmp5 + tmp6;
+        let z3 = tmp4 + tmp6;
+        let z4 = tmp5 + tmp7;
+        let z5 = (z3 + z4) * FDCT12_FIX_1_175875602;
+        let tmp4 = tmp4 * FDCT12_FIX_0_298631336;
+        let tmp5 = tmp5 * FDCT12_FIX_2_053119869;
+        let tmp6 = tmp6 * FDCT12_FIX_3_072711026;
+        let tmp7 = tmp7 * FDCT12_FIX_1_501321110;
+        let z1 = z1 * (-FDCT12_FIX_0_899976223);
+        let z2 = z2 * (-FDCT12_FIX_2_562915447);
+        let z3 = z3 * (-FDCT12_FIX_1_961570560) + z5;
+        let z4 = z4 * (-FDCT12_FIX_0_390180644) + z5;
+        output[col + 56] = descale(tmp4 + z1 + z3, FDCT12_CONST_BITS + FDCT12_PASS1_BITS);
+        output[col + 40] = descale(tmp5 + z2 + z4, FDCT12_CONST_BITS + FDCT12_PASS1_BITS);
+        output[col + 24] = descale(tmp6 + z2 + z3, FDCT12_CONST_BITS + FDCT12_PASS1_BITS);
+        output[col + 8] = descale(tmp7 + z1 + z4, FDCT12_CONST_BITS + FDCT12_PASS1_BITS);
+    }
+}
+
+// ============================================================
+// 12-bit compress
+// ============================================================
+
+/// Compress 12-bit sample data to JPEG.
+pub fn compress_12bit(
+    pixels: &[i16],
+    width: usize,
+    height: usize,
+    num_components: usize,
+    quality: u8,
+    subsampling: Subsampling,
+) -> Result<Vec<u8>> {
+    if width == 0 || height == 0 {
+        return Err(JpegError::CorruptData(
+            "image dimensions must be non-zero".to_string(),
+        ));
+    }
+    if num_components != 1 && num_components != 3 {
+        return Err(JpegError::Unsupported(format!(
+            "12-bit compression supports 1 or 3 components, got {}",
+            num_components
+        )));
+    }
+    let expected_len: usize = width * height * num_components;
+    if pixels.len() < expected_len {
+        return Err(JpegError::BufferTooSmall {
+            need: expected_len,
+            got: pixels.len(),
+        });
+    }
+    if num_components == 1 {
+        compress_12bit_grayscale(pixels, width, height, quality)
+    } else {
+        compress_12bit_color(pixels, width, height, quality, subsampling)
+    }
+}
+
+fn compress_12bit_grayscale(
+    pixels: &[i16],
+    width: usize,
+    height: usize,
+    quality: u8,
+) -> Result<Vec<u8>> {
+    let precision: u8 = 12;
+    let level_shift: i32 = 2048;
+    let luma_quant = tables::quality_scale_quant_table(&tables::STD_LUMINANCE_QUANT_TABLE, quality);
+    let luma_quant_12 = scale_quant_12bit(&luma_quant);
+    let luma_divisors = scale_quant_for_fdct(&luma_quant_12);
+    let dc_table = build_huff_table(&tables::DC_LUMINANCE_BITS, &tables::DC_LUMINANCE_VALUES);
+    let ac_table = build_huff_table(&tables::AC_LUMINANCE_BITS, &tables::AC_LUMINANCE_VALUES);
+    let mcus_x = (width + 7) / 8;
+    let mcus_y = (height + 7) / 8;
+    let mut bit_writer = BitWriter::new(width * height);
+    let mut prev_dc: i16 = 0;
+    for mcu_row in 0..mcus_y {
+        for mcu_col in 0..mcus_x {
+            let x0 = mcu_col * 8;
+            let y0 = mcu_row * 8;
+            let mut block = [0i16; 64];
+            extract_block_12bit(pixels, width, height, x0, y0, level_shift, &mut block);
+            let mut dct_output = [0i32; 64];
+            fdct_12bit(&block, &mut dct_output);
+            let mut quantized = [0i16; 64];
+            quant::quantize_block(&dct_output, &luma_divisors, &mut quantized);
+            for k in 1..64 {
+                quantized[k] = quantized[k].clamp(-1023, 1023);
+            }
+            HuffmanEncoder::encode_block(
+                &mut bit_writer,
+                &quantized,
+                &mut prev_dc,
+                &dc_table,
+                &ac_table,
+            );
+        }
+    }
+    bit_writer.flush();
+    let mut output = Vec::with_capacity(bit_writer.data().len() + 512);
+    marker_writer::write_soi(&mut output);
+    marker_writer::write_app0_jfif(&mut output);
+    marker_writer::write_dqt(&mut output, 0, &luma_quant_12);
+    write_sof0_precision(
+        &mut output,
+        width as u16,
+        height as u16,
+        precision,
+        &[(1, 1, 1, 0)],
+    );
+    marker_writer::write_dht(
+        &mut output,
+        0,
+        0,
+        &tables::DC_LUMINANCE_BITS,
+        &tables::DC_LUMINANCE_VALUES,
+    );
+    marker_writer::write_dht(
+        &mut output,
+        1,
+        0,
+        &tables::AC_LUMINANCE_BITS,
+        &tables::AC_LUMINANCE_VALUES,
+    );
+    marker_writer::write_sos(&mut output, &[(1, 0, 0)]);
+    output.extend_from_slice(bit_writer.data());
+    marker_writer::write_eoi(&mut output);
+    Ok(output)
+}
+
+fn compress_12bit_color(
+    pixels: &[i16],
+    width: usize,
+    height: usize,
+    quality: u8,
+    subsampling: Subsampling,
+) -> Result<Vec<u8>> {
+    let precision: u8 = 12;
+    let level_shift: i32 = 2048;
+    if subsampling != Subsampling::S444 {
+        return Err(JpegError::Unsupported(
+            "12-bit color only supports 4:4:4 subsampling".to_string(),
+        ));
+    }
+    let luma_quant = tables::quality_scale_quant_table(&tables::STD_LUMINANCE_QUANT_TABLE, quality);
+    let chroma_quant =
+        tables::quality_scale_quant_table(&tables::STD_CHROMINANCE_QUANT_TABLE, quality);
+    let luma_quant_12 = scale_quant_12bit(&luma_quant);
+    let chroma_quant_12 = scale_quant_12bit(&chroma_quant);
+    let luma_divisors = scale_quant_for_fdct(&luma_quant_12);
+    let chroma_divisors = scale_quant_for_fdct(&chroma_quant_12);
+    let dc_luma = build_huff_table(&tables::DC_LUMINANCE_BITS, &tables::DC_LUMINANCE_VALUES);
+    let ac_luma = build_huff_table(&tables::AC_LUMINANCE_BITS, &tables::AC_LUMINANCE_VALUES);
+    let dc_chroma = build_huff_table(&tables::DC_CHROMINANCE_BITS, &tables::DC_CHROMINANCE_VALUES);
+    let ac_chroma = build_huff_table(&tables::AC_CHROMINANCE_BITS, &tables::AC_CHROMINANCE_VALUES);
+    let num_pixels = width * height;
+    let mut comp_planes: Vec<Vec<i16>> = vec![vec![0i16; num_pixels]; 3];
+    for i in 0..num_pixels {
+        comp_planes[0][i] = pixels[i * 3].clamp(0, 4095);
+        comp_planes[1][i] = pixels[i * 3 + 1].clamp(0, 4095);
+        comp_planes[2][i] = pixels[i * 3 + 2].clamp(0, 4095);
+    }
+    let mcus_x = (width + 7) / 8;
+    let mcus_y = (height + 7) / 8;
+    let mut bit_writer = BitWriter::new(num_pixels * 3);
+    let mut prev_dc = [0i16; 3];
+    let dc_tables = [&dc_luma, &dc_chroma, &dc_chroma];
+    let ac_tables = [&ac_luma, &ac_chroma, &ac_chroma];
+    let divisors_list = [&luma_divisors, &chroma_divisors, &chroma_divisors];
+    for mcu_row in 0..mcus_y {
+        for mcu_col in 0..mcus_x {
+            let x0 = mcu_col * 8;
+            let y0 = mcu_row * 8;
+            for c in 0..3 {
+                let mut block = [0i16; 64];
+                extract_block_12bit(
+                    &comp_planes[c],
+                    width,
+                    height,
+                    x0,
+                    y0,
+                    level_shift,
+                    &mut block,
+                );
+                let mut dct_out = [0i32; 64];
+                fdct_12bit(&block, &mut dct_out);
+                let mut quantized = [0i16; 64];
+                quant::quantize_block(&dct_out, divisors_list[c], &mut quantized);
+                for k in 1..64 {
+                    quantized[k] = quantized[k].clamp(-1023, 1023);
+                }
+                HuffmanEncoder::encode_block(
+                    &mut bit_writer,
+                    &quantized,
+                    &mut prev_dc[c],
+                    dc_tables[c],
+                    ac_tables[c],
+                );
+            }
+        }
+    }
+    bit_writer.flush();
+    let mut output = Vec::with_capacity(bit_writer.data().len() + 1024);
+    marker_writer::write_soi(&mut output);
+    marker_writer::write_app0_jfif(&mut output);
+    marker_writer::write_dqt(&mut output, 0, &luma_quant_12);
+    marker_writer::write_dqt(&mut output, 1, &chroma_quant_12);
+    write_sof0_precision(
+        &mut output,
+        width as u16,
+        height as u16,
+        precision,
+        &[(1, 1, 1, 0), (2, 1, 1, 1), (3, 1, 1, 1)],
+    );
+    marker_writer::write_dht(
+        &mut output,
+        0,
+        0,
+        &tables::DC_LUMINANCE_BITS,
+        &tables::DC_LUMINANCE_VALUES,
+    );
+    marker_writer::write_dht(
+        &mut output,
+        1,
+        0,
+        &tables::AC_LUMINANCE_BITS,
+        &tables::AC_LUMINANCE_VALUES,
+    );
+    marker_writer::write_dht(
+        &mut output,
+        0,
+        1,
+        &tables::DC_CHROMINANCE_BITS,
+        &tables::DC_CHROMINANCE_VALUES,
+    );
+    marker_writer::write_dht(
+        &mut output,
+        1,
+        1,
+        &tables::AC_CHROMINANCE_BITS,
+        &tables::AC_CHROMINANCE_VALUES,
+    );
+    marker_writer::write_sos(&mut output, &[(1, 0, 0), (2, 1, 1), (3, 1, 1)]);
+    output.extend_from_slice(bit_writer.data());
+    marker_writer::write_eoi(&mut output);
+    Ok(output)
+}
+
+fn extract_block_12bit(
+    plane: &[i16],
+    width: usize,
+    height: usize,
+    bx: usize,
+    by: usize,
+    level_shift: i32,
+    block: &mut [i16; 64],
+) {
+    for row in 0..8 {
+        let sy = (by + row).min(height - 1);
+        for col in 0..8 {
+            let sx = (bx + col).min(width - 1);
+            block[row * 8 + col] =
+                (plane[sy * width + sx].clamp(0, 4095) as i32 - level_shift) as i16;
+        }
+    }
+}
+
+fn scale_quant_12bit(table: &[u16; 64]) -> [u16; 64] {
+    let mut r = [0u16; 64];
+    for i in 0..64 {
+        r[i] = (table[i] as u32 * 16).min(65535) as u16;
+    }
+    r
+}
+
+fn scale_quant_for_fdct(table: &[u16; 64]) -> [u16; 64] {
+    let mut r = [0u16; 64];
+    for i in 0..64 {
+        r[i] = (table[i] as u32 * 8).min(65535) as u16;
+    }
+    r
+}
+
+fn write_sof0_precision(
+    buf: &mut Vec<u8>,
+    width: u16,
+    height: u16,
+    precision: u8,
+    components: &[(u8, u8, u8, u8)],
+) {
+    buf.push(0xFF);
+    buf.push(0xC0);
+    let length: u16 = 2 + 1 + 2 + 2 + 1 + (components.len() as u16 * 3);
+    buf.extend_from_slice(&length.to_be_bytes());
+    buf.push(precision);
+    buf.extend_from_slice(&height.to_be_bytes());
+    buf.extend_from_slice(&width.to_be_bytes());
+    buf.push(components.len() as u8);
+    for &(id, h, v, qt) in components {
+        buf.push(id);
+        buf.push((h << 4) | v);
+        buf.push(qt);
+    }
+}
+
+// ============================================================
+// 12-bit decompress
+// ============================================================
+
+/// Decompress JPEG to 12-bit sample data.
+pub fn decompress_12bit(data: &[u8]) -> Result<Image12> {
+    let mut reader = MarkerReader::new(data);
+    let metadata = reader.read_markers()?;
+    let frame = &metadata.frame;
+    let width = frame.width as usize;
+    let height = frame.height as usize;
+    let num_components = frame.components.len();
+    if frame.precision != 12 {
+        return Err(JpegError::Unsupported(format!(
+            "decompress_12bit requires precision=12, got {}",
+            frame.precision
+        )));
+    }
+    if frame.is_lossless {
+        return Err(JpegError::Unsupported(
+            "decompress_12bit does not support lossless JPEG".to_string(),
+        ));
+    }
+    let quant_tables: Vec<&crate::common::quant_table::QuantTable> = frame
+        .components
+        .iter()
+        .map(|comp| {
+            metadata.quant_tables[comp.quant_table_index as usize]
+                .as_ref()
+                .ok_or_else(|| {
+                    JpegError::CorruptData(format!(
+                        "missing quant table {}",
+                        comp.quant_table_index
+                    ))
+                })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let scan = &metadata.scan;
+    let mut dc_tables = Vec::with_capacity(num_components);
+    let mut ac_tables = Vec::with_capacity(num_components);
+    for i in 0..scan.components.len().min(num_components) {
+        let di = scan.components[i].dc_table_index as usize;
+        let ai = scan.components[i].ac_table_index as usize;
+        dc_tables.push(
+            metadata.dc_huffman_tables[di]
+                .as_ref()
+                .ok_or_else(|| JpegError::CorruptData(format!("missing DC table {}", di)))?,
+        );
+        ac_tables.push(
+            metadata.ac_huffman_tables[ai]
+                .as_ref()
+                .ok_or_else(|| JpegError::CorruptData(format!("missing AC table {}", ai)))?,
+        );
+    }
+    let entropy_data = &data[metadata.entropy_data_offset..];
+    let mut bit_reader = BitReader::new(entropy_data);
+    let level_shift: i32 = 2048;
+    let mcus_x = (width + 7) / 8;
+    let mcus_y = (height + 7) / 8;
+    let fw = mcus_x * 8;
+    let fh = mcus_y * 8;
+    let mut planes: Vec<Vec<i16>> = vec![vec![0i16; fw * fh]; num_components];
+    let mut prev_dc = vec![0i16; num_components];
+    for mcu_row in 0..mcus_y {
+        for mcu_col in 0..mcus_x {
+            let bx = mcu_col * 8;
+            let by = mcu_row * 8;
+            for c in 0..num_components {
+                let mut block = [0i16; 64];
+                let dc_diff = huffman::decode_dc_coefficient(&mut bit_reader, dc_tables[c])?;
+                block[0] = prev_dc[c] + dc_diff;
+                prev_dc[c] = block[0];
+                huffman::decode_ac_coefficients(&mut bit_reader, ac_tables[c], &mut block)?;
+                // Dequantize: block is already in natural order from decode_ac_coefficients
+                let qt = quant_tables[c];
+                let mut deq_i16 = [0i16; 64];
+                for k in 0..64 {
+                    let val: i32 = block[k] as i32 * qt.values[k] as i32;
+                    deq_i16[k] = val.clamp(-32768, 32767) as i16;
+                }
+                let idct_out = crate::decode::idct::idct_8x8(&deq_i16);
+                for row in 0..8 {
+                    for col in 0..8 {
+                        let py = by + row;
+                        let px = bx + col;
+                        if py < fh && px < fw {
+                            let val = idct_out[row * 8 + col] as i32 + level_shift;
+                            planes[c][py * fw + px] = val.clamp(0, 4095) as i16;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let mut result = Vec::with_capacity(width * height * num_components);
+    for y in 0..height {
+        for x in 0..width {
+            for c in 0..num_components {
+                result.push(planes[c][y * fw + x]);
+            }
+        }
+    }
+    Ok(Image12 {
+        data: result,
+        width,
+        height,
+        num_components,
+    })
+}
+
+// ============================================================
+// 16-bit lossless compress
+// ============================================================
+
+/// Compress 16-bit sample data to lossless JPEG (SOF3).
+pub fn compress_16bit(
+    pixels: &[u16],
+    width: usize,
+    height: usize,
+    num_components: usize,
+    predictor: u8,
+    point_transform: u8,
+) -> Result<Vec<u8>> {
+    if predictor < 1 || predictor > 7 {
+        return Err(JpegError::Unsupported(format!(
+            "lossless predictor must be 1-7, got {}",
+            predictor
+        )));
+    }
+    if point_transform > 15 {
+        return Err(JpegError::Unsupported(format!(
+            "point transform must be 0-15, got {}",
+            point_transform
+        )));
+    }
+    if width == 0 || height == 0 {
+        return Err(JpegError::CorruptData(
+            "image dimensions must be non-zero".to_string(),
+        ));
+    }
+    if num_components != 1 && num_components != 3 {
+        return Err(JpegError::Unsupported(format!(
+            "16-bit supports 1 or 3 components, got {}",
+            num_components
+        )));
+    }
+    let expected = width * height * num_components;
+    if pixels.len() < expected {
+        return Err(JpegError::BufferTooSmall {
+            need: expected,
+            got: pixels.len(),
+        });
+    }
+    if num_components == 1 {
+        compress_16bit_gray(pixels, width, height, predictor, point_transform)
+    } else {
+        compress_16bit_multi(
+            pixels,
+            width,
+            height,
+            num_components,
+            predictor,
+            point_transform,
+        )
+    }
+}
+
+fn compress_16bit_gray(
+    pixels: &[u16],
+    width: usize,
+    height: usize,
+    predictor: u8,
+    pt: u8,
+) -> Result<Vec<u8>> {
+    let precision: u8 = 16;
+    let dc_table = build_huff_table(&DC_LUMA_EXT_BITS, &DC_LUMA_EXT_VALUES);
+    let mut bw = BitWriter::new(width * height * 2);
+    for y in 0..height {
+        for x in 0..width {
+            let diff = lossless_diff_16(
+                pixels[y * width + x] as i32,
+                x,
+                y,
+                pixels,
+                width,
+                predictor,
+                pt,
+                precision,
+            );
+            encode_dc_only_wide(&mut bw, diff, &dc_table);
+        }
+    }
+    bw.flush();
+    let mut out = Vec::with_capacity(bw.data().len() + 256);
+    marker_writer::write_soi(&mut out);
+    marker_writer::write_dht(&mut out, 0, 0, &DC_LUMA_EXT_BITS, &DC_LUMA_EXT_VALUES);
+    marker_writer::write_sof3(
+        &mut out,
+        width as u16,
+        height as u16,
+        precision,
+        &[(1, 1, 1, 0)],
+    );
+    marker_writer::write_sos_lossless(&mut out, &[(1, 0)], predictor, pt);
+    out.extend_from_slice(bw.data());
+    marker_writer::write_eoi(&mut out);
+    Ok(out)
+}
+
+fn compress_16bit_multi(
+    pixels: &[u16],
+    width: usize,
+    height: usize,
+    nc: usize,
+    predictor: u8,
+    pt: u8,
+) -> Result<Vec<u8>> {
+    let precision: u8 = 16;
+    let np = width * height;
+    let planes: Vec<Vec<u16>> = (0..nc)
+        .map(|c| (0..np).map(|i| pixels[i * nc + c]).collect())
+        .collect();
+    let dc_luma = build_huff_table(&DC_LUMA_EXT_BITS, &DC_LUMA_EXT_VALUES);
+    let dc_chroma = build_huff_table(&DC_CHROMA_EXT_BITS, &DC_CHROMA_EXT_VALUES);
+    let mut bw = BitWriter::new(np * nc * 2);
+    for y in 0..height {
+        for x in 0..width {
+            for c in 0..nc {
+                let diff = lossless_diff_16(
+                    planes[c][y * width + x] as i32,
+                    x,
+                    y,
+                    &planes[c],
+                    width,
+                    predictor,
+                    pt,
+                    precision,
+                );
+                let t = if c == 0 { &dc_luma } else { &dc_chroma };
+                encode_dc_only_wide(&mut bw, diff, t);
+            }
+        }
+    }
+    bw.flush();
+    let mut out = Vec::with_capacity(bw.data().len() + 512);
+    marker_writer::write_soi(&mut out);
+    marker_writer::write_dht(&mut out, 0, 0, &DC_LUMA_EXT_BITS, &DC_LUMA_EXT_VALUES);
+    marker_writer::write_dht(&mut out, 0, 1, &DC_CHROMA_EXT_BITS, &DC_CHROMA_EXT_VALUES);
+    let comps: Vec<(u8, u8, u8, u8)> = (0..nc).map(|c| (c as u8 + 1, 1, 1, 0)).collect();
+    marker_writer::write_sof3(&mut out, width as u16, height as u16, precision, &comps);
+    let sc: Vec<(u8, u8)> = (0..nc)
+        .map(|c| (c as u8 + 1, if c == 0 { 0 } else { 1 }))
+        .collect();
+    marker_writer::write_sos_lossless(&mut out, &sc, predictor, pt);
+    out.extend_from_slice(bw.data());
+    marker_writer::write_eoi(&mut out);
+    Ok(out)
+}
+
+fn lossless_diff_16(
+    pixel: i32,
+    x: usize,
+    y: usize,
+    plane: &[u16],
+    width: usize,
+    predictor: u8,
+    pt: u8,
+    precision: u8,
+) -> i32 {
+    let mask: i64 = (1i64 << precision as i64) - 1;
+    let initial = 1i32 << (precision as i32 - pt as i32 - 1);
+    let sample = pixel >> pt as i32;
+    let prediction = if y == 0 && x == 0 {
+        initial
+    } else if y == 0 {
+        (plane[y * width + x - 1] as i32) >> pt as i32
+    } else if x == 0 {
+        (plane[(y - 1) * width + x] as i32) >> pt as i32
+    } else {
+        let ra = (plane[y * width + x - 1] as i32) >> pt as i32;
+        let rb = (plane[(y - 1) * width + x] as i32) >> pt as i32;
+        let rc = (plane[(y - 1) * width + x - 1] as i32) >> pt as i32;
+        lossless::predict(predictor, ra, rb, rc)
+    };
+    let diff = (sample as i64 - prediction as i64) & mask;
+    let half = 1i64 << (precision - 1);
+    if diff >= half {
+        (diff - (1i64 << precision)) as i32
+    } else {
+        diff as i32
+    }
+}
+
+fn encode_dc_only_wide(
+    writer: &mut BitWriter,
+    diff: i32,
+    dc_table: &crate::encode::huffman_encode::HuffTable,
+) {
+    if diff == 0 {
+        writer.write_bits(dc_table.ehufco[0], dc_table.ehufsi[0]);
+        return;
+    }
+    let abs_diff = diff.unsigned_abs();
+    let category = 32 - abs_diff.leading_zeros() as u8;
+    writer.write_bits(
+        dc_table.ehufco[category as usize],
+        dc_table.ehufsi[category as usize],
+    );
+    let magnitude_bits: u16 = if diff > 0 {
+        diff as u16
+    } else {
+        (diff - 1) as u16
+    };
+    if category > 0 && category <= 16 {
+        writer.write_bits(magnitude_bits, category);
+    }
+}
+
+// ============================================================
+// 16-bit lossless decompress
+// ============================================================
+
+/// Decompress lossless JPEG to 16-bit sample data.
+pub fn decompress_16bit(data: &[u8]) -> Result<Image16> {
+    let mut reader = MarkerReader::new(data);
+    let metadata = reader.read_markers()?;
+    let frame = &metadata.frame;
+    let width = frame.width as usize;
+    let height = frame.height as usize;
+    let nc = frame.components.len();
+    if frame.precision != 16 {
+        return Err(JpegError::Unsupported(format!(
+            "decompress_16bit requires precision=16, got {}",
+            frame.precision
+        )));
+    }
+    if !frame.is_lossless {
+        return Err(JpegError::Unsupported(
+            "16-bit requires lossless JPEG".to_string(),
+        ));
+    }
+    let scan = &metadata.scan;
+    let psv = scan.spec_start;
+    let pt = scan.succ_low;
+    if psv < 1 || psv > 7 {
+        return Err(JpegError::Unsupported(format!(
+            "lossless predictor {} (must be 1-7)",
+            psv
+        )));
+    }
+    let mut dc_tables = Vec::with_capacity(nc);
+    for i in 0..scan.components.len().min(nc) {
+        let idx = scan.components[i].dc_table_index as usize;
+        dc_tables.push(
+            metadata.dc_huffman_tables[idx]
+                .as_ref()
+                .ok_or_else(|| JpegError::CorruptData(format!("missing DC table {}", idx)))?,
+        );
+    }
+    let entropy = &data[metadata.entropy_data_offset..];
+    let mut br = BitReader::new(entropy);
+    if nc == 1 {
+        let mut output = vec![0u16; width * height];
+        let mut prev_row: Option<Vec<u16>> = None;
+        for y in 0..height {
+            let rs = y * width;
+            let mut diffs = Vec::with_capacity(width);
+            for _ in 0..width {
+                diffs.push(decode_dc_wide(&mut br, dc_tables[0])?);
+            }
+            undifference_row_16(
+                &diffs,
+                prev_row.as_deref(),
+                &mut output[rs..rs + width],
+                psv,
+                16,
+                pt,
+                y == 0,
+            );
+            prev_row = Some(output[rs..rs + width].to_vec());
+        }
+        if pt > 0 {
+            for v in output.iter_mut() {
+                *v = ((*v as u32) << pt) as u16;
+            }
+        }
+        Ok(Image16 {
+            data: output,
+            width,
+            height,
+            num_components: 1,
+        })
+    } else {
+        let mut planes: Vec<Vec<u16>> = (0..nc).map(|_| vec![0u16; width * height]).collect();
+        let mut prev_rows: Vec<Option<Vec<u16>>> = vec![None; nc];
+        for y in 0..height {
+            let rs = y * width;
+            let mut cd: Vec<Vec<i16>> = (0..nc).map(|_| Vec::with_capacity(width)).collect();
+            for _ in 0..width {
+                for c in 0..nc {
+                    cd[c].push(decode_dc_wide(&mut br, dc_tables[c])?);
+                }
+            }
+            for c in 0..nc {
+                undifference_row_16(
+                    &cd[c],
+                    prev_rows[c].as_deref(),
+                    &mut planes[c][rs..rs + width],
+                    psv,
+                    16,
+                    pt,
+                    y == 0,
+                );
+                prev_rows[c] = Some(planes[c][rs..rs + width].to_vec());
+            }
+        }
+        let mut result = Vec::with_capacity(width * height * nc);
+        for i in 0..width * height {
+            for c in 0..nc {
+                let v = if pt > 0 {
+                    ((planes[c][i] as u32) << pt) as u16
+                } else {
+                    planes[c][i]
+                };
+                result.push(v);
+            }
+        }
+        Ok(Image16 {
+            data: result,
+            width,
+            height,
+            num_components: nc,
+        })
+    }
+}
+
+fn undifference_row_16(
+    diffs: &[i16],
+    prev_row: Option<&[u16]>,
+    output: &mut [u16],
+    psv: u8,
+    precision: u8,
+    pt: u8,
+    is_first_row: bool,
+) {
+    let mask: i64 = (1i64 << precision as i64) - 1;
+    let initial = 1i32 << (precision as i32 - pt as i32 - 1);
+    for x in 0..diffs.len() {
+        let prediction = if is_first_row && x == 0 {
+            initial
+        } else if is_first_row {
+            output[x - 1] as i32
+        } else if x == 0 {
+            prev_row.unwrap()[0] as i32
+        } else {
+            let ra = output[x - 1] as i32;
+            let rb = prev_row.unwrap()[x] as i32;
+            let rc = prev_row.unwrap()[x - 1] as i32;
+            lossless::predict(psv, ra, rb, rc)
+        };
+        output[x] = ((diffs[x] as i32 + prediction) as i64 & mask) as u16;
+    }
+}
+
+fn decode_dc_wide(
+    reader: &mut BitReader,
+    table: &crate::common::huffman_table::HuffmanTable,
+) -> Result<i16> {
+    let peek = reader.peek_bits(16);
+    let (s, l) = table.lookup_fast(peek);
+    let (category, code_len) = if l > 0 { (s, l) } else { table.lookup(peek)? };
+    reader.skip_bits(code_len);
+    if category == 0 {
+        return Ok(0);
+    }
+    let extra_bits = reader.read_bits(category);
+    if extra_bits >= 1u16.wrapping_shl(category as u32 - 1) {
+        Ok(extra_bits as i16)
+    } else {
+        Ok(((-1i32 << category as i32) + 1 + extra_bits as i32) as i16)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,12 @@ pub use common::traits::{DefaultErrorHandler, ErrorHandler, ProgressInfo, Progre
 pub use common::types::*;
 pub use decode::pipeline::Image;
 pub use transform::{TransformOp, TransformOptions};
+/// 12-bit and 16-bit sample precision support.
+pub mod precision {
+    pub use crate::api::precision::{
+        compress_12bit, compress_16bit, decompress_12bit, decompress_16bit, Image12, Image16,
+    };
+}
 /// TJ3-compatible handle/parameter API.
 pub mod tj3 {
     pub use crate::api::tj3::{TjHandle, TjParam};

--- a/tests/precision.rs
+++ b/tests/precision.rs
@@ -1,0 +1,208 @@
+use libjpeg_turbo_rs::common::types::Subsampling;
+use libjpeg_turbo_rs::precision::{
+    compress_12bit, compress_16bit, decompress_12bit, decompress_16bit, Image12, Image16,
+};
+
+#[test]
+fn roundtrip_12bit_grayscale_quality100() {
+    let width: usize = 16;
+    let height: usize = 16;
+    let nc: usize = 1;
+    let mut pixels: Vec<i16> = Vec::with_capacity(width * height);
+    for y in 0..height {
+        for x in 0..width {
+            pixels.push(((y * width + x) * 16) as i16);
+        }
+    }
+    let jpeg = compress_12bit(&pixels, width, height, nc, 100, Subsampling::S444).unwrap();
+    let img = decompress_12bit(&jpeg).unwrap();
+    assert_eq!(img.width, width);
+    assert_eq!(img.height, height);
+    assert_eq!(img.num_components, nc);
+    assert_eq!(img.data.len(), width * height);
+    let max_diff: i16 = pixels
+        .iter()
+        .zip(img.data.iter())
+        .map(|(a, b)| (*a - *b).abs())
+        .max()
+        .unwrap_or(0);
+    assert!(
+        max_diff <= 8,
+        "12-bit q100 roundtrip max diff {} exceeds tolerance",
+        max_diff
+    );
+}
+
+#[test]
+fn roundtrip_12bit_grayscale_lower_quality() {
+    let width: usize = 8;
+    let height: usize = 8;
+    let mut pixels: Vec<i16> = Vec::with_capacity(width * height);
+    for i in 0..(width * height) {
+        pixels.push((i as i16 * 50) % 4096);
+    }
+    let jpeg = compress_12bit(&pixels, width, height, 1, 50, Subsampling::S444).unwrap();
+    let img = decompress_12bit(&jpeg).unwrap();
+    assert_eq!(img.width, width);
+    assert_eq!(img.height, height);
+    for &val in &img.data {
+        assert!(val >= 0 && val <= 4095, "12-bit value {} out of range", val);
+    }
+}
+
+#[test]
+fn roundtrip_12bit_three_component() {
+    let width: usize = 16;
+    let height: usize = 16;
+    let nc: usize = 3;
+    let mut pixels: Vec<i16> = Vec::with_capacity(width * height * nc);
+    for y in 0..height {
+        for x in 0..width {
+            pixels.push(((y * width + x) * 16) as i16);
+            pixels.push((x * 256) as i16);
+            pixels.push((y * 256) as i16);
+        }
+    }
+    let jpeg = compress_12bit(&pixels, width, height, nc, 100, Subsampling::S444).unwrap();
+    let img = decompress_12bit(&jpeg).unwrap();
+    assert_eq!(img.width, width);
+    assert_eq!(img.height, height);
+    assert_eq!(img.num_components, nc);
+    assert_eq!(img.data.len(), width * height * nc);
+}
+
+#[test]
+fn verify_12bit_sof_precision() {
+    let pixels: Vec<i16> = vec![2048i16; 64];
+    let jpeg = compress_12bit(&pixels, 8, 8, 1, 90, Subsampling::S444).unwrap();
+    let sof_pos = jpeg.windows(2).position(|w| w == [0xFF, 0xC0]);
+    assert!(sof_pos.is_some(), "SOF0 marker not found");
+    assert_eq!(jpeg[sof_pos.unwrap() + 4], 12, "SOF precision should be 12");
+}
+
+#[test]
+fn roundtrip_16bit_lossless_grayscale() {
+    let width: usize = 16;
+    let height: usize = 16;
+    let mut pixels: Vec<u16> = Vec::with_capacity(width * height);
+    for y in 0..height {
+        for x in 0..width {
+            pixels.push(((y * width + x) * 256) as u16);
+        }
+    }
+    let jpeg = compress_16bit(&pixels, width, height, 1, 1, 0).unwrap();
+    let img = decompress_16bit(&jpeg).unwrap();
+    assert_eq!(img.width, width);
+    assert_eq!(img.height, height);
+    assert_eq!(img.data, pixels, "16-bit lossless must be exact");
+}
+
+#[test]
+fn roundtrip_16bit_lossless_three_component() {
+    let width: usize = 16;
+    let height: usize = 16;
+    let nc: usize = 3;
+    let mut pixels: Vec<u16> = Vec::with_capacity(width * height * nc);
+    for y in 0..height {
+        for x in 0..width {
+            pixels.push(((y * width + x) * 256) as u16);
+            pixels.push(((x * 512) % 65536) as u16);
+            pixels.push(((y * 512) % 65536) as u16);
+        }
+    }
+    let jpeg = compress_16bit(&pixels, width, height, nc, 1, 0).unwrap();
+    let img = decompress_16bit(&jpeg).unwrap();
+    assert_eq!(img.width, width);
+    assert_eq!(img.height, height);
+    assert_eq!(img.num_components, nc);
+    assert_eq!(img.data, pixels, "16-bit lossless 3-comp must be exact");
+}
+
+#[test]
+fn roundtrip_16bit_lossless_all_predictors() {
+    let width: usize = 8;
+    let height: usize = 8;
+    let mut pixels: Vec<u16> = Vec::with_capacity(width * height);
+    for i in 0..(width * height) {
+        pixels.push((i as u16).wrapping_mul(1000));
+    }
+    for predictor in 1u8..=7 {
+        let jpeg = compress_16bit(&pixels, width, height, 1, predictor, 0)
+            .unwrap_or_else(|e| panic!("predictor {} failed: {}", predictor, e));
+        let img = decompress_16bit(&jpeg)
+            .unwrap_or_else(|e| panic!("decompress predictor {} failed: {}", predictor, e));
+        assert_eq!(
+            img.data, pixels,
+            "predictor {} roundtrip must be exact",
+            predictor
+        );
+    }
+}
+
+#[test]
+fn roundtrip_16bit_lossless_with_point_transform() {
+    let width: usize = 8;
+    let height: usize = 8;
+    let mut pixels: Vec<u16> = Vec::with_capacity(width * height);
+    for i in 0..(width * height) {
+        pixels.push((i as u16).wrapping_mul(1024) & 0xFFFC);
+    }
+    let jpeg = compress_16bit(&pixels, width, height, 1, 1, 2).unwrap();
+    let img = decompress_16bit(&jpeg).unwrap();
+    for (orig, decoded) in pixels.iter().zip(img.data.iter()) {
+        let expected = (orig >> 2) << 2;
+        assert_eq!(
+            *decoded, expected,
+            "pt=2: orig={}, expected={}, got={}",
+            orig, expected, decoded
+        );
+    }
+}
+
+#[test]
+fn verify_16bit_sof_precision() {
+    let pixels: Vec<u16> = vec![32768u16; 64];
+    let jpeg = compress_16bit(&pixels, 8, 8, 1, 1, 0).unwrap();
+    let sof_pos = jpeg.windows(2).position(|w| w == [0xFF, 0xC3]);
+    assert!(sof_pos.is_some(), "SOF3 marker not found");
+    assert_eq!(jpeg[sof_pos.unwrap() + 4], 16, "SOF precision should be 16");
+}
+
+#[test]
+fn error_16bit_invalid_predictor() {
+    let pixels: Vec<u16> = vec![100u16; 64];
+    assert!(compress_16bit(&pixels, 8, 8, 1, 0, 0).is_err());
+    assert!(compress_16bit(&pixels, 8, 8, 1, 8, 0).is_err());
+}
+
+#[test]
+fn roundtrip_12bit_edge_values() {
+    let mut pixels: Vec<i16> = vec![0i16; 64];
+    pixels[0] = 0;
+    pixels[1] = 4095;
+    pixels[2] = 2048;
+    let jpeg = compress_12bit(&pixels, 8, 8, 1, 100, Subsampling::S444).unwrap();
+    let img = decompress_12bit(&jpeg).unwrap();
+    for &val in &img.data {
+        assert!(val >= 0 && val <= 4095, "12-bit value {} out of range", val);
+    }
+}
+
+#[test]
+fn roundtrip_16bit_full_range() {
+    let mut pixels: Vec<u16> = Vec::with_capacity(64);
+    pixels.push(0);
+    pixels.push(65535);
+    pixels.push(32768);
+    pixels.push(1);
+    pixels.push(65534);
+    for i in 5..64 {
+        pixels.push((i as u16).wrapping_mul(997));
+    }
+    let jpeg = compress_16bit(&pixels, 8, 8, 1, 1, 0).unwrap();
+    let img = decompress_16bit(&jpeg).unwrap();
+    assert_eq!(
+        img.data, pixels,
+        "16-bit full-range roundtrip must be exact"
+    );
+}


### PR DESCRIPTION
## Summary
- Implement 12-bit DCT-based JPEG encode/decode (Phase 5 #9) for medical imaging (DICOM) with values 0-4095
- Implement 16-bit lossless JPEG encode/decode (Phase 5 #10) with values 0-65535
- Complete Phase 5 (Extended Formats) — all 8 items now done

### 12-bit precision (J12SAMPLE / i16)
- Custom FDCT with `PASS1_BITS=1` to prevent `i32` overflow (matching libjpeg-turbo's `jfdctint.c` for 12-bit)
- Quantization tables scaled 16x for 12-bit dynamic range
- Grayscale and 3-component (4:4:4) support
- `compress_12bit()` / `decompress_12bit()` / `Image12`

### 16-bit precision (J16SAMPLE / u16)
- Lossless-only (SOF3) encoding/decoding
- Extended DC Huffman tables supporting categories 0-16
- All 7 predictors and point transforms 0-15
- Grayscale and multi-component support
- `compress_16bit()` / `decompress_16bit()` / `Image16`

## Test plan
- [x] 12-bit grayscale roundtrip at quality 100 (max diff <= 8)
- [x] 12-bit grayscale roundtrip at lower quality (values in range)
- [x] 12-bit 3-component roundtrip
- [x] 12-bit SOF marker precision verification (precision=12)
- [x] 12-bit edge values (0, 4095, 2048)
- [x] 16-bit lossless grayscale roundtrip (exact)
- [x] 16-bit lossless 3-component roundtrip (exact)
- [x] 16-bit all 7 predictors (exact roundtrip)
- [x] 16-bit point transform roundtrip
- [x] 16-bit SOF marker precision verification (precision=16)
- [x] 16-bit full range (0, 65535, 32768)
- [x] 16-bit invalid predictor error handling
- [x] All existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)