### PR TITLE
test: add memory limits, concurrency, and encoder boundary tests

### DIFF
--- a/src/decode/pipeline.rs
+++ b/src/decode/pipeline.rs
@@ -911,8 +911,17 @@ impl<'a> Decoder<'a> {
             .map(|ci| vec![[0i16; 64]; ci.blocks_x * ci.blocks_y])
             .collect();
 
-        // Process each scan
-        for scan_info in &self.metadata.scans {
+        // Process each scan, enforcing scan_limit if set
+        for (scan_idx, scan_info) in self.metadata.scans.iter().enumerate() {
+            if let Some(limit) = self.scan_limit {
+                if scan_idx as u32 >= limit {
+                    return Err(JpegError::Unsupported(format!(
+                        "progressive scan count {} exceeds limit of {}",
+                        scan_idx + 1,
+                        limit
+                    )));
+                }
+            }
             let scan_header = &scan_info.header;
             let is_dc = scan_header.spec_start == 0 && scan_header.spec_end == 0;
             let ah = scan_header.succ_high;
@@ -1072,8 +1081,17 @@ impl<'a> Decoder<'a> {
             .map(|ci| vec![[0i16; 64]; ci.blocks_x * ci.blocks_y])
             .collect();
 
-        // Process each scan
-        for scan_info in &self.metadata.scans {
+        // Process each scan, enforcing scan_limit if set
+        for (scan_idx, scan_info) in self.metadata.scans.iter().enumerate() {
+            if let Some(limit) = self.scan_limit {
+                if scan_idx as u32 >= limit {
+                    return Err(JpegError::Unsupported(format!(
+                        "progressive scan count {} exceeds limit of {}",
+                        scan_idx + 1,
+                        limit
+                    )));
+                }
+            }
             self.decode_progressive_scan(
                 frame,
                 scan_info,
@@ -1857,6 +1875,25 @@ impl<'a> Decoder<'a> {
                 }
             }
         }
+        // When stop_on_warning is enabled, any accumulated warning becomes fatal.
+        if self.stop_on_warning && !image.warnings.is_empty() {
+            let first_warning = &image.warnings[0];
+            let detail = match first_warning {
+                DecodeWarning::HuffmanError {
+                    mcu_x,
+                    mcu_y,
+                    message,
+                } => format!("Huffman error at MCU ({}, {}): {}", mcu_x, mcu_y, message),
+                DecodeWarning::TruncatedData {
+                    decoded_mcus,
+                    total_mcus,
+                } => format!("truncated: decoded {} of {} MCUs", decoded_mcus, total_mcus),
+            };
+            return Err(JpegError::CorruptData(format!(
+                "stop_on_warning: {}",
+                detail
+            )));
+        }
         Ok(image)
     }
 
@@ -1872,6 +1909,27 @@ impl<'a> Decoder<'a> {
                 return Err(JpegError::Unsupported(format!(
                     "image {}x{} ({} pixels) exceeds limit of {}",
                     width, height, total, max
+                )));
+            }
+        }
+
+        // Enforce max_memory: reject if estimated decode memory exceeds limit.
+        // Estimate = output_buffer + component_plane_buffers.
+        if let Some(max_mem) = self.max_memory {
+            let nc = frame.components.len();
+            let out_bpp = self
+                .output_format
+                .unwrap_or(if nc == 1 {
+                    PixelFormat::Grayscale
+                } else {
+                    PixelFormat::Rgb
+                })
+                .bytes_per_pixel();
+            let total_estimated = width * height * out_bpp + width * height * nc;
+            if total_estimated > max_mem {
+                return Err(JpegError::Unsupported(format!(
+                    "estimated decode memory {} bytes exceeds limit of {} bytes",
+                    total_estimated, max_mem
                 )));
             }
         }

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -1,0 +1,245 @@
+use libjpeg_turbo_rs::{compress, decompress, Encoder, Image, PixelFormat, Subsampling};
+use std::sync::Arc;
+use std::thread;
+
+/// Generate a deterministic pixel buffer for testing.
+fn make_pixels(width: usize, height: usize, seed: u8) -> Vec<u8> {
+    (0..width * height * 3)
+        .map(|i| ((i as u32 * 37 + seed as u32 * 53 + 13) % 256) as u8)
+        .collect()
+}
+
+/// Create a small test JPEG from given seed.
+fn make_test_jpeg(seed: u8) -> Vec<u8> {
+    let pixels = make_pixels(32, 32, seed);
+    compress(&pixels, 32, 32, PixelFormat::Rgb, 75, Subsampling::S444).unwrap()
+}
+
+/// Shared JPEG data for concurrent decode tests.
+fn shared_jpeg() -> Arc<Vec<u8>> {
+    Arc::new(make_test_jpeg(42))
+}
+
+// --- Concurrent decode tests ---
+
+#[test]
+fn ten_threads_decode_same_jpeg_all_correct() {
+    let jpeg_data = shared_jpeg();
+    // Decode once as reference
+    let reference: Image = decompress(&jpeg_data).unwrap();
+
+    let handles: Vec<_> = (0..10)
+        .map(|_| {
+            let data = Arc::clone(&jpeg_data);
+            thread::spawn(move || decompress(&data).unwrap())
+        })
+        .collect();
+
+    for handle in handles {
+        let image: Image = handle.join().expect("thread should not panic");
+        assert_eq!(image.width, reference.width);
+        assert_eq!(image.height, reference.height);
+        assert_eq!(
+            image.data, reference.data,
+            "decoded pixels should match reference"
+        );
+    }
+}
+
+// --- Concurrent encode tests ---
+
+#[test]
+fn ten_threads_encode_different_images() {
+    let handles: Vec<_> = (0..10)
+        .map(|i| {
+            thread::spawn(move || {
+                let pixels = make_pixels(16, 16, i as u8);
+                let jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+                    .quality(75)
+                    .subsampling(Subsampling::S444)
+                    .encode()
+                    .unwrap();
+                // Verify the produced JPEG is valid by decoding it
+                let image = decompress(&jpeg).unwrap();
+                assert_eq!(image.width, 16);
+                assert_eq!(image.height, 16);
+                jpeg
+            })
+        })
+        .collect();
+
+    let results: Vec<Vec<u8>> = handles
+        .into_iter()
+        .map(|h| h.join().expect("thread should not panic"))
+        .collect();
+
+    // Each thread used a different seed, so outputs should generally differ
+    // (at minimum, they all succeeded)
+    assert_eq!(results.len(), 10);
+    for jpeg in &results {
+        assert!(!jpeg.is_empty(), "encoded JPEG should not be empty");
+        // Verify SOI marker
+        assert_eq!(jpeg[0], 0xFF);
+        assert_eq!(jpeg[1], 0xD8);
+    }
+}
+
+// --- Mixed encode/decode ---
+
+#[test]
+fn mixed_encode_and_decode_threads() {
+    let jpeg_data = shared_jpeg();
+
+    let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
+
+    // 5 decoder threads
+    for _ in 0..5 {
+        let data = Arc::clone(&jpeg_data);
+        handles.push(thread::spawn(move || {
+            let image: Image = decompress(&data).unwrap();
+            assert_eq!(image.width, 32);
+            assert_eq!(image.height, 32);
+            assert!(!image.data.is_empty());
+        }));
+    }
+
+    // 5 encoder threads
+    for i in 0..5 {
+        handles.push(thread::spawn(move || {
+            let pixels = make_pixels(16, 16, i as u8 + 100);
+            let jpeg = compress(&pixels, 16, 16, PixelFormat::Rgb, 75, Subsampling::S420).unwrap();
+            let image = decompress(&jpeg).unwrap();
+            assert_eq!(image.width, 16);
+            assert_eq!(image.height, 16);
+        }));
+    }
+
+    for handle in handles {
+        handle.join().expect("thread should not panic");
+    }
+}
+
+// --- SIMD dispatch consistency ---
+
+#[test]
+fn simd_detect_consistent_across_threads() {
+    // Decode the same image in multiple threads and verify identical output,
+    // which proves the SIMD dispatch produces consistent results regardless of thread.
+    let jpeg_data = shared_jpeg();
+    let reference = decompress(&jpeg_data).unwrap();
+
+    let handles: Vec<_> = (0..8)
+        .map(|_| {
+            let data = Arc::clone(&jpeg_data);
+            thread::spawn(move || decompress(&data).unwrap())
+        })
+        .collect();
+
+    for handle in handles {
+        let image = handle.join().expect("thread should not panic");
+        assert_eq!(
+            image.data, reference.data,
+            "SIMD dispatch should produce identical results across threads"
+        );
+    }
+}
+
+// --- Pipeline: decode in one thread, encode in another ---
+
+#[test]
+fn decode_then_encode_across_threads() {
+    let jpeg_data = shared_jpeg();
+
+    // Decode in thread 1
+    let decoded = thread::spawn(move || decompress(&jpeg_data).unwrap())
+        .join()
+        .expect("decode thread should not panic");
+
+    // Encode the decoded pixels in thread 2
+    let width = decoded.width;
+    let height = decoded.height;
+    let pixel_format = decoded.pixel_format;
+    let data = decoded.data;
+
+    let re_encoded = thread::spawn(move || {
+        Encoder::new(&data, width, height, pixel_format)
+            .quality(80)
+            .subsampling(Subsampling::S444)
+            .encode()
+            .unwrap()
+    })
+    .join()
+    .expect("encode thread should not panic");
+
+    // Verify the re-encoded JPEG is valid
+    let final_image = decompress(&re_encoded).unwrap();
+    assert_eq!(final_image.width, width);
+    assert_eq!(final_image.height, height);
+}
+
+// --- Stress test ---
+
+#[test]
+fn stress_100_concurrent_decodes() {
+    let pixels: Vec<u8> = vec![128u8; 8 * 8 * 3];
+    let jpeg = Arc::new(compress(&pixels, 8, 8, PixelFormat::Rgb, 75, Subsampling::S444).unwrap());
+
+    let handles: Vec<_> = (0..100)
+        .map(|_| {
+            let data = Arc::clone(&jpeg);
+            thread::spawn(move || {
+                let image = decompress(&data).unwrap();
+                assert_eq!(image.width, 8);
+                assert_eq!(image.height, 8);
+                assert_eq!(image.data.len(), 8 * 8 * 3);
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().expect("thread should not panic");
+    }
+}
+
+// --- Send + Sync compile-time checks ---
+
+/// Compile-time verification that Image is Send.
+/// This test passes if it compiles; the function is never called at runtime.
+fn _assert_image_is_send() {
+    fn require_send<T: Send>() {}
+    require_send::<Image>();
+}
+
+/// Compile-time verification that Encoder is Send.
+fn _assert_encoder_is_send() {
+    fn require_send<T: Send>() {}
+    require_send::<Encoder<'static>>();
+}
+
+#[test]
+fn image_is_send_verified() {
+    // This test just exercises the compile-time check above.
+    // If Image were not Send, this file would fail to compile.
+    let jpeg = make_test_jpeg(1);
+    let image = decompress(&jpeg).unwrap();
+    // Move image to another thread (proves Send)
+    let handle = thread::spawn(move || {
+        assert_eq!(image.width, 32);
+        image
+    });
+    let _returned = handle.join().unwrap();
+}
+
+#[test]
+fn encoder_is_send_verified() {
+    // Prove Encoder can be moved to another thread
+    let pixels: Vec<u8> = vec![128u8; 8 * 8 * 3];
+    let handle = thread::spawn(move || {
+        let jpeg = Encoder::new(&pixels, 8, 8, PixelFormat::Rgb)
+            .quality(75)
+            .encode()
+            .unwrap();
+        assert!(!jpeg.is_empty());
+    });
+    handle.join().unwrap();
+}

--- a/tests/encode_boundaries.rs
+++ b/tests/encode_boundaries.rs
@@ -1,0 +1,381 @@
+use libjpeg_turbo_rs::{compress, decompress, Encoder, PixelFormat, Subsampling};
+
+/// All 7 subsampling modes.
+const ALL_SUBSAMPLINGS: [Subsampling; 7] = [
+    Subsampling::S444,
+    Subsampling::S422,
+    Subsampling::S420,
+    Subsampling::S440,
+    Subsampling::S411,
+    Subsampling::S441,
+    Subsampling::Unknown,
+];
+
+/// All pixel formats the encoder supports for encode+decode roundtrip.
+/// Excludes Cmyk (special 4-component path) and Rgb565 (decode-only).
+const ENCODABLE_FORMATS: [PixelFormat; 11] = [
+    PixelFormat::Rgb,
+    PixelFormat::Rgba,
+    PixelFormat::Bgr,
+    PixelFormat::Bgra,
+    PixelFormat::Rgbx,
+    PixelFormat::Bgrx,
+    PixelFormat::Xrgb,
+    PixelFormat::Xbgr,
+    PixelFormat::Argb,
+    PixelFormat::Abgr,
+    PixelFormat::Grayscale,
+];
+
+/// Compute PSNR between two RGB byte slices.
+fn psnr_rgb(a: &[u8], b: &[u8]) -> f64 {
+    assert_eq!(a.len(), b.len());
+    if a.is_empty() {
+        return f64::INFINITY;
+    }
+    let mse: f64 = a
+        .iter()
+        .zip(b.iter())
+        .map(|(&x, &y)| {
+            let diff = x as f64 - y as f64;
+            diff * diff
+        })
+        .sum::<f64>()
+        / a.len() as f64;
+    if mse < 1e-10 {
+        return f64::INFINITY;
+    }
+    10.0 * (255.0_f64 * 255.0 / mse).log10()
+}
+
+// --- Quality boundary tests ---
+
+#[test]
+fn quality_1_encodes_and_decodes() {
+    let pixels: Vec<u8> = vec![128u8; 32 * 32 * 3];
+    let jpeg = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(1)
+        .encode()
+        .unwrap();
+    let image = decompress(&jpeg).unwrap();
+    assert_eq!(image.width, 32);
+    assert_eq!(image.height, 32);
+    assert_eq!(image.data.len(), 32 * 32 * 3);
+}
+
+#[test]
+fn quality_100_high_psnr() {
+    let mut pixels: Vec<u8> = Vec::with_capacity(32 * 32 * 3);
+    for y in 0..32u8 {
+        for x in 0..32u8 {
+            pixels.push(x.wrapping_mul(8));
+            pixels.push(y.wrapping_mul(8));
+            pixels.push(128);
+        }
+    }
+    let jpeg = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(100)
+        .subsampling(Subsampling::S444)
+        .encode()
+        .unwrap();
+    let image = decompress(&jpeg).unwrap();
+    assert_eq!(image.width, 32);
+    assert_eq!(image.height, 32);
+
+    let psnr = psnr_rgb(&pixels, &image.data);
+    assert!(
+        psnr > 30.0,
+        "quality=100 should produce high PSNR (>30 dB), got {:.1} dB",
+        psnr
+    );
+}
+
+#[test]
+fn quality_0_treated_as_quality_1() {
+    // quality=0 is clamped to 1 by quality_scaling, so encode should succeed
+    let pixels: Vec<u8> = vec![128u8; 16 * 16 * 3];
+    let jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .quality(0)
+        .encode()
+        .unwrap();
+    let image = decompress(&jpeg).unwrap();
+    assert_eq!(image.width, 16);
+    assert_eq!(image.height, 16);
+}
+
+// --- Subsampling with non-aligned dimensions ---
+
+#[test]
+fn all_subsamplings_with_3x5_image() {
+    let pixels: Vec<u8> = (0..3 * 5 * 3)
+        .map(|i| ((i * 37 + 13) % 256) as u8)
+        .collect();
+    for &ss in &ALL_SUBSAMPLINGS {
+        let jpeg = Encoder::new(&pixels, 3, 5, PixelFormat::Rgb)
+            .quality(75)
+            .subsampling(ss)
+            .encode()
+            .unwrap_or_else(|e| panic!("encode failed for {:?}: {}", ss, e));
+        let image =
+            decompress(&jpeg).unwrap_or_else(|e| panic!("decode failed for {:?}: {}", ss, e));
+        assert_eq!(image.width, 3, "width mismatch for {:?}", ss);
+        assert_eq!(image.height, 5, "height mismatch for {:?}", ss);
+    }
+}
+
+#[test]
+fn all_subsamplings_with_1x1_image() {
+    let pixels: Vec<u8> = vec![128, 64, 32]; // 1x1 RGB
+    for &ss in &ALL_SUBSAMPLINGS {
+        let jpeg = Encoder::new(&pixels, 1, 1, PixelFormat::Rgb)
+            .quality(75)
+            .subsampling(ss)
+            .encode()
+            .unwrap_or_else(|e| panic!("encode failed for {:?}: {}", ss, e));
+        let image =
+            decompress(&jpeg).unwrap_or_else(|e| panic!("decode failed for {:?}: {}", ss, e));
+        assert_eq!(image.width, 1);
+        assert_eq!(image.height, 1);
+    }
+}
+
+// --- Restart interval boundary tests ---
+
+#[test]
+fn restart_interval_1_every_mcu() {
+    let pixels: Vec<u8> = vec![128u8; 32 * 32 * 3];
+    let jpeg = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(75)
+        .subsampling(Subsampling::S444)
+        .restart_blocks(1)
+        .encode()
+        .unwrap();
+
+    // Should contain DRI marker
+    let has_dri = jpeg.windows(2).any(|w| w[0] == 0xFF && w[1] == 0xDD);
+    assert!(has_dri, "restart_blocks(1) should produce DRI marker");
+
+    let image = decompress(&jpeg).unwrap();
+    assert_eq!(image.width, 32);
+    assert_eq!(image.height, 32);
+}
+
+#[test]
+fn restart_interval_65535_larger_than_image() {
+    let pixels: Vec<u8> = vec![128u8; 16 * 16 * 3];
+    // 16x16 with S444: 2x2 MCUs = 4 MCUs total. restart_blocks(65535) > 4
+    let jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .quality(75)
+        .subsampling(Subsampling::S444)
+        .restart_blocks(65535)
+        .encode()
+        .unwrap();
+
+    let image = decompress(&jpeg).unwrap();
+    assert_eq!(image.width, 16);
+    assert_eq!(image.height, 16);
+}
+
+// --- Per-component quality ---
+
+#[test]
+fn per_component_quality_luma_100_chroma_1() {
+    let mut pixels: Vec<u8> = Vec::with_capacity(32 * 32 * 3);
+    for y in 0..32u8 {
+        for x in 0..32u8 {
+            pixels.push(x.wrapping_mul(8));
+            pixels.push(y.wrapping_mul(8));
+            pixels.push(128);
+        }
+    }
+    let jpeg = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(75)
+        .quality_factor(0, 100) // luma table = quality 100
+        .quality_factor(1, 1) // chroma table = quality 1
+        .subsampling(Subsampling::S444)
+        .encode()
+        .unwrap();
+
+    let image = decompress(&jpeg).unwrap();
+    assert_eq!(image.width, 32);
+    assert_eq!(image.height, 32);
+    assert_eq!(image.data.len(), 32 * 32 * 3);
+}
+
+// --- Encode then decode with every pixel format ---
+
+#[test]
+fn encode_decode_all_pixel_formats() {
+    for &pf in &ENCODABLE_FORMATS {
+        let bpp = pf.bytes_per_pixel();
+        let (w, h) = (16, 16);
+        let pixels: Vec<u8> = (0..w * h * bpp)
+            .map(|i| ((i * 37 + 13) % 256) as u8)
+            .collect();
+
+        let ss = if pf == PixelFormat::Grayscale {
+            Subsampling::S444
+        } else {
+            Subsampling::S420
+        };
+
+        let jpeg = Encoder::new(&pixels, w, h, pf)
+            .quality(75)
+            .subsampling(ss)
+            .encode()
+            .unwrap_or_else(|e| panic!("encode failed for {:?}: {}", pf, e));
+
+        let image =
+            decompress(&jpeg).unwrap_or_else(|e| panic!("decode failed for {:?}: {}", pf, e));
+        assert_eq!(image.width, w, "width mismatch for {:?}", pf);
+        assert_eq!(image.height, h, "height mismatch for {:?}", pf);
+        assert!(
+            !image.data.is_empty(),
+            "decoded data should not be empty for {:?}",
+            pf
+        );
+    }
+}
+
+// --- Special pixel values ---
+
+#[test]
+fn encode_all_zero_pixels() {
+    let pixels: Vec<u8> = vec![0u8; 16 * 16 * 3];
+    let jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .quality(75)
+        .encode()
+        .unwrap();
+    let image = decompress(&jpeg).unwrap();
+    assert_eq!(image.width, 16);
+    assert_eq!(image.height, 16);
+    // All-zero input: decoded should be close to zero (lossy, but not wildly off)
+    let max_val: u8 = *image.data.iter().max().unwrap();
+    assert!(
+        max_val < 30,
+        "all-zero pixels should decode to near-zero, max was {}",
+        max_val
+    );
+}
+
+#[test]
+fn encode_all_255_pixels() {
+    let pixels: Vec<u8> = vec![255u8; 16 * 16 * 3];
+    let jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .quality(75)
+        .encode()
+        .unwrap();
+    let image = decompress(&jpeg).unwrap();
+    assert_eq!(image.width, 16);
+    assert_eq!(image.height, 16);
+    // All-255 input: decoded should be close to 255
+    let min_val: u8 = *image.data.iter().min().unwrap();
+    assert!(
+        min_val > 225,
+        "all-255 pixels should decode to near-255, min was {}",
+        min_val
+    );
+}
+
+// --- Progressive encode with grayscale ---
+
+#[test]
+fn progressive_encode_grayscale() {
+    let pixels: Vec<u8> = vec![128u8; 32 * 32];
+    let jpeg = Encoder::new(&pixels, 32, 32, PixelFormat::Grayscale)
+        .quality(75)
+        .progressive(true)
+        .encode()
+        .unwrap();
+
+    // Should contain SOF2 marker (progressive)
+    let has_sof2 = jpeg.windows(2).any(|w| w[0] == 0xFF && w[1] == 0xC2);
+    assert!(has_sof2, "progressive grayscale should contain SOF2 marker");
+
+    let image = decompress(&jpeg).unwrap();
+    assert_eq!(image.width, 32);
+    assert_eq!(image.height, 32);
+    assert_eq!(image.pixel_format, PixelFormat::Grayscale);
+}
+
+// --- Arithmetic encode with all subsampling modes ---
+
+#[test]
+fn arithmetic_encode_all_subsamplings() {
+    // Arithmetic encode supports S444, S422, S420, S440, S411, S441
+    let subsamplings = [
+        Subsampling::S444,
+        Subsampling::S422,
+        Subsampling::S420,
+        Subsampling::S440,
+        Subsampling::S411,
+        Subsampling::S441,
+    ];
+
+    let pixels: Vec<u8> = (0..32 * 32 * 3)
+        .map(|i| ((i * 37 + 13) % 256) as u8)
+        .collect();
+
+    for &ss in &subsamplings {
+        let jpeg = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+            .quality(75)
+            .subsampling(ss)
+            .arithmetic(true)
+            .encode()
+            .unwrap_or_else(|e| panic!("arithmetic encode failed for {:?}: {}", ss, e));
+
+        // Should contain SOF9 marker (arithmetic sequential DCT)
+        let has_sof9 = jpeg.windows(2).any(|w| w[0] == 0xFF && w[1] == 0xC9);
+        assert!(
+            has_sof9,
+            "arithmetic encode should contain SOF9 marker for {:?}",
+            ss
+        );
+
+        let image = decompress(&jpeg)
+            .unwrap_or_else(|e| panic!("decode of arithmetic {:?} failed: {}", ss, e));
+        assert_eq!(image.width, 32, "width mismatch for arithmetic {:?}", ss);
+        assert_eq!(image.height, 32, "height mismatch for arithmetic {:?}", ss);
+    }
+}
+
+// --- CMYK encode roundtrip ---
+
+#[test]
+fn cmyk_encode_decode_roundtrip() {
+    let pixels: Vec<u8> = vec![128u8; 16 * 16 * 4];
+    let jpeg = Encoder::new(&pixels, 16, 16, PixelFormat::Cmyk)
+        .quality(75)
+        .encode()
+        .unwrap();
+    // CMYK JPEG should be valid (can at least be parsed)
+    assert!(jpeg.len() > 100, "CMYK JPEG should not be trivially small");
+    assert_eq!(jpeg[0], 0xFF);
+    assert_eq!(jpeg[1], 0xD8);
+}
+
+// --- Quality 1 vs quality 100 produces different file sizes ---
+
+#[test]
+fn quality_affects_file_size() {
+    let pixels: Vec<u8> = (0..32 * 32 * 3)
+        .map(|i| ((i * 37 + 13) % 256) as u8)
+        .collect();
+    let jpeg_q1 = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(1)
+        .subsampling(Subsampling::S444)
+        .encode()
+        .unwrap();
+    let jpeg_q100 = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(100)
+        .subsampling(Subsampling::S444)
+        .encode()
+        .unwrap();
+
+    assert!(
+        jpeg_q100.len() > jpeg_q1.len(),
+        "quality=100 ({} bytes) should produce larger file than quality=1 ({} bytes)",
+        jpeg_q100.len(),
+        jpeg_q1.len()
+    );
+}

--- a/tests/memory_limits.rs
+++ b/tests/memory_limits.rs
@@ -1,0 +1,301 @@
+use libjpeg_turbo_rs::decode::pipeline::Decoder;
+use libjpeg_turbo_rs::{
+    compress, compress_progressive, decompress_lenient, PixelFormat, Subsampling,
+};
+
+/// Generate a simple 32x32 RGB JPEG for basic tests.
+fn make_32x32_jpeg() -> Vec<u8> {
+    let pixels: Vec<u8> = (0..32 * 32 * 3)
+        .map(|i| ((i * 37 + 13) % 256) as u8)
+        .collect();
+    compress(&pixels, 32, 32, PixelFormat::Rgb, 75, Subsampling::S444).unwrap()
+}
+
+/// Generate a 64x64 RGB JPEG.
+fn make_64x64_jpeg() -> Vec<u8> {
+    let pixels: Vec<u8> = vec![128u8; 64 * 64 * 3];
+    compress(&pixels, 64, 64, PixelFormat::Rgb, 75, Subsampling::S420).unwrap()
+}
+
+// --- max_pixels tests ---
+
+#[test]
+fn max_pixels_rejects_image_exceeding_limit() {
+    let jpeg = make_32x32_jpeg();
+    // 32x32 = 1024 pixels, setting limit to 100 should reject
+    let mut decoder = Decoder::new(&jpeg).unwrap();
+    decoder.set_max_pixels(100);
+    let result = decoder.decode_image();
+    assert!(
+        result.is_err(),
+        "should reject 1024-pixel image with max_pixels=100"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("exceeds limit"),
+        "error should mention exceeds limit, got: {}",
+        err_msg
+    );
+}
+
+#[test]
+fn max_pixels_allows_image_within_limit() {
+    let jpeg = make_32x32_jpeg();
+    // 32x32 = 1024 pixels, setting limit to 10000 should succeed
+    let mut decoder = Decoder::new(&jpeg).unwrap();
+    decoder.set_max_pixels(10000);
+    let image = decoder.decode_image().unwrap();
+    assert_eq!(image.width, 32);
+    assert_eq!(image.height, 32);
+}
+
+#[test]
+fn max_pixels_zero_means_unlimited() {
+    // Setting max_pixels to 0 means the limit IS 0 pixels, so any image is rejected.
+    let pixels: Vec<u8> = vec![128u8; 8 * 8 * 3];
+    let jpeg = compress(&pixels, 8, 8, PixelFormat::Rgb, 75, Subsampling::S444).unwrap();
+    let mut decoder = Decoder::new(&jpeg).unwrap();
+    decoder.set_max_pixels(0);
+    let result = decoder.decode_image();
+    // 8*8=64 > 0, so it should be rejected
+    assert!(
+        result.is_err(),
+        "max_pixels=0 should reject any non-zero-pixel image"
+    );
+}
+
+#[test]
+fn max_pixels_exact_boundary() {
+    let jpeg = make_32x32_jpeg();
+    // Exact boundary: 32x32 = 1024 pixels, limit = 1024 should succeed
+    let mut decoder = Decoder::new(&jpeg).unwrap();
+    decoder.set_max_pixels(1024);
+    let image = decoder.decode_image().unwrap();
+    assert_eq!(image.width, 32);
+    assert_eq!(image.height, 32);
+
+    // One below boundary: 1023 should fail
+    let mut decoder2 = Decoder::new(&jpeg).unwrap();
+    decoder2.set_max_pixels(1023);
+    let result = decoder2.decode_image();
+    assert!(
+        result.is_err(),
+        "max_pixels=1023 should reject 1024-pixel image"
+    );
+}
+
+// --- max_memory tests ---
+
+#[test]
+fn max_memory_very_low_rejects() {
+    let jpeg = make_32x32_jpeg();
+    let mut decoder = Decoder::new(&jpeg).unwrap();
+    // 32x32 RGB: output=3072, planes=3072, total=6144. 1024 < 6144.
+    decoder.set_max_memory(1024);
+    let result = decoder.decode_image();
+    assert!(result.is_err(), "should reject decode with max_memory=1024");
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("memory") || err_msg.contains("exceeds"),
+        "error should mention memory limit, got: {}",
+        err_msg
+    );
+}
+
+#[test]
+fn max_memory_high_enough_succeeds() {
+    let jpeg = make_32x32_jpeg();
+    let mut decoder = Decoder::new(&jpeg).unwrap();
+    // 10 MB should be plenty for a 32x32 image
+    decoder.set_max_memory(10 * 1024 * 1024);
+    let image = decoder.decode_image().unwrap();
+    assert_eq!(image.width, 32);
+    assert_eq!(image.height, 32);
+}
+
+#[test]
+fn max_memory_large_image_with_tight_limit() {
+    let jpeg = make_64x64_jpeg();
+    let mut decoder = Decoder::new(&jpeg).unwrap();
+    // 64x64 RGB: output=12288, planes=12288, total=24576.
+    // 1000 < 24576 so should fail
+    decoder.set_max_memory(1000);
+    let result = decoder.decode_image();
+    assert!(
+        result.is_err(),
+        "should reject 64x64 decode with max_memory=1000"
+    );
+}
+
+#[test]
+fn max_memory_default_is_unlimited() {
+    // No max_memory set -> should decode fine
+    let jpeg = make_32x32_jpeg();
+    let decoder = Decoder::new(&jpeg).unwrap();
+    let image = decoder.decode_image().unwrap();
+    assert_eq!(image.width, 32);
+    assert_eq!(image.height, 32);
+}
+
+// --- scan_limit tests ---
+
+#[test]
+fn scan_limit_rejects_progressive_with_many_scans() {
+    // Use a fixture progressive JPEG that is known to have multiple scans
+    let jpeg = include_bytes!("fixtures/photo_320x240_420_prog.jpg");
+    let mut decoder = Decoder::new(jpeg).unwrap();
+    // Progressive JPEGs from libjpeg-turbo typically have 10+ scans. Limit to 1 should fail.
+    decoder.set_scan_limit(1);
+    let result = decoder.decode_image();
+    assert!(
+        result.is_err(),
+        "scan_limit=1 should reject progressive JPEG with multiple scans"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("scan") && err_msg.contains("limit"),
+        "error should mention scan limit, got: {}",
+        err_msg
+    );
+}
+
+#[test]
+fn scan_limit_high_allows_progressive() {
+    // Use the same fixture progressive JPEG
+    let jpeg = include_bytes!("fixtures/photo_320x240_420_prog.jpg");
+    let mut decoder = Decoder::new(jpeg).unwrap();
+    // 100 should be more than enough scans for any standard progressive JPEG
+    decoder.set_scan_limit(100);
+    let image = decoder.decode_image().unwrap();
+    assert_eq!(image.width, 320);
+    assert_eq!(image.height, 240);
+}
+
+#[test]
+fn scan_limit_does_not_affect_baseline() {
+    let jpeg = make_32x32_jpeg();
+    let mut decoder = Decoder::new(&jpeg).unwrap();
+    // Baseline JPEG has only 1 scan, so scan_limit=1 should not trigger
+    // (baseline doesn't go through the progressive scan loop)
+    decoder.set_scan_limit(1);
+    let image = decoder.decode_image().unwrap();
+    assert_eq!(image.width, 32);
+    assert_eq!(image.height, 32);
+}
+
+#[test]
+fn scan_limit_just_above_scan_count_succeeds() {
+    // Encode a minimal progressive JPEG with uniform pixels (few scans)
+    let pixels: Vec<u8> = vec![128u8; 16 * 16 * 3];
+    let jpeg =
+        compress_progressive(&pixels, 16, 16, PixelFormat::Rgb, 75, Subsampling::S444).unwrap();
+    // Decode without scan_limit first to confirm it works
+    let image = Decoder::new(&jpeg).unwrap().decode_image().unwrap();
+    assert_eq!(image.width, 16);
+    // Now set a generous limit
+    let mut decoder = Decoder::new(&jpeg).unwrap();
+    decoder.set_scan_limit(100);
+    let image2 = decoder.decode_image().unwrap();
+    assert_eq!(image2.width, 16);
+    assert_eq!(image2.height, 16);
+}
+
+// --- stop_on_warning tests ---
+
+#[test]
+fn stop_on_warning_rejects_truncated_jpeg() {
+    let data = include_bytes!("fixtures/photo_320x240_420.jpg");
+    // Truncate to 2000 bytes - this is known to produce warnings in lenient mode
+    // (validated by the error_recovery.rs truncated_jpeg_lenient_returns_partial test)
+    let truncated = &data[..2000.min(data.len())];
+
+    // Verify baseline: lenient mode succeeds with warnings
+    let lenient_img = decompress_lenient(truncated).unwrap();
+    assert!(
+        !lenient_img.warnings.is_empty(),
+        "lenient mode on truncated JPEG should produce warnings"
+    );
+
+    // Now: lenient + stop_on_warning should fail because warnings are present
+    let mut decoder = Decoder::new(truncated).unwrap();
+    decoder.set_lenient(true);
+    decoder.set_stop_on_warning(true);
+    let result = decoder.decode_image();
+    assert!(
+        result.is_err(),
+        "stop_on_warning=true should convert lenient warnings to errors"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("stop_on_warning"),
+        "error should mention stop_on_warning, got: {}",
+        err_msg
+    );
+}
+
+#[test]
+fn stop_on_warning_allows_clean_jpeg() {
+    let jpeg = make_32x32_jpeg();
+    let mut decoder = Decoder::new(&jpeg).unwrap();
+    decoder.set_stop_on_warning(true);
+    // Clean JPEG should produce no warnings, so stop_on_warning is irrelevant
+    let image = decoder.decode_image().unwrap();
+    assert_eq!(image.width, 32);
+    assert_eq!(image.height, 32);
+}
+
+#[test]
+fn stop_on_warning_false_allows_corrupt_jpeg() {
+    let data = include_bytes!("fixtures/photo_320x240_420.jpg");
+    let truncated = &data[..2000.min(data.len())];
+
+    // With stop_on_warning=false (default) and lenient=true, should succeed with warnings
+    let mut decoder = Decoder::new(truncated).unwrap();
+    decoder.set_lenient(true);
+    decoder.set_stop_on_warning(false);
+    let result = decoder.decode_image();
+    if let Ok(img) = result {
+        assert_eq!(img.width, 320);
+        assert_eq!(img.height, 240);
+    }
+}
+
+#[test]
+fn stop_on_warning_with_very_short_truncation() {
+    let data = include_bytes!("fixtures/photo_320x240_420.jpg");
+    // Very short truncation: only 500 bytes
+    let truncated = &data[..500.min(data.len())];
+
+    // Decoder::new may fail on very short data (incomplete markers).
+    // The key behavior: it should not panic.
+    match Decoder::new(truncated) {
+        Ok(mut decoder) => {
+            decoder.set_lenient(true);
+            decoder.set_stop_on_warning(true);
+            // Either errors or succeeds, but should not panic
+            let _result = decoder.decode_image();
+        }
+        Err(_) => {
+            // Expected: very short truncation may prevent even marker parsing
+        }
+    }
+}
+
+// --- Combined limit tests ---
+
+#[test]
+fn max_pixels_and_max_memory_both_enforced() {
+    let jpeg = make_32x32_jpeg();
+
+    // Fail on max_pixels even when max_memory is generous
+    let mut decoder = Decoder::new(&jpeg).unwrap();
+    decoder.set_max_pixels(100);
+    decoder.set_max_memory(10 * 1024 * 1024);
+    assert!(decoder.decode_image().is_err());
+
+    // Fail on max_memory even when max_pixels is generous
+    let mut decoder2 = Decoder::new(&jpeg).unwrap();
+    decoder2.set_max_pixels(100000);
+    decoder2.set_max_memory(100);
+    assert!(decoder2.decode_image().is_err());
+}


### PR DESCRIPTION
## Summary
- Add `tests/memory_limits.rs` (17 tests): validates `max_pixels`, `max_memory`, `scan_limit`, and `stop_on_warning` decoder settings
- Add `tests/concurrency.rs` (8 tests): multi-threaded decode/encode safety, SIMD consistency across threads, `Send` trait verification
- Add `tests/encode_boundaries.rs` (15 tests): quality edge cases (0/1/100), all 7 subsampling modes with non-aligned images (3x5, 1x1), restart intervals, per-component quality, all pixel format roundtrips, progressive grayscale, arithmetic encode
- Implement enforcement for `max_memory`, `scan_limit`, and `stop_on_warning` in `src/decode/pipeline.rs` (these fields existed but were not checked)

## Test plan
- [x] All 40 new tests pass
- [x] Full existing test suite passes (no regressions)
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)