### PR TITLE
feat: add buffer size, transform, and utility functions

### DIFF
--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -168,7 +168,7 @@
 - [x] `jpeg_write_raw_data()` — Write raw downsampled data (`compress_raw()`)
 - [ ] `jpeg12_write_scanlines()` — 12-bit scanlines
 - [ ] `jpeg16_write_scanlines()` — 16-bit scanlines
-- [ ] `jpeg_calc_jpeg_dimensions()` — Compute output dimensions
+- [x] `jpeg_calc_jpeg_dimensions()` — Compute output dimensions (`calc_jpeg_dimensions()`)
 - [x] `next_scanline` tracking (`ScanlineEncoder::next_scanline()`)
 
 ---
@@ -232,7 +232,7 @@
 - [x] `jpeg_read_raw_data()` — Read raw downsampled data (`decompress_raw()`)
 - [ ] `jpeg12_read_scanlines()` / `jpeg12_skip_scanlines()` / `jpeg12_crop_scanline()`
 - [ ] `jpeg16_read_scanlines()`
-- [ ] `jpeg_calc_output_dimensions()` / `jpeg_core_output_dimensions()`
+- [x] `jpeg_calc_output_dimensions()` / `jpeg_core_output_dimensions()` (`calc_output_dimensions()`, `calc_jpeg_dimensions()`)
 - [x] `output_scanline` tracking (`ScanlineDecoder::output_scanline()`)
 
 ### Color Quantization (8-bit indexed output)
@@ -256,7 +256,7 @@
 - [x] Arbitrary APP markers — Read (`Decoder::save_markers()` + `Image.markers()`)
 - [x] Arbitrary markers — Write (`marker_writer::write_marker()`, `Encoder::saved_marker()`)
 - [x] DPI/density — Read (`Image.density`) / Write (`DensityInfo`)
-- [ ] JFIF thumbnail extraction
+- [x] JFIF thumbnail extraction (`extract_jfif_thumbnail()`)
 - [x] Marker preservation across transform/re-encode (`TransformOptions.copy_markers`)
 
 ---
@@ -288,9 +288,9 @@
 - [x] `read_coefficients()` — Extract quantized DCT blocks
 - [x] `write_coefficients()` — Encode from coefficient blocks
 - [x] `transform_jpeg()` — Apply spatial transform
-- [ ] `jpeg_copy_critical_parameters()` — Copy tables between compress/decompress
+- [x] `jpeg_copy_critical_parameters()` — Copy tables between compress/decompress (`copy_critical_parameters()`)
 - [x] `tjtransform.customFilter` — User callback for coefficient inspection/modification
-- [ ] `tj3TransformBufSize()` — Output buffer size estimation
+- [x] `tj3TransformBufSize()` — Output buffer size estimation (`transform_buf_size()`)
 
 ---
 
@@ -362,9 +362,9 @@
 - [ ] `TJPARAM_NOREALLOC` — Pre-allocated output buffer
 
 ### Buffer Size Calculation
-- [ ] `tj3JPEGBufSize()` — Worst-case JPEG output size
-- [ ] `tj3YUVBufSize()` — YUV buffer size
-- [ ] `tj3TransformBufSize()` — Transform output buffer size
+- [x] `tj3JPEGBufSize()` — Worst-case JPEG output size (`jpeg_buf_size()`)
+- [x] `tj3YUVBufSize()` — YUV buffer size (`yuv_buf_size()`)
+- [x] `tj3TransformBufSize()` — Transform output buffer size (`transform_buf_size()`)
 
 ### Image File I/O (BMP/PPM)
 - [x] `tj3LoadImage8()` / `tj3LoadImage12()` / `tj3LoadImage16()` — 8-bit implemented (`load_image` / `load_image_from_bytes`)
@@ -429,16 +429,16 @@
 | Pixel formats | 13 | 13 | 100% |
 | Chroma subsampling | 8 | 8 | 100% |
 | Color spaces | 6 | 6 | 100% |
-| Compress params | ~45 | ~65 | ~69% |
-| Decompress params | ~30 | ~55 | ~55% |
-| Metadata | 10 | 10 | 100% |
+| Compress params | ~46 | ~65 | ~71% |
+| Decompress params | ~31 | ~55 | ~56% |
+| Metadata | 11 | 11 | 100% |
 | Transform ops | 8 | 8 | 100% |
 | Transform options | 9 | 9 | 100% |
