### PR TITLE
fix: add input validation for SOF/SOS/encoder (4 bugs)

### DIFF
--- a/src/decode/marker.rs
+++ b/src/decode/marker.rs
@@ -530,15 +530,33 @@ impl<'a> MarkerReader<'a> {
         let width = self.read_u16_be()?;
         let num_components = self.read_u8()? as usize;
 
+        if width == 0 {
+            return Err(JpegError::CorruptData("SOF width must not be 0".into()));
+        }
+        if num_components == 0 || num_components > 4 {
+            return Err(JpegError::CorruptData(format!(
+                "SOF component count must be 1-4, got {}",
+                num_components
+            )));
+        }
+
         let mut components = Vec::with_capacity(num_components);
         for _ in 0..num_components {
             let id = self.read_u8()?;
             let sampling = self.read_u8()?;
+            let h_samp = sampling >> 4;
+            let v_samp = sampling & 0x0F;
+            if h_samp == 0 || h_samp > 4 || v_samp == 0 || v_samp > 4 {
+                return Err(JpegError::CorruptData(format!(
+                    "sampling factor must be 1-4, got {}x{}",
+                    h_samp, v_samp
+                )));
+            }
             let quant_table_index = self.read_u8()?;
             components.push(ComponentInfo {
                 id,
-                horizontal_sampling: sampling >> 4,
-                vertical_sampling: sampling & 0x0F,
+                horizontal_sampling: h_samp,
+                vertical_sampling: v_samp,
                 quant_table_index,
             });
         }
@@ -669,6 +687,13 @@ impl<'a> MarkerReader<'a> {
     fn read_sos(&mut self) -> Result<ScanHeader> {
         let _length = self.read_u16_be()?;
         let num_components = self.read_u8()? as usize;
+
+        if num_components == 0 || num_components > 4 {
+            return Err(JpegError::CorruptData(format!(
+                "SOS component count must be 1-4, got {}",
+                num_components
+            )));
+        }
 
         let mut components = Vec::with_capacity(num_components);
         for _ in 0..num_components {

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -1126,9 +1126,9 @@ pub fn compress_lossless_extended(
         )));
     }
 
-    if point_transform > 15 {
+    if point_transform >= 8 {
         return Err(JpegError::Unsupported(format!(
-            "point transform must be 0-15, got {}",
+            "point transform must be 0-7 for 8-bit precision, got {}",
             point_transform
         )));
     }
@@ -1404,9 +1404,9 @@ pub fn compress_lossless_arithmetic(
         )));
     }
 
-    if point_transform > 15 {
+    if point_transform >= 8 {
         return Err(JpegError::Unsupported(format!(
-            "point transform must be 0-15, got {}",
+            "point transform must be 0-7 for 8-bit precision, got {}",
             point_transform
         )));
     }

--- a/tests/edge_case_inputs.rs
+++ b/tests/edge_case_inputs.rs
@@ -347,21 +347,14 @@ fn lossless_point_transform_7() {
 }
 
 #[test]
-fn lossless_point_transform_15_errors_or_handles() {
-    // point_transform=15 is beyond 8-bit range; should either error or not panic.
-    // Currently the encoder panics on shift overflow, so we catch it here.
-    // TODO(correctness): encoder should return Err instead of panicking for pt>7 with 8-bit
-    let result = std::panic::catch_unwind(|| {
-        let pixels: Vec<u8> = (0..64).map(|i| (i * 4) as u8).collect();
-        compress_lossless_extended(&pixels, 8, 8, PixelFormat::Grayscale, 1, 15)
-    });
-    // Either Ok(Err(...)) or Err(panic) — both are acceptable; the test ensures
-    // we observe the behavior without crashing the test harness.
-    match result {
-        Ok(Ok(_)) => {}  // Unlikely but fine
-        Ok(Err(_)) => {} // Proper error return
-        Err(_) => {}     // Panic caught — encoder needs fixing but test is aware
-    }
+fn lossless_point_transform_15_returns_error() {
+    // point_transform=15 is beyond 8-bit range (must be < precision=8).
+    let pixels: Vec<u8> = (0..64).map(|i| (i * 4) as u8).collect();
+    let result = compress_lossless_extended(&pixels, 8, 8, PixelFormat::Grayscale, 1, 15);
+    assert!(
+        result.is_err(),
+        "pt=15 with 8-bit precision should be rejected"
+    );
 }
 
 #[test]

--- a/tests/malformed_jpeg.rs
+++ b/tests/malformed_jpeg.rs
@@ -108,8 +108,7 @@ fn sof_width_zero() {
         jpeg[pos + 7] = 0;
         jpeg[pos + 8] = 0;
     }
-    // TODO(correctness): decoder should reject width=0 with an error
-    let _ = decompress(&jpeg);
+    assert!(decompress(&jpeg).is_err(), "width=0 should be rejected");
 }
 
 #[test]
@@ -220,13 +219,7 @@ fn sos_component_count_mismatch() {
             jpeg[ns_byte] = 0;
         }
     }
-    // TODO(correctness): decoder should return Err for Ns=0 instead of panicking
-    let result = std::panic::catch_unwind(|| decompress(&jpeg));
-    match result {
-        Ok(Ok(_)) => {}  // Unlikely but acceptable
-        Ok(Err(_)) => {} // Proper error return
-        Err(_) => {}     // Panic caught — decoder needs bounds check
-    }
+    assert!(decompress(&jpeg).is_err(), "SOS Ns=0 should be rejected");
 }
 
 // ===========================================================================
@@ -364,8 +357,10 @@ fn component_sampling_factor_too_large() {
             jpeg[sampling_byte] = 0x55;
         }
     }
-    // TODO(correctness): decoder should reject sampling factor > 4 with an error
-    let _ = decompress(&jpeg);
+    assert!(
+        decompress(&jpeg).is_err(),
+        "sampling factor > 4 should be rejected"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Fixes 4 bugs found by malformed JPEG tests (PR #57):

1. **SOF width=0** — decoder silently accepted, now returns error
2. **Sampling factor > 4** — decoder accepted invalid values, now rejects
3. **SOS Ns=0** — decoder panicked on index OOB, now returns error
4. **point_transform >= 8** — encoder panicked on shift overflow, now returns error

All 4 match libjpeg-turbo C's validation behavior (`ERREXIT`).

## Test plan
- [x] Updated 4 tests from `catch_unwind`/TODO to `assert!(is_err())`
- [x] All 118 malformed/edge case tests pass
- [x] Full test suite: 837 pass, 2 pre-existing failures (unrelated tjunittest_transform tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)