-| Transform misc | 4 | 6 | 67% |
+| Transform misc | 6 | 6 | 100% |
 | YUV/Planar API | 12 | 12 | 100% |
 | SIMD (aarch64) | 10 | 12 | 83% |
 | SIMD (x86_64) | 6 | 6 | 100% |
-| Memory & I/O | 8 | ~20 | ~40% |
+| Memory & I/O | 11 | ~20 | ~55% |
 | Error handling | 5 | ~14 | ~36% |
 | Progress | 4 | 4 | 100% |
 | TJ3 Handle API | 6 | 6 | 100% |

--- a/src/api/coefficient.rs
+++ b/src/api/coefficient.rs
@@ -43,6 +43,60 @@ pub struct JpegCoefficients {
     pub quant_tables: Vec<[u16; 64]>,
 }
 
+/// Per-component info extracted for re-encoding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncoderComponentInfo {
+    /// Horizontal sampling factor.
+    pub h_sampling: u8,
+    /// Vertical sampling factor.
+    pub v_sampling: u8,
+    /// Quantization table index.
+    pub quant_table_index: u8,
+}
+
+/// Critical JPEG parameters extracted from decoded coefficients for re-encoding.
+///
+/// Matches the subset of `jpeg_compress_struct` fields that
+/// `jpeg_copy_critical_parameters()` copies between a decompressor and compressor.
+#[derive(Debug, Clone)]
+pub struct EncoderConfig {
+    /// Image width in pixels.
+    pub width: usize,
+    /// Image height in pixels.
+    pub height: usize,
+    /// Number of components.
+    pub num_components: usize,
+    /// Per-component sampling and quantization info.
+    pub component_info: Vec<EncoderComponentInfo>,
+    /// Quantization tables (in zigzag order).
+    pub quant_tables: Vec<[u16; 64]>,
+}
+
+/// Copy critical JPEG parameters from decoded coefficients for re-encoding.
+///
+/// Extracts dimensions, sampling factors, and quantization tables from
+/// `JpegCoefficients` into an `EncoderConfig` suitable for driving a new
+/// encoding pass. Matches libjpeg-turbo's `jpeg_copy_critical_parameters()`.
+pub fn copy_critical_parameters(coeffs: &JpegCoefficients) -> EncoderConfig {
+    let component_info: Vec<EncoderComponentInfo> = coeffs
+        .components
+        .iter()
+        .map(|comp| EncoderComponentInfo {
+            h_sampling: comp.h_sampling,
+            v_sampling: comp.v_sampling,
+            quant_table_index: comp.quant_table_index,
+        })
+        .collect();
+
+    EncoderConfig {
+        width: coeffs.width as usize,
+        height: coeffs.height as usize,
+        num_components: coeffs.components.len(),
+        component_info,
+        quant_tables: coeffs.quant_tables.clone(),
+    }
+}
+
 /// Read DCT coefficients from a JPEG byte stream.
 ///
 /// Decodes entropy data to recover quantized DCT coefficients

--- a/src/common/bufsize.rs
+++ b/src/common/bufsize.rs
@@ -5,6 +5,7 @@
 //! `tj3YUVPlaneSize`, `tj3YUVPlaneWidth`, and `tj3YUVPlaneHeight`.
 
 use super::types::Subsampling;
+use crate::transform::TransformOp;
 
 /// Rounds `value` up to the nearest multiple of `alignment`.
 ///
@@ -89,6 +90,60 @@ pub fn yuv_buf_size(width: usize, height: usize, subsampling: Subsampling) -> us
         total += yuv_plane_size(component, width, height, subsampling);
     }
     total
+}
+
+/// Worst-case transform output buffer size, accounting for dimension swaps.
+///
+/// Matches `tj3TransformBufSize()`. For transforms that swap width and height
+/// (Transpose, Transverse, Rot90, Rot270), dimensions are swapped before
+/// computing the buffer size via `jpeg_buf_size`.
+pub fn transform_buf_size(
+    width: usize,
+    height: usize,
+    subsampling: Subsampling,
+    op: TransformOp,
+) -> usize {
+    let swaps_dimensions: bool = matches!(
+        op,
+        TransformOp::Transpose | TransformOp::Transverse | TransformOp::Rot90 | TransformOp::Rot270
+    );
+
+    if swaps_dimensions {
+        jpeg_buf_size(height, width, subsampling)
+    } else {
+        jpeg_buf_size(width, height, subsampling)
+    }
+}
+
+/// Compute scaled output dimensions for decompression.
+///
+/// Matches `jpeg_calc_output_dimensions()`. Applies the scaling factor
+/// `scale_num / scale_denom` to both width and height, rounding up.
+pub fn calc_output_dimensions(
+    width: usize,
+    height: usize,
+    scale_num: u32,
+    scale_denom: u32,
+) -> (usize, usize) {
+    let out_width: usize =
+        (width * scale_num as usize + scale_denom as usize - 1) / scale_denom as usize;
+    let out_height: usize =
+        (height * scale_num as usize + scale_denom as usize - 1) / scale_denom as usize;
+    (out_width, out_height)
+}
+
+/// Compute MCU-padded JPEG dimensions for encoding.
+///
+/// Matches `jpeg_calc_jpeg_dimensions()`. Rounds width and height up to the
+/// nearest MCU boundary determined by the subsampling mode.
+pub fn calc_jpeg_dimensions(
+    width: usize,
+    height: usize,
+    subsampling: Subsampling,
+) -> (usize, usize) {
+    let mcu_width: usize = subsampling.mcu_width_blocks() * 8;
+    let mcu_height: usize = subsampling.mcu_height_blocks() * 8;
+    (pad(width, mcu_width), pad(height, mcu_height))
 }
 
 #[cfg(test)]

--- a/src/common/jfif.rs
+++ b/src/common/jfif.rs
@@ -1,0 +1,106 @@
+//! JFIF APP0 thumbnail extraction.
+//!
+//! Parses the JFIF APP0 marker in a JPEG byte stream to extract an embedded
+//! uncompressed RGB thumbnail, if present.
+
+/// Extract JFIF thumbnail from JPEG data if present.
+///
+/// Parses the first APP0 (JFIF) marker in the JPEG stream and extracts the
+/// uncompressed RGB thumbnail data. Returns `None` if no JFIF marker is found,
+/// or the thumbnail dimensions are 0x0.
+///
+/// The JFIF APP0 format after the length field is:
+/// - `"JFIF\0"` (5 bytes) identifier
+/// - Version major/minor (2 bytes)
+/// - Density units (1 byte)
+/// - X density (2 bytes, big-endian)
+/// - Y density (2 bytes, big-endian)
+/// - Thumbnail width (1 byte)
+/// - Thumbnail height (1 byte)
+/// - Thumbnail pixel data (3 * width * height bytes, RGB)
+pub fn extract_jfif_thumbnail(data: &[u8]) -> Option<Vec<u8>> {
+    // Minimum JPEG: SOI (2 bytes) + marker (2 bytes) + length (2 bytes)
+    if data.len() < 6 {
+        return None;
+    }
+
+    // Verify SOI marker
+    if data[0] != 0xFF || data[1] != 0xD8 {
+        return None;
+    }
+
+    // Scan for APP0 marker (0xFF 0xE0)
+    let mut pos: usize = 2;
+    while pos + 4 <= data.len() {
+        if data[pos] != 0xFF {
+            return None;
+        }
+
+        let marker_code: u8 = data[pos + 1];
+
+        // Skip padding 0xFF bytes
+        if marker_code == 0xFF {
+            pos += 1;
+            continue;
+        }
+
+        // Found APP0
+        if marker_code == 0xE0 {
+            return parse_jfif_app0(&data[pos + 2..]);
+        }
+
+        // Not APP0 — skip this marker segment
+        if pos + 4 > data.len() {
+            return None;
+        }
+        let seg_length: usize = u16::from_be_bytes([data[pos + 2], data[pos + 3]]) as usize;
+        if seg_length < 2 {
+            return None;
+        }
+        pos += 2 + seg_length;
+    }
+
+    None
+}
+
+/// Parse JFIF APP0 payload starting at the length field.
+fn parse_jfif_app0(data: &[u8]) -> Option<Vec<u8>> {
+    if data.len() < 2 {
+        return None;
+    }
+
+    let seg_length: usize = u16::from_be_bytes([data[0], data[1]]) as usize;
+    if seg_length < 16 {
+        // Minimum JFIF payload: 5 (id) + 2 (ver) + 1 (units) + 4 (density) + 2 (thumb dims) = 14
+        // Plus 2 for the length field itself = 16
+        return None;
+    }
+
+    let payload: &[u8] = &data[2..];
+    if payload.len() < seg_length - 2 {
+        return None;
+    }
+
+    // Verify "JFIF\0" identifier
+    if payload.len() < 14 || &payload[..5] != b"JFIF\0" {
+        return None;
+    }
+
+    // Thumbnail dimensions are at offset 12 and 13 within the payload
+    // (after "JFIF\0" (5) + version (2) + units (1) + density (4) = 12)
+    let thumb_w: u8 = payload[12];
+    let thumb_h: u8 = payload[13];
+
+    if thumb_w == 0 || thumb_h == 0 {
+        return None;
+    }
+
+    let thumb_size: usize = thumb_w as usize * thumb_h as usize * 3;
+    let thumb_start: usize = 14; // offset within payload where thumbnail data begins
+
+    if payload.len() < thumb_start + thumb_size {
+        return None;
+    }
+
+    Some(payload[thumb_start..thumb_start + thumb_size].to_vec())
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod exif;
 pub mod huffman_table;
 pub mod icc;
+pub mod jfif;
 pub mod quant_table;
 pub mod sample;
 pub mod traits;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,9 @@ pub mod simd;
 pub mod transform;
 
 pub use api::coefficient::{
-    read_coefficients, transform_jpeg as transform, transform_jpeg_with_options,
-    write_coefficients, JpegCoefficients,
+    copy_critical_parameters, read_coefficients, transform_jpeg as transform,
+    transform_jpeg_with_options, write_coefficients, EncoderComponentInfo, EncoderConfig,
+    JpegCoefficients,
 };
 pub use api::encoder::{Encoder, HuffmanTableDef};
 pub use api::high_level::{
@@ -30,9 +31,11 @@ pub use api::scanline::{ScanlineDecoder, ScanlineEncoder};
 /// Streaming I/O functions for reading/writing JPEG via `std::io` traits and file paths.
 pub use api::stream;
 pub use common::bufsize::{
-    jpeg_buf_size, yuv_buf_size, yuv_plane_height, yuv_plane_size, yuv_plane_width,
+    calc_jpeg_dimensions, calc_output_dimensions, jpeg_buf_size, transform_buf_size, yuv_buf_size,
+    yuv_plane_height, yuv_plane_size, yuv_plane_width,
 };
 pub use common::error::{DecodeWarning, JpegError, Result};
+pub use common::jfif::extract_jfif_thumbnail;
 pub use common::sample::Sample;
 pub use common::traits::{DefaultErrorHandler, ErrorHandler, ProgressInfo, ProgressListener};
 pub use common::types::*;

--- a/tests/bufsize_extras.rs
+++ b/tests/bufsize_extras.rs
@@ -1,0 +1,276 @@
+use libjpeg_turbo_rs::{
+    calc_jpeg_dimensions, calc_output_dimensions, compress, copy_critical_parameters,
+    extract_jfif_thumbnail, jpeg_buf_size, read_coefficients, transform_buf_size, PixelFormat,
+    Subsampling, TransformOp,
+};
+
+// --- transform_buf_size ---
+
+#[test]
+fn transform_buf_size_none_matches_jpeg_buf_size() {
+    let size: usize = transform_buf_size(640, 480, Subsampling::S420, TransformOp::None);
+    let expected: usize = jpeg_buf_size(640, 480, Subsampling::S420);
+    assert_eq!(size, expected);
+}
+
+#[test]
+fn transform_buf_size_hflip_preserves_dimensions() {
+    let size: usize = transform_buf_size(640, 480, Subsampling::S420, TransformOp::HFlip);
+    let expected: usize = jpeg_buf_size(640, 480, Subsampling::S420);
+    assert_eq!(size, expected);
+}
+
+#[test]
+fn transform_buf_size_rot90_swaps_dimensions() {
+    let size: usize = transform_buf_size(640, 480, Subsampling::S420, TransformOp::Rot90);
+    let expected: usize = jpeg_buf_size(480, 640, Subsampling::S420);
+    assert_eq!(size, expected);
+}
+
+#[test]
+fn transform_buf_size_rot270_swaps_dimensions() {
+    let size: usize = transform_buf_size(640, 480, Subsampling::S420, TransformOp::Rot270);
+    let expected: usize = jpeg_buf_size(480, 640, Subsampling::S420);
+    assert_eq!(size, expected);
+}
+
+#[test]
+fn transform_buf_size_transpose_swaps_dimensions() {
+    let size: usize = transform_buf_size(1920, 1080, Subsampling::S422, TransformOp::Transpose);
+    let expected: usize = jpeg_buf_size(1080, 1920, Subsampling::S422);
+    assert_eq!(size, expected);
+}
+
+#[test]
+fn transform_buf_size_transverse_swaps_dimensions() {
+    let size: usize = transform_buf_size(800, 600, Subsampling::S444, TransformOp::Transverse);
+    let expected: usize = jpeg_buf_size(600, 800, Subsampling::S444);
+    assert_eq!(size, expected);
+}
+
+#[test]
+fn transform_buf_size_rot180_preserves_dimensions() {
+    let size: usize = transform_buf_size(640, 480, Subsampling::S420, TransformOp::Rot180);
+    let expected: usize = jpeg_buf_size(640, 480, Subsampling::S420);
+    assert_eq!(size, expected);
+}
+
+#[test]
+fn transform_buf_size_vflip_preserves_dimensions() {
+    let size: usize = transform_buf_size(640, 480, Subsampling::S420, TransformOp::VFlip);
+    let expected: usize = jpeg_buf_size(640, 480, Subsampling::S420);
+    assert_eq!(size, expected);
+}
+
+#[test]
+fn transform_buf_size_asymmetric_shows_difference() {
+    // S411 MCU=32x8: pad(100,32)=128, pad(50,8)=56 vs pad(50,32)=64, pad(100,8)=104
+    let no_swap: usize = transform_buf_size(100, 50, Subsampling::S411, TransformOp::None);
+    let swapped: usize = transform_buf_size(100, 50, Subsampling::S411, TransformOp::Rot90);
+    assert_ne!(no_swap, swapped);
+}
+
+// --- calc_output_dimensions ---
+
+#[test]
+fn calc_output_dimensions_identity() {
+    let (w, h) = calc_output_dimensions(640, 480, 1, 1);
+    assert_eq!((w, h), (640, 480));
+}
+
+#[test]
+fn calc_output_dimensions_half() {
+    let (w, h) = calc_output_dimensions(640, 480, 1, 2);
+    assert_eq!((w, h), (320, 240));
+}
+
+#[test]
+fn calc_output_dimensions_quarter() {
+    let (w, h) = calc_output_dimensions(640, 480, 1, 4);
+    assert_eq!((w, h), (160, 120));
+}
+
+#[test]
+fn calc_output_dimensions_eighth() {
+    let (w, h) = calc_output_dimensions(640, 480, 1, 8);
+    assert_eq!((w, h), (80, 60));
+}
+
+#[test]
+fn calc_output_dimensions_rounds_up() {
+    let (w, h) = calc_output_dimensions(641, 481, 1, 2);
+    assert_eq!((w, h), (321, 241));
+}
+
+#[test]
+fn calc_output_dimensions_scale_up() {
+    let (w, h) = calc_output_dimensions(640, 480, 3, 2);
+    assert_eq!((w, h), (960, 720));
+}
+
+// --- calc_jpeg_dimensions ---
+
+#[test]
+fn calc_jpeg_dimensions_s444_no_padding() {
+    let (w, h) = calc_jpeg_dimensions(640, 480, Subsampling::S444);
+    assert_eq!((w, h), (640, 480));
+}
+
+#[test]
+fn calc_jpeg_dimensions_s420_no_padding() {
+    let (w, h) = calc_jpeg_dimensions(640, 480, Subsampling::S420);
+    assert_eq!((w, h), (640, 480));
+}
+
+#[test]
+fn calc_jpeg_dimensions_s420_pads_to_mcu() {
+    let (w, h) = calc_jpeg_dimensions(641, 481, Subsampling::S420);
+    assert_eq!((w, h), (656, 496));
+}
+
+#[test]
+fn calc_jpeg_dimensions_s411_pads_to_mcu() {
+    let (w, h) = calc_jpeg_dimensions(641, 481, Subsampling::S411);
+    assert_eq!((w, h), (672, 488));
+}
+
+// --- extract_jfif_thumbnail ---
+
+#[test]
+fn extract_jfif_thumbnail_absent() {
+    let pixels: Vec<u8> = vec![255u8; 64 * 64 * 3];
+    let jpeg_data: Vec<u8> = compress(&pixels, 64, 64, PixelFormat::Rgb, 75, Subsampling::S420)
+        .expect("compress failed");
+    let thumb: Option<Vec<u8>> = extract_jfif_thumbnail(&jpeg_data);
+    assert!(thumb.is_none());
+}
+
+#[test]
+fn extract_jfif_thumbnail_with_embedded_thumb() {
+    let thumb_w: u8 = 2;
+    let thumb_h: u8 = 2;
+    let thumb_pixels: Vec<u8> = vec![255, 0, 0, 0, 255, 0, 0, 0, 255, 255, 255, 0];
+
+    let mut app0_data: Vec<u8> = Vec::new();
+    app0_data.extend_from_slice(b"JFIF\0");
+    app0_data.push(1);
+    app0_data.push(2);
+    app0_data.push(1);
+    app0_data.extend_from_slice(&72u16.to_be_bytes());
+    app0_data.extend_from_slice(&72u16.to_be_bytes());
+    app0_data.push(thumb_w);
+    app0_data.push(thumb_h);
+    app0_data.extend_from_slice(&thumb_pixels);
+
+    let app0_length: u16 = (app0_data.len() + 2) as u16;
+
+    let pixels: Vec<u8> = vec![128u8; 8 * 8 * 3];
+    let base_jpeg: Vec<u8> =
+        compress(&pixels, 8, 8, PixelFormat::Rgb, 75, Subsampling::S420).expect("compress failed");
+
+    let mut new_jpeg: Vec<u8> = Vec::new();
+    new_jpeg.push(0xFF);
+    new_jpeg.push(0xD8);
+    new_jpeg.push(0xFF);
+    new_jpeg.push(0xE0);
+    new_jpeg.extend_from_slice(&app0_length.to_be_bytes());
+    new_jpeg.extend_from_slice(&app0_data);
+
+    let mut pos: usize = 2;
+    if base_jpeg.len() > 4 && base_jpeg[2] == 0xFF && base_jpeg[3] == 0xE0 {
+        let orig_len: usize = u16::from_be_bytes([base_jpeg[4], base_jpeg[5]]) as usize + 2;
+        pos = 2 + 2 + orig_len;
+    }
+    new_jpeg.extend_from_slice(&base_jpeg[pos..]);
+
+    let thumb: Option<Vec<u8>> = extract_jfif_thumbnail(&new_jpeg);
+    assert!(thumb.is_some(), "thumbnail should be found");
+    assert_eq!(thumb.unwrap(), thumb_pixels);
+}
+
+#[test]
+fn extract_jfif_thumbnail_zero_size() {
+    let mut app0_data: Vec<u8> = Vec::new();
+    app0_data.extend_from_slice(b"JFIF\0");
+    app0_data.push(1);
+    app0_data.push(2);
+    app0_data.push(1);
+    app0_data.extend_from_slice(&72u16.to_be_bytes());
+    app0_data.extend_from_slice(&72u16.to_be_bytes());
+    app0_data.push(0);
+    app0_data.push(0);
+
+    let app0_length: u16 = (app0_data.len() + 2) as u16;
+
+    let pixels: Vec<u8> = vec![128u8; 8 * 8 * 3];
+    let base_jpeg: Vec<u8> =
+        compress(&pixels, 8, 8, PixelFormat::Rgb, 75, Subsampling::S420).expect("compress failed");
+
+    let mut new_jpeg: Vec<u8> = Vec::new();
+    new_jpeg.push(0xFF);
+    new_jpeg.push(0xD8);
+    new_jpeg.push(0xFF);
+    new_jpeg.push(0xE0);
+    new_jpeg.extend_from_slice(&app0_length.to_be_bytes());
+    new_jpeg.extend_from_slice(&app0_data);
+
+    let mut pos: usize = 2;
+    if base_jpeg.len() > 4 && base_jpeg[2] == 0xFF && base_jpeg[3] == 0xE0 {
+        let orig_len: usize = u16::from_be_bytes([base_jpeg[4], base_jpeg[5]]) as usize + 2;
+        pos = 2 + 2 + orig_len;
+    }
+    new_jpeg.extend_from_slice(&base_jpeg[pos..]);
+
+    let thumb: Option<Vec<u8>> = extract_jfif_thumbnail(&new_jpeg);
+    assert!(thumb.is_none());
+}
+
+// --- copy_critical_parameters ---
+
+#[test]
+fn copy_critical_parameters_preserves_quant_tables() {
+    let pixels: Vec<u8> = vec![128u8; 64 * 64 * 3];
+    let jpeg_data: Vec<u8> = compress(&pixels, 64, 64, PixelFormat::Rgb, 90, Subsampling::S420)
+        .expect("compress failed");
+    let coeffs = read_coefficients(&jpeg_data).expect("read_coefficients failed");
+
+    let config = copy_critical_parameters(&coeffs);
+
+    assert_eq!(config.quant_tables.len(), coeffs.quant_tables.len());
+    for (i, table) in config.quant_tables.iter().enumerate() {
+        assert_eq!(table, &coeffs.quant_tables[i], "quant table {} mismatch", i);
+    }
+}
+
+#[test]
+fn copy_critical_parameters_preserves_dimensions() {
+    let pixels: Vec<u8> = vec![128u8; 100 * 80 * 3];
+    let jpeg_data: Vec<u8> = compress(&pixels, 100, 80, PixelFormat::Rgb, 75, Subsampling::S420)
+        .expect("compress failed");
+    let coeffs = read_coefficients(&jpeg_data).expect("read_coefficients failed");
+
+    let config = copy_critical_parameters(&coeffs);
+
+    assert_eq!(config.width, 100);
+    assert_eq!(config.height, 80);
+}
+
+#[test]
+fn copy_critical_parameters_preserves_sampling_factors() {
+    let pixels: Vec<u8> = vec![128u8; 64 * 64 * 3];
+    let jpeg_data: Vec<u8> = compress(&pixels, 64, 64, PixelFormat::Rgb, 75, Subsampling::S420)
+        .expect("compress failed");
+    let coeffs = read_coefficients(&jpeg_data).expect("read_coefficients failed");
+
+    let config = copy_critical_parameters(&coeffs);
+
+    assert_eq!(config.num_components, coeffs.components.len());
+    for (i, comp) in config.component_info.iter().enumerate() {
+        assert_eq!(comp.h_sampling, coeffs.components[i].h_sampling);
+        assert_eq!(comp.v_sampling, coeffs.components[i].v_sampling);
+        assert_eq!(
+            comp.quant_table_index,
+            coeffs.components[i].quant_table_index
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `transform_buf_size()` matching `tj3TransformBufSize()` — dimension-swap-aware worst-case buffer size
- Add `calc_output_dimensions()` matching `jpeg_calc_output_dimensions()` — scaled decompression output
- Add `calc_jpeg_dimensions()` matching `jpeg_calc_jpeg_dimensions()` — MCU-padded encoding dimensions
- Add `copy_critical_parameters()` matching `jpeg_copy_critical_parameters()` — extract `EncoderConfig` from `JpegCoefficients`
- Add `extract_jfif_thumbnail()` — parse JFIF APP0 for embedded RGB thumbnail
- Register `jfif` module, export all new symbols from `lib.rs`
- Update FEATURE_PARITY.md: check off 8 items across 5 sections (Transform misc 6/6, Metadata 11/11, Buffer Size 3/3)

## Test plan
- [x] 25 tests in `tests/bufsize_extras.rs` covering all 5 functions
- [x] Full `cargo test` suite passes (no regressions)
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)