### PR TITLE
test: add tests for single-dimension parity gaps

### DIFF
--- a/tests/crop_c_compat.rs
+++ b/tests/crop_c_compat.rs
@@ -1,0 +1,287 @@
+//! C-compatible crop region tests.
+//!
+//! The C libjpeg-turbo test suite tests these 5 exact crop regions on a
+//! 64x64 image: 14x14+23+23, 21x21+4+4, 18x18+13+13, 21x21+0+0, 24x26+20+18
+//!
+//! This test file verifies our cropped decompress API produces correct results
+//! for these exact coordinates, matching C behavior:
+//! - Output dimensions match requested crop (clamped to image bounds)
+//! - Pixel values match full decode at the same coordinates
+//! - Works with both 4:4:4 and 4:2:0 subsampling
+
+use libjpeg_turbo_rs::{
+    compress, decompress, decompress_cropped, CropRegion, PixelFormat, Subsampling,
+};
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+/// Generate a 64x64 gradient test image, encode as JPEG, return bytes.
+fn encode_64x64(subsampling: Subsampling) -> Vec<u8> {
+    let (w, h) = (64, 64);
+    let mut pixels: Vec<u8> = Vec::with_capacity(w * h * 3);
+    for y in 0..h {
+        for x in 0..w {
+            // Distinct per-pixel pattern so crop correctness is verifiable
+            pixels.push(((x * 4 + y) % 256) as u8);
+            pixels.push(((y * 4 + x) % 256) as u8);
+            pixels.push(((x * y) % 256) as u8);
+        }
+    }
+    compress(&pixels, w, h, PixelFormat::Rgb, 95, subsampling).unwrap()
+}
+
+/// Verify that cropped pixels match the corresponding region in a full decode.
+fn verify_crop_matches_full(
+    jpeg_data: &[u8],
+    crop_x: usize,
+    crop_y: usize,
+    crop_w: usize,
+    crop_h: usize,
+) {
+    let full = decompress(jpeg_data).unwrap();
+    let bpp: usize = full.pixel_format.bytes_per_pixel();
+    let region = CropRegion {
+        x: crop_x,
+        y: crop_y,
+        width: crop_w,
+        height: crop_h,
+    };
+    let cropped = decompress_cropped(jpeg_data, region).unwrap();
+
+    // The crop API clamps to image bounds
+    let effective_w: usize = crop_w.min(full.width.saturating_sub(crop_x));
+    let effective_h: usize = crop_h.min(full.height.saturating_sub(crop_y));
+
+    assert_eq!(
+        cropped.width, effective_w,
+        "crop {}x{}+{}+{}: width mismatch (expected {}, got {})",
+        crop_w, crop_h, crop_x, crop_y, effective_w, cropped.width
+    );
+    assert_eq!(
+        cropped.height, effective_h,
+        "crop {}x{}+{}+{}: height mismatch (expected {}, got {})",
+        crop_w, crop_h, crop_x, crop_y, effective_h, cropped.height
+    );
+    assert_eq!(
+        cropped.data.len(),
+        effective_w * effective_h * bpp,
+        "crop {}x{}+{}+{}: data length mismatch",
+        crop_w,
+        crop_h,
+        crop_x,
+        crop_y
+    );
+
+    // Pixel-by-pixel comparison with full decode
+    for row in 0..effective_h {
+        for col in 0..effective_w {
+            let crop_idx: usize = (row * effective_w + col) * bpp;
+            let full_idx: usize = ((crop_y + row) * full.width + (crop_x + col)) * bpp;
+            for c in 0..bpp {
+                assert_eq!(
+                    cropped.data[crop_idx + c],
+                    full.data[full_idx + c],
+                    "crop {}x{}+{}+{}: pixel mismatch at row={}, col={}, channel={}",
+                    crop_w,
+                    crop_h,
+                    crop_x,
+                    crop_y,
+                    row,
+                    col,
+                    c
+                );
+            }
+        }
+    }
+}
+
+// ===========================================================================
+// C test coordinates on 4:4:4 subsampling
+// ===========================================================================
+
+#[test]
+fn crop_14x14_at_23_23_444() {
+    let jpeg = encode_64x64(Subsampling::S444);
+    verify_crop_matches_full(&jpeg, 23, 23, 14, 14);
+}
+
+#[test]
+fn crop_21x21_at_4_4_444() {
+    let jpeg = encode_64x64(Subsampling::S444);
+    verify_crop_matches_full(&jpeg, 4, 4, 21, 21);
+}
+
+#[test]
+fn crop_18x18_at_13_13_444() {
+    let jpeg = encode_64x64(Subsampling::S444);
+    verify_crop_matches_full(&jpeg, 13, 13, 18, 18);
+}
+
+#[test]
+fn crop_21x21_at_0_0_444() {
+    let jpeg = encode_64x64(Subsampling::S444);
+    verify_crop_matches_full(&jpeg, 0, 0, 21, 21);
+}
+
+#[test]
+fn crop_24x26_at_20_18_444() {
+    let jpeg = encode_64x64(Subsampling::S444);
+    verify_crop_matches_full(&jpeg, 20, 18, 24, 26);
+}
+
+// ===========================================================================
+// C test coordinates on 4:2:0 subsampling
+// ===========================================================================
+
+#[test]
+fn crop_14x14_at_23_23_420() {
+    let jpeg = encode_64x64(Subsampling::S420);
+    verify_crop_matches_full(&jpeg, 23, 23, 14, 14);
+}
+
+#[test]
+fn crop_21x21_at_4_4_420() {
+    let jpeg = encode_64x64(Subsampling::S420);
+    verify_crop_matches_full(&jpeg, 4, 4, 21, 21);
+}
+
+#[test]
+fn crop_18x18_at_13_13_420() {
+    let jpeg = encode_64x64(Subsampling::S420);
+    verify_crop_matches_full(&jpeg, 13, 13, 18, 18);
+}
+
+#[test]
+fn crop_21x21_at_0_0_420() {
+    let jpeg = encode_64x64(Subsampling::S420);
+    verify_crop_matches_full(&jpeg, 0, 0, 21, 21);
+}
+
+#[test]
+fn crop_24x26_at_20_18_420() {
+    let jpeg = encode_64x64(Subsampling::S420);
+    verify_crop_matches_full(&jpeg, 20, 18, 24, 26);
+}
+
+// ===========================================================================
+// C test coordinates with real photo fixture (photo_64x64_420.jpg)
+// ===========================================================================
+
+#[test]
+fn crop_14x14_at_23_23_photo() {
+    let jpeg = include_bytes!("fixtures/photo_64x64_420.jpg");
+    verify_crop_matches_full(jpeg, 23, 23, 14, 14);
+}
+
+#[test]
+fn crop_21x21_at_4_4_photo() {
+    let jpeg = include_bytes!("fixtures/photo_64x64_420.jpg");
+    verify_crop_matches_full(jpeg, 4, 4, 21, 21);
+}
+
+#[test]
+fn crop_18x18_at_13_13_photo() {
+    let jpeg = include_bytes!("fixtures/photo_64x64_420.jpg");
+    verify_crop_matches_full(jpeg, 13, 13, 18, 18);
+}
+
+#[test]
+fn crop_21x21_at_0_0_photo() {
+    let jpeg = include_bytes!("fixtures/photo_64x64_420.jpg");
+    verify_crop_matches_full(jpeg, 0, 0, 21, 21);
+}
+
+#[test]
+fn crop_24x26_at_20_18_photo() {
+    let jpeg = include_bytes!("fixtures/photo_64x64_420.jpg");
+    verify_crop_matches_full(jpeg, 20, 18, 24, 26);
+}
+
+// ===========================================================================
+// Edge cases derived from C coordinates
+// ===========================================================================
+
+#[test]
+fn crop_extends_beyond_image_bounds() {
+    // C coordinate 24x26+20+18 on 64x64: x+w=44, y+h=44, within bounds.
+    // Test a crop that WOULD exceed: 24x26+50+50 on 64x64.
+    let jpeg = encode_64x64(Subsampling::S444);
+    let region = CropRegion {
+        x: 50,
+        y: 50,
+        width: 24,
+        height: 26,
+    };
+    let cropped = decompress_cropped(&jpeg, region).unwrap();
+    // Clamped: effective_w = min(24, 64-50) = 14, effective_h = min(26, 64-50) = 14
+    assert_eq!(cropped.width, 14);
+    assert_eq!(cropped.height, 14);
+}
+
+#[test]
+fn crop_all_five_c_regions_sequential_444() {
+    // Verify all 5 C test crops produce valid output in sequence on same image
+    let jpeg = encode_64x64(Subsampling::S444);
+    let regions: Vec<(usize, usize, usize, usize)> = vec![
+        (23, 23, 14, 14),
+        (4, 4, 21, 21),
+        (13, 13, 18, 18),
+        (0, 0, 21, 21),
+        (20, 18, 24, 26),
+    ];
+    for (x, y, w, h) in regions {
+        let region = CropRegion {
+            x,
+            y,
+            width: w,
+            height: h,
+        };
+        let cropped = decompress_cropped(&jpeg, region).unwrap();
+        assert_eq!(cropped.width, w, "crop {}x{}+{}+{} width", w, h, x, y);
+        assert_eq!(cropped.height, h, "crop {}x{}+{}+{} height", w, h, x, y);
+        assert!(
+            !cropped.data.is_empty(),
+            "crop {}x{}+{}+{} should produce non-empty data",
+            w,
+            h,
+            x,
+            y
+        );
+    }
+}
+
+#[test]
+fn crop_non_mcu_aligned_offsets_420() {
+    // 4:2:0 has 16x16 MCU blocks. The C test coordinates (23,23), (4,4),
+    // (13,13) are intentionally non-MCU-aligned to test sub-MCU extraction.
+    let jpeg = encode_64x64(Subsampling::S420);
+    let non_aligned_offsets: Vec<(usize, usize)> = vec![(23, 23), (4, 4), (13, 13)];
+    for (ox, oy) in non_aligned_offsets {
+        let region = CropRegion {
+            x: ox,
+            y: oy,
+            width: 16,
+            height: 16,
+        };
+        let cropped = decompress_cropped(&jpeg, region).unwrap();
+        assert_eq!(
+            cropped.width, 16,
+            "non-aligned crop at ({},{}) width",
+            ox, oy
+        );
+        assert_eq!(
+            cropped.height, 16,
+            "non-aligned crop at ({},{}) height",
+            ox, oy
+        );
+    }
+}
+
+#[test]
+fn crop_full_image_64x64() {
+    // Crop the entire image should match full decode
+    let jpeg = encode_64x64(Subsampling::S444);
+    verify_crop_matches_full(&jpeg, 0, 0, 64, 64);
+}

--- a/tests/precision_extended.rs
+++ b/tests/precision_extended.rs
@@ -1,0 +1,485 @@
+//! Extended precision tests for lossless JPEG encoding/decoding.
+//!
+//! The C libjpeg-turbo test suite tests lossless JPEG at every precision from
+//! 2-bit to 16-bit. Our implementation currently supports:
+//! - 8-bit lossless via `compress_lossless` / `compress_lossless_extended` (u8 samples, hardcoded precision=8)
+//! - 12-bit lossy via `compress_12bit` / `decompress_12bit` (i16 samples, hardcoded precision=12)
+//! - 16-bit lossless via `compress_16bit` / `decompress_16bit` (u16 samples, hardcoded precision=16)
+//!
+//! Arbitrary precision (2-7, 9-11, 13-15) is NOT supported because:
+//! - The 8-bit API uses `u8` and hardcodes precision=8 in the SOF marker
+//! - The 16-bit API hardcodes precision=16 in the SOF marker
+//! - There is no API parameter to specify arbitrary bit depth
+//!
+//! This test file:
+//! - Tests all 3 supported precision levels (8, 12, 16) thoroughly
+//! - Documents which precisions are unsupported
+
+use libjpeg_turbo_rs::common::types::Subsampling;
+use libjpeg_turbo_rs::precision::{
+    compress_12bit, compress_16bit, decompress_12bit, decompress_16bit,
+};
+use libjpeg_turbo_rs::{compress_lossless, compress_lossless_extended, decompress, PixelFormat};
+
+// ---------------------------------------------------------------------------
+// 8-bit lossless precision tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lossless_precision_8_roundtrip_flat() {
+    // All pixels same value
+    let pixels: Vec<u8> = vec![128; 16 * 16];
+    let jpeg = compress_lossless(&pixels, 16, 16, PixelFormat::Grayscale).unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.data, pixels, "8-bit flat image roundtrip must be exact");
+}
+
+#[test]
+fn lossless_precision_8_roundtrip_full_range() {
+    // All 256 possible values
+    let pixels: Vec<u8> = (0..=255).collect();
+    let jpeg = compress_lossless(&pixels, 16, 16, PixelFormat::Grayscale).unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.data, pixels, "8-bit full-range roundtrip must be exact");
+}
+
+#[test]
+fn lossless_precision_8_roundtrip_extremes() {
+    // Worst-case for prediction: alternating 0 and 255
+    let mut pixels: Vec<u8> = vec![0; 8 * 8];
+    for i in 0..pixels.len() {
+        pixels[i] = if i % 2 == 0 { 0 } else { 255 };
+    }
+    let jpeg = compress_lossless(&pixels, 8, 8, PixelFormat::Grayscale).unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.data, pixels, "8-bit extremes roundtrip must be exact");
+}
+
+#[test]
+fn lossless_precision_8_all_predictors() {
+    let mut pixels: Vec<u8> = vec![0; 16 * 16];
+    for i in 0..pixels.len() {
+        pixels[i] = ((i * 7 + 13) % 256) as u8;
+    }
+    for predictor in 1u8..=7 {
+        let jpeg =
+            compress_lossless_extended(&pixels, 16, 16, PixelFormat::Grayscale, predictor, 0)
+                .unwrap_or_else(|e| panic!("predictor {} encode failed: {}", predictor, e));
+        let img = decompress(&jpeg)
+            .unwrap_or_else(|e| panic!("predictor {} decode failed: {}", predictor, e));
+        assert_eq!(
+            img.data, pixels,
+            "8-bit predictor {} roundtrip must be exact",
+            predictor
+        );
+    }
+}
+
+#[test]
+fn lossless_precision_8_point_transform_0_through_7() {
+    // Test multiple point transform values
+    for pt in 0u8..=7 {
+        let mask: u8 = !((1u16 << pt) as u8).wrapping_sub(1);
+        let mut pixels: Vec<u8> = vec![0; 8 * 8];
+        for i in 0..pixels.len() {
+            // Values already aligned to 2^pt boundary so no info is lost
+            pixels[i] = ((i * 4) as u8) & mask;
+        }
+        let jpeg = compress_lossless_extended(&pixels, 8, 8, PixelFormat::Grayscale, 1, pt)
+            .unwrap_or_else(|e| panic!("pt={} encode failed: {}", pt, e));
+        let img = decompress(&jpeg).unwrap_or_else(|e| panic!("pt={} decode failed: {}", pt, e));
+        assert_eq!(
+            img.data, pixels,
+            "8-bit pt={} roundtrip must be exact for aligned values",
+            pt
+        );
+    }
+}
+
+#[test]
+fn lossless_precision_8_verifies_sof3_marker() {
+    let pixels: Vec<u8> = vec![42; 64];
+    let jpeg = compress_lossless(&pixels, 8, 8, PixelFormat::Grayscale).unwrap();
+    let sof3_pos = jpeg.windows(2).position(|w| w[0] == 0xFF && w[1] == 0xC3);
+    assert!(
+        sof3_pos.is_some(),
+        "SOF3 marker not found in 8-bit lossless"
+    );
+    // Precision byte is at offset +4 from marker start
+    assert_eq!(jpeg[sof3_pos.unwrap() + 4], 8, "SOF3 precision should be 8");
+}
+
+#[test]
+fn lossless_precision_8_rgb_roundtrip() {
+    let (w, h) = (16, 16);
+    let mut pixels: Vec<u8> = vec![0; w * h * 3];
+    for i in 0..w * h {
+        pixels[i * 3] = (i * 3 % 256) as u8;
+        pixels[i * 3 + 1] = (i * 7 % 256) as u8;
+        pixels[i * 3 + 2] = (i * 11 % 256) as u8;
+    }
+    let jpeg = compress_lossless_extended(&pixels, w, h, PixelFormat::Rgb, 1, 0).unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, w);
+    assert_eq!(img.height, h);
+    assert_eq!(img.data.len(), w * h * 3);
+    // Allow small rounding from YCbCr conversion
+    for i in 0..pixels.len() {
+        let diff: i16 = (img.data[i] as i16 - pixels[i] as i16).abs();
+        assert!(
+            diff <= 2,
+            "8-bit RGB byte {} differs by {}: expected {}, got {}",
+            i,
+            diff,
+            pixels[i],
+            img.data[i]
+        );
+    }
+}
+
+#[test]
+fn lossless_precision_8_large_image() {
+    // 128x128 image to test beyond minimum MCU sizes
+    let (w, h) = (128, 128);
+    let mut pixels: Vec<u8> = vec![0; w * h];
+    for y in 0..h {
+        for x in 0..w {
+            pixels[y * w + x] = ((x ^ y) % 256) as u8;
+        }
+    }
+    let jpeg = compress_lossless(&pixels, w, h, PixelFormat::Grayscale).unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(
+        img.data, pixels,
+        "8-bit large image roundtrip must be exact"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 12-bit precision tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lossless_precision_12_roundtrip_q100() {
+    // 12-bit is lossy (DCT-based), so use quality 100 for minimum loss
+    let (w, h) = (16, 16);
+    let mut pixels: Vec<i16> = Vec::with_capacity(w * h);
+    for i in 0..(w * h) {
+        pixels.push(((i * 16) % 4096) as i16);
+    }
+    let jpeg = compress_12bit(&pixels, w, h, 1, 100, Subsampling::S444).unwrap();
+    let img = decompress_12bit(&jpeg).unwrap();
+    assert_eq!(img.width, w);
+    assert_eq!(img.height, h);
+    let max_diff: i16 = pixels
+        .iter()
+        .zip(img.data.iter())
+        .map(|(a, b)| (*a - *b).abs())
+        .max()
+        .unwrap_or(0);
+    assert!(
+        max_diff <= 8,
+        "12-bit q100 max diff {} exceeds tolerance 8",
+        max_diff
+    );
+}
+
+#[test]
+fn lossless_precision_12_full_range_values() {
+    // Test with minimum (0) and maximum (4095) values
+    let (w, h) = (8, 8);
+    let mut pixels: Vec<i16> = Vec::with_capacity(w * h);
+    pixels.push(0);
+    pixels.push(4095);
+    pixels.push(2048);
+    pixels.push(1);
+    pixels.push(4094);
+    for i in 5..(w * h) {
+        pixels.push((i as i16 * 63) % 4096);
+    }
+    let jpeg = compress_12bit(&pixels, w, h, 1, 100, Subsampling::S444).unwrap();
+    let img = decompress_12bit(&jpeg).unwrap();
+    for &val in &img.data {
+        assert!(
+            val >= 0 && val <= 4095,
+            "12-bit value {} out of valid range 0-4095",
+            val
+        );
+    }
+}
+
+#[test]
+fn lossless_precision_12_three_components() {
+    let (w, h, nc) = (16, 16, 3);
+    let mut pixels: Vec<i16> = Vec::with_capacity(w * h * nc);
+    for y in 0..h {
+        for x in 0..w {
+            pixels.push(((y * w + x) * 16) as i16);
+            pixels.push((x * 256) as i16);
+            pixels.push((y * 256) as i16);
+        }
+    }
+    let jpeg = compress_12bit(&pixels, w, h, nc, 100, Subsampling::S444).unwrap();
+    let img = decompress_12bit(&jpeg).unwrap();
+    assert_eq!(img.num_components, nc);
+    assert_eq!(img.data.len(), w * h * nc);
+}
+
+#[test]
+fn lossless_precision_12_sof_marker_verification() {
+    let pixels: Vec<i16> = vec![2048i16; 64];
+    let jpeg = compress_12bit(&pixels, 8, 8, 1, 90, Subsampling::S444).unwrap();
+    let sof_pos = jpeg.windows(2).position(|w| w[0] == 0xFF && w[1] == 0xC0);
+    assert!(sof_pos.is_some(), "SOF0 marker not found in 12-bit JPEG");
+    assert_eq!(
+        jpeg[sof_pos.unwrap() + 4],
+        12,
+        "SOF0 precision should be 12"
+    );
+}
+
+#[test]
+fn lossless_precision_12_quality_50() {
+    let (w, h) = (16, 16);
+    let mut pixels: Vec<i16> = Vec::with_capacity(w * h);
+    for i in 0..(w * h) {
+        pixels.push((i as i16 * 50) % 4096);
+    }
+    let jpeg = compress_12bit(&pixels, w, h, 1, 50, Subsampling::S444).unwrap();
+    let img = decompress_12bit(&jpeg).unwrap();
+    assert_eq!(img.width, w);
+    assert_eq!(img.height, h);
+    // At quality 50, output is valid but lossy
+    for &val in &img.data {
+        assert!(val >= 0 && val <= 4095, "12-bit value {} out of range", val);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 16-bit lossless precision tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lossless_precision_16_roundtrip_grayscale() {
+    let (w, h) = (16, 16);
+    let mut pixels: Vec<u16> = Vec::with_capacity(w * h);
+    for i in 0..(w * h) {
+        pixels.push((i as u16).wrapping_mul(256));
+    }
+    let jpeg = compress_16bit(&pixels, w, h, 1, 1, 0).unwrap();
+    let img = decompress_16bit(&jpeg).unwrap();
+    assert_eq!(img.data, pixels, "16-bit grayscale roundtrip must be exact");
+}
+
+#[test]
+fn lossless_precision_16_roundtrip_three_component() {
+    let (w, h, nc) = (16, 16, 3);
+    let mut pixels: Vec<u16> = Vec::with_capacity(w * h * nc);
+    for y in 0..h {
+        for x in 0..w {
+            pixels.push(((y * w + x) * 256) as u16);
+            pixels.push(((x * 512) % 65536) as u16);
+            pixels.push(((y * 512) % 65536) as u16);
+        }
+    }
+    let jpeg = compress_16bit(&pixels, w, h, nc, 1, 0).unwrap();
+    let img = decompress_16bit(&jpeg).unwrap();
+    assert_eq!(img.data, pixels, "16-bit 3-comp roundtrip must be exact");
+}
+
+#[test]
+fn lossless_precision_16_full_range() {
+    let (w, h) = (8, 8);
+    let mut pixels: Vec<u16> = Vec::with_capacity(w * h);
+    pixels.push(0);
+    pixels.push(65535);
+    pixels.push(32768);
+    pixels.push(1);
+    pixels.push(65534);
+    for i in 5..(w * h) {
+        pixels.push((i as u16).wrapping_mul(997));
+    }
+    let jpeg = compress_16bit(&pixels, w, h, 1, 1, 0).unwrap();
+    let img = decompress_16bit(&jpeg).unwrap();
+    assert_eq!(
+        img.data, pixels,
+        "16-bit full-range roundtrip must be exact"
+    );
+}
+
+#[test]
+fn lossless_precision_16_all_predictors() {
+    let (w, h) = (8, 8);
+    let mut pixels: Vec<u16> = Vec::with_capacity(w * h);
+    for i in 0..(w * h) {
+        pixels.push((i as u16).wrapping_mul(1000));
+    }
+    for predictor in 1u8..=7 {
+        let jpeg = compress_16bit(&pixels, w, h, 1, predictor, 0)
+            .unwrap_or_else(|e| panic!("predictor {} encode failed: {}", predictor, e));
+        let img = decompress_16bit(&jpeg)
+            .unwrap_or_else(|e| panic!("predictor {} decode failed: {}", predictor, e));
+        assert_eq!(
+            img.data, pixels,
+            "16-bit predictor {} roundtrip must be exact",
+            predictor
+        );
+    }
+}
+
+#[test]
+fn lossless_precision_16_point_transforms() {
+    let (w, h) = (8, 8);
+    for pt in 0u8..=4 {
+        let shift: u16 = 1u16 << pt;
+        let mask: u16 = !shift.wrapping_sub(1);
+        let mut pixels: Vec<u16> = Vec::with_capacity(w * h);
+        for i in 0..(w * h) {
+            pixels.push(((i as u16).wrapping_mul(1024)) & mask);
+        }
+        let jpeg = compress_16bit(&pixels, w, h, 1, 1, pt)
+            .unwrap_or_else(|e| panic!("pt={} encode failed: {}", pt, e));
+        let img =
+            decompress_16bit(&jpeg).unwrap_or_else(|e| panic!("pt={} decode failed: {}", pt, e));
+        for (orig, decoded) in pixels.iter().zip(img.data.iter()) {
+            let expected: u16 = (orig >> pt) << pt;
+            assert_eq!(
+                *decoded, expected,
+                "16-bit pt={}: orig={}, expected={}, got={}",
+                pt, orig, expected, decoded
+            );
+        }
+    }
+}
+
+#[test]
+fn lossless_precision_16_sof_marker_verification() {
+    let pixels: Vec<u16> = vec![32768u16; 64];
+    let jpeg = compress_16bit(&pixels, 8, 8, 1, 1, 0).unwrap();
+    let sof_pos = jpeg.windows(2).position(|w| w[0] == 0xFF && w[1] == 0xC3);
+    assert!(
+        sof_pos.is_some(),
+        "SOF3 marker not found in 16-bit lossless"
+    );
+    assert_eq!(
+        jpeg[sof_pos.unwrap() + 4],
+        16,
+        "SOF3 precision should be 16"
+    );
+}
+
+#[test]
+fn lossless_precision_16_large_image() {
+    // 64x64 to test beyond minimum sizes
+    let (w, h) = (64, 64);
+    let mut pixels: Vec<u16> = Vec::with_capacity(w * h);
+    for y in 0..h {
+        for x in 0..w {
+            pixels.push((x as u16).wrapping_mul(1024) ^ (y as u16).wrapping_mul(512));
+        }
+    }
+    let jpeg = compress_16bit(&pixels, w, h, 1, 1, 0).unwrap();
+    let img = decompress_16bit(&jpeg).unwrap();
+    assert_eq!(
+        img.data, pixels,
+        "16-bit large image roundtrip must be exact"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Unsupported precision documentation
+// ---------------------------------------------------------------------------
+
+/// Document that arbitrary precision values (2-7, 9-11, 13-15) are not
+/// supported by the current API. The 8-bit API uses u8 (precision=8),
+/// 12-bit uses i16 (precision=12), 16-bit uses u16 (precision=16).
+///
+/// These tests verify that values that fit within supported ranges work
+/// correctly, demonstrating the limitation is in the bit-depth encoding,
+/// not in the value range.
+#[test]
+fn precision_2_through_7_fit_in_8bit_api() {
+    // Values from 2-bit (0-3) through 7-bit (0-127) all fit in u8.
+    // The encoder writes precision=8 in the SOF marker regardless.
+    for bits in 2u32..=7 {
+        let max_val: u8 = ((1u32 << bits) - 1) as u8;
+        let mut pixels: Vec<u8> = vec![0; 8 * 8];
+        for i in 0..pixels.len() {
+            pixels[i] = (i as u8) % (max_val + 1);
+        }
+        let jpeg = compress_lossless(&pixels, 8, 8, PixelFormat::Grayscale)
+            .unwrap_or_else(|e| panic!("{}-bit values encode failed: {}", bits, e));
+        let img = decompress(&jpeg)
+            .unwrap_or_else(|e| panic!("{}-bit values decode failed: {}", bits, e));
+        assert_eq!(
+            img.data, pixels,
+            "{}-bit values roundtrip through 8-bit API must be exact",
+            bits
+        );
+
+        // Verify that SOF still says precision=8, not the actual bit depth
+        let sof_pos = jpeg.windows(2).position(|w| w[0] == 0xFF && w[1] == 0xC3);
+        assert!(sof_pos.is_some());
+        assert_eq!(
+            jpeg[sof_pos.unwrap() + 4],
+            8,
+            "{}-bit values encoded with precision=8 (not {})",
+            bits,
+            bits
+        );
+    }
+}
+
+#[test]
+fn precision_9_through_11_fit_in_16bit_api() {
+    // Values from 9-bit (0-511) through 11-bit (0-2047) fit in u16.
+    // The encoder writes precision=16 in the SOF marker regardless.
+    for bits in 9u32..=11 {
+        let max_val: u16 = ((1u32 << bits) - 1) as u16;
+        let mut pixels: Vec<u16> = vec![0; 8 * 8];
+        for i in 0..pixels.len() {
+            pixels[i] = (i as u16) % (max_val + 1);
+        }
+        let jpeg = compress_16bit(&pixels, 8, 8, 1, 1, 0)
+            .unwrap_or_else(|e| panic!("{}-bit values encode failed: {}", bits, e));
+        let img = decompress_16bit(&jpeg)
+            .unwrap_or_else(|e| panic!("{}-bit values decode failed: {}", bits, e));
+        assert_eq!(
+            img.data, pixels,
+            "{}-bit values roundtrip through 16-bit API must be exact",
+            bits
+        );
+
+        // Verify SOF still says precision=16
+        let sof_pos = jpeg.windows(2).position(|w| w[0] == 0xFF && w[1] == 0xC3);
+        assert!(sof_pos.is_some());
+        assert_eq!(
+            jpeg[sof_pos.unwrap() + 4],
+            16,
+            "{}-bit values encoded with precision=16 (not {})",
+            bits,
+            bits
+        );
+    }
+}
+
+#[test]
+fn precision_13_through_15_fit_in_16bit_api() {
+    // Values from 13-bit (0-8191) through 15-bit (0-32767) fit in u16.
+    for bits in 13u32..=15 {
+        let max_val: u16 = ((1u32 << bits) - 1) as u16;
+        let mut pixels: Vec<u16> = vec![0; 8 * 8];
+        for i in 0..pixels.len() {
+            pixels[i] = (i as u16) % (max_val + 1);
+        }
+        let jpeg = compress_16bit(&pixels, 8, 8, 1, 1, 0)
+            .unwrap_or_else(|e| panic!("{}-bit values encode failed: {}", bits, e));
+        let img = decompress_16bit(&jpeg)
+            .unwrap_or_else(|e| panic!("{}-bit values decode failed: {}", bits, e));
+        assert_eq!(
+            img.data, pixels,
+            "{}-bit values roundtrip through 16-bit API must be exact",
+            bits
+        );
+    }
+}

--- a/tests/restart_byte_unit.rs
+++ b/tests/restart_byte_unit.rs
@@ -1,0 +1,354 @@
+//! Byte-unit (MCU block) restart interval tests.
+//!
+//! The C libjpeg-turbo test suite tests `-r 1b` which sets the restart
+//! interval to 1 MCU block (the smallest possible). Our API exposes this
+//! via `Encoder::restart_blocks(n)` where `n` is the number of MCU blocks
+//! between restart markers.
+//!
+//! This test file:
+//! - Verifies restart_blocks(1) produces DRI marker and RST markers
+//! - Tests that the DRI marker value equals 1
+//! - Verifies roundtrip correctness with the smallest restart interval
+//! - Tests multiple subsampling modes and image sizes
+
+use libjpeg_turbo_rs::{decompress, Encoder, PixelFormat, Subsampling};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Count occurrences of a 2-byte marker in JPEG data.
+fn count_marker(data: &[u8], marker_byte: u8) -> usize {
+    data.windows(2)
+        .filter(|w| w[0] == 0xFF && w[1] == marker_byte)
+        .count()
+}
+
+/// Count all RST markers (0xFFD0 through 0xFFD7) in JPEG data.
+fn count_rst_markers(data: &[u8]) -> usize {
+    data.windows(2)
+        .filter(|w| w[0] == 0xFF && (0xD0..=0xD7).contains(&w[1]))
+        .count()
+}
+
+/// Find DRI marker and return the restart interval value it contains.
+/// DRI format: FF DD 00 04 Rr Rr (2-byte interval value, big-endian).
+fn read_dri_interval(data: &[u8]) -> Option<u16> {
+    for i in 0..data.len().saturating_sub(5) {
+        if data[i] == 0xFF && data[i + 1] == 0xDD {
+            // length is at i+2..i+4 (should be 0x0004)
+            let interval: u16 = ((data[i + 4] as u16) << 8) | data[i + 5] as u16;
+            return Some(interval);
+        }
+    }
+    None
+}
+
+/// Create a gradient pixel buffer.
+fn make_pixels(width: usize, height: usize, bpp: usize) -> Vec<u8> {
+    let mut pixels: Vec<u8> = Vec::with_capacity(width * height * bpp);
+    for y in 0..height {
+        for x in 0..width {
+            for c in 0..bpp {
+                pixels.push(((x * 7 + y * 13 + c * 31) % 256) as u8);
+            }
+        }
+    }
+    pixels
+}
+
+// ===========================================================================
+// restart_blocks(1) — smallest interval (every single MCU)
+// ===========================================================================
+
+#[test]
+fn restart_blocks_1_has_dri_marker() {
+    let pixels: Vec<u8> = make_pixels(32, 32, 3);
+    let jpeg = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(75)
+        .subsampling(Subsampling::S444)
+        .restart_blocks(1)
+        .encode()
+        .unwrap();
+
+    let dri_count: usize = count_marker(&jpeg, 0xDD);
+    assert!(dri_count >= 1, "DRI marker (0xFFDD) must be present");
+}
+
+#[test]
+fn restart_blocks_1_dri_value_equals_1() {
+    let pixels: Vec<u8> = make_pixels(32, 32, 3);
+    let jpeg = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(75)
+        .subsampling(Subsampling::S444)
+        .restart_blocks(1)
+        .encode()
+        .unwrap();
+
+    let interval: u16 = read_dri_interval(&jpeg).expect("DRI marker not found");
+    assert_eq!(
+        interval, 1,
+        "DRI interval should be 1 for restart_blocks(1), got {}",
+        interval
+    );
+}
+
+#[test]
+fn restart_blocks_1_has_rst_markers_in_entropy_data() {
+    let pixels: Vec<u8> = make_pixels(32, 32, 3);
+    let jpeg = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(75)
+        .subsampling(Subsampling::S444)
+        .restart_blocks(1)
+        .encode()
+        .unwrap();
+
+    let rst_count: usize = count_rst_markers(&jpeg);
+    // 32x32 with S444 = 4x4 = 16 MCUs, so 15 RST markers expected (between MCUs)
+    assert!(rst_count > 0, "RST markers must be present in entropy data");
+    // With restart_blocks(1), there should be (total_mcus - 1) RST markers
+    // For S444 32x32: MCU = 8x8, so 4*4 = 16 MCUs, 15 RSTs
+    assert!(
+        rst_count >= 10,
+        "expected many RST markers for restart_blocks(1), got {}",
+        rst_count
+    );
+}
+
+#[test]
+fn restart_blocks_1_roundtrip_444() {
+    let pixels: Vec<u8> = make_pixels(32, 32, 3);
+    let jpeg = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(90)
+        .subsampling(Subsampling::S444)
+        .restart_blocks(1)
+        .encode()
+        .unwrap();
+
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 32);
+    assert_eq!(img.height, 32);
+    assert_eq!(img.data.len(), 32 * 32 * 3);
+}
+
+#[test]
+fn restart_blocks_1_roundtrip_420() {
+    let pixels: Vec<u8> = make_pixels(32, 32, 3);
+    let jpeg = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(90)
+        .subsampling(Subsampling::S420)
+        .restart_blocks(1)
+        .encode()
+        .unwrap();
+
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 32);
+    assert_eq!(img.height, 32);
+    assert_eq!(img.data.len(), 32 * 32 * 3);
+}
+
+#[test]
+fn restart_blocks_1_roundtrip_422() {
+    let pixels: Vec<u8> = make_pixels(32, 32, 3);
+    let jpeg = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(90)
+        .subsampling(Subsampling::S422)
+        .restart_blocks(1)
+        .encode()
+        .unwrap();
+
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 32);
+    assert_eq!(img.height, 32);
+    assert_eq!(img.data.len(), 32 * 32 * 3);
+}
+
+#[test]
+fn restart_blocks_1_roundtrip_grayscale() {
+    let pixels: Vec<u8> = make_pixels(32, 32, 1);
+    let jpeg = Encoder::new(&pixels, 32, 32, PixelFormat::Grayscale)
+        .quality(90)
+        .restart_blocks(1)
+        .encode()
+        .unwrap();
+
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 32);
+    assert_eq!(img.height, 32);
+    assert_eq!(img.pixel_format, PixelFormat::Grayscale);
+}
+
+// ===========================================================================
+// restart_blocks(1) with non-MCU-aligned dimensions
+// ===========================================================================
+
+#[test]
+fn restart_blocks_1_non_mcu_aligned_444() {
+    // 37x29: not divisible by 8 (MCU size for S444)
+    let pixels: Vec<u8> = make_pixels(37, 29, 3);
+    let jpeg = Encoder::new(&pixels, 37, 29, PixelFormat::Rgb)
+        .quality(85)
+        .subsampling(Subsampling::S444)
+        .restart_blocks(1)
+        .encode()
+        .unwrap();
+
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 37);
+    assert_eq!(img.height, 29);
+
+    let interval: u16 = read_dri_interval(&jpeg).expect("DRI marker not found");
+    assert_eq!(interval, 1);
+}
+
+#[test]
+fn restart_blocks_1_non_mcu_aligned_420() {
+    // 37x29: not divisible by 16 (MCU size for S420)
+    let pixels: Vec<u8> = make_pixels(37, 29, 3);
+    let jpeg = Encoder::new(&pixels, 37, 29, PixelFormat::Rgb)
+        .quality(85)
+        .subsampling(Subsampling::S420)
+        .restart_blocks(1)
+        .encode()
+        .unwrap();
+
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 37);
+    assert_eq!(img.height, 29);
+
+    let interval: u16 = read_dri_interval(&jpeg).expect("DRI marker not found");
+    assert_eq!(interval, 1);
+}
+
+// ===========================================================================
+// Comparison: restart_blocks(1) vs no restart
+// ===========================================================================
+
+#[test]
+fn restart_blocks_1_decode_matches_no_restart_quality() {
+    // Image content should be identical to without restart markers (at same quality)
+    let pixels: Vec<u8> = make_pixels(32, 32, 3);
+
+    let jpeg_with_rst = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(100)
+        .subsampling(Subsampling::S444)
+        .restart_blocks(1)
+        .encode()
+        .unwrap();
+
+    let jpeg_no_rst = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(100)
+        .subsampling(Subsampling::S444)
+        .encode()
+        .unwrap();
+
+    let img_rst = decompress(&jpeg_with_rst).unwrap();
+    let img_no = decompress(&jpeg_no_rst).unwrap();
+
+    assert_eq!(img_rst.width, img_no.width);
+    assert_eq!(img_rst.height, img_no.height);
+    // At quality 100, restart markers should not change the pixel values
+    assert_eq!(
+        img_rst.data, img_no.data,
+        "restart_blocks(1) at q100 should produce identical pixels to no restart"
+    );
+}
+
+// ===========================================================================
+// restart_blocks(1) produces larger file than without restart
+// ===========================================================================
+
+#[test]
+fn restart_blocks_1_increases_file_size() {
+    let pixels: Vec<u8> = make_pixels(64, 64, 3);
+
+    let jpeg_with_rst = Encoder::new(&pixels, 64, 64, PixelFormat::Rgb)
+        .quality(75)
+        .subsampling(Subsampling::S444)
+        .restart_blocks(1)
+        .encode()
+        .unwrap();
+
+    let jpeg_no_rst = Encoder::new(&pixels, 64, 64, PixelFormat::Rgb)
+        .quality(75)
+        .subsampling(Subsampling::S444)
+        .encode()
+        .unwrap();
+
+    // RST markers add overhead
+    assert!(
+        jpeg_with_rst.len() > jpeg_no_rst.len(),
+        "restart_blocks(1) JPEG ({} bytes) should be larger than no-restart ({} bytes)",
+        jpeg_with_rst.len(),
+        jpeg_no_rst.len()
+    );
+}
+
+// ===========================================================================
+// Larger restart intervals for comparison
+// ===========================================================================
+
+#[test]
+fn restart_blocks_2_has_fewer_rst_than_blocks_1() {
+    let pixels: Vec<u8> = make_pixels(64, 64, 3);
+
+    let jpeg_1 = Encoder::new(&pixels, 64, 64, PixelFormat::Rgb)
+        .quality(75)
+        .subsampling(Subsampling::S444)
+        .restart_blocks(1)
+        .encode()
+        .unwrap();
+
+    let jpeg_2 = Encoder::new(&pixels, 64, 64, PixelFormat::Rgb)
+        .quality(75)
+        .subsampling(Subsampling::S444)
+        .restart_blocks(2)
+        .encode()
+        .unwrap();
+
+    let rst_1: usize = count_rst_markers(&jpeg_1);
+    let rst_2: usize = count_rst_markers(&jpeg_2);
+
+    assert!(
+        rst_1 > rst_2,
+        "restart_blocks(1) should have more RST markers ({}) than restart_blocks(2) ({})",
+        rst_1,
+        rst_2
+    );
+}
+
+#[test]
+fn restart_blocks_2_dri_value_equals_2() {
+    let pixels: Vec<u8> = make_pixels(32, 32, 3);
+    let jpeg = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(75)
+        .subsampling(Subsampling::S444)
+        .restart_blocks(2)
+        .encode()
+        .unwrap();
+
+    let interval: u16 = read_dri_interval(&jpeg).expect("DRI marker not found");
+    assert_eq!(
+        interval, 2,
+        "DRI interval should be 2 for restart_blocks(2)"
+    );
+}
+
+// ===========================================================================
+// Decode existing fixture with restart markers
+// ===========================================================================
+
+#[test]
+fn decode_fixture_with_restart_markers() {
+    let data = include_bytes!("fixtures/photo_640x480_420_rst.jpg");
+    let img = decompress(data).unwrap();
+    // Despite the filename, the actual image dimensions are 320x240
+    assert_eq!(img.width, 320);
+    assert_eq!(img.height, 240);
+    // Verify it has RST markers
+    let rst_count: usize = count_rst_markers(data);
+    assert!(
+        rst_count > 0,
+        "fixture photo_640x480_420_rst.jpg should contain RST markers"
+    );
+}

--- a/tests/scaling_extended.rs
+++ b/tests/scaling_extended.rs
@@ -1,0 +1,555 @@
+//! Extended scaling factor tests.
+//!
+//! The C libjpeg-turbo test suite tests 15 scaling factors: 16/8, 15/8, 14/8,
+//! 13/8, 12/8, 11/8, 10/8, 9/8, 7/8, 6/8, 5/8, 4/8, 3/8, 2/8, 1/8.
+//!
+//! Our implementation supports only the standard libjpeg scaling factors via
+//! reduced IDCT: 1/1 (8/8), 1/2 (4/8), 1/4 (2/8), 1/8 (1/8).
+//! Intermediate factors (e.g., 15/8, 7/8) are NOT supported because our
+//! ScalingFactor::block_size() maps them to the nearest supported IDCT size.
+//!
+//! This test file:
+//! - Thoroughly tests all 4 supported factors across multiple subsampling modes
+//! - Documents the unsupported intermediate factors with explicit tests showing
+//!   they map to the nearest supported factor (not a separate decode path)
+
+use libjpeg_turbo_rs::api::streaming::StreamingDecoder;
+use libjpeg_turbo_rs::{compress, decompress, Image, PixelFormat, ScalingFactor, Subsampling};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn decode_scaled(data: &[u8], num: u32, denom: u32) -> Image {
+    let mut decoder = StreamingDecoder::new(data).unwrap();
+    decoder.set_scale(ScalingFactor::new(num, denom));
+    decoder.decode().unwrap()
+}
+
+/// Create a synthetic test image with a gradient pattern.
+fn make_gradient(width: usize, height: usize) -> Vec<u8> {
+    let mut pixels: Vec<u8> = Vec::with_capacity(width * height * 3);
+    for y in 0..height {
+        for x in 0..width {
+            pixels.push(((x * 255) / width.max(1)) as u8); // R
+            pixels.push(((y * 255) / height.max(1)) as u8); // G
+            pixels.push((((x + y) * 127) / (width + height).max(1)) as u8); // B
+        }
+    }
+    pixels
+}
+
+/// Encode a gradient image with the given subsampling, return JPEG bytes.
+fn encode_gradient(width: usize, height: usize, subsampling: Subsampling) -> Vec<u8> {
+    let pixels: Vec<u8> = make_gradient(width, height);
+    compress(&pixels, width, height, PixelFormat::Rgb, 90, subsampling).unwrap()
+}
+
+/// Encode a grayscale gradient, return JPEG bytes.
+fn encode_grayscale_gradient(width: usize, height: usize) -> Vec<u8> {
+    let mut pixels: Vec<u8> = Vec::with_capacity(width * height);
+    for y in 0..height {
+        for x in 0..width {
+            pixels.push(((x * 255 + y * 127) / (width + height).max(1)) as u8);
+        }
+    }
+    compress(
+        &pixels,
+        width,
+        height,
+        PixelFormat::Grayscale,
+        90,
+        Subsampling::S444,
+    )
+    .unwrap()
+}
+
+// ===========================================================================
+// 1/1 scale (full size)
+// ===========================================================================
+
+#[test]
+fn scale_1_1_420_dimensions() {
+    let data = encode_gradient(320, 240, Subsampling::S420);
+    let img = decode_scaled(&data, 1, 1);
+    assert_eq!(img.width, 320);
+    assert_eq!(img.height, 240);
+    assert_eq!(img.data.len(), 320 * 240 * 3);
+}
+
+#[test]
+fn scale_1_1_444_dimensions() {
+    let data = encode_gradient(320, 240, Subsampling::S444);
+    let img = decode_scaled(&data, 1, 1);
+    assert_eq!(img.width, 320);
+    assert_eq!(img.height, 240);
+    assert_eq!(img.data.len(), 320 * 240 * 3);
+}
+
+#[test]
+fn scale_1_1_grayscale_dimensions() {
+    let data = encode_grayscale_gradient(320, 240);
+    let img = decode_scaled(&data, 1, 1);
+    assert_eq!(img.width, 320);
+    assert_eq!(img.height, 240);
+    assert_eq!(img.pixel_format, PixelFormat::Grayscale);
+    assert_eq!(img.data.len(), 320 * 240);
+}
+
+#[test]
+fn scale_1_1_matches_default_decode() {
+    let data = include_bytes!("fixtures/photo_320x240_420.jpg");
+    let default_img = decompress(data).unwrap();
+    let scaled_img = decode_scaled(data, 1, 1);
+    assert_eq!(default_img.width, scaled_img.width);
+    assert_eq!(default_img.height, scaled_img.height);
+    assert_eq!(default_img.data, scaled_img.data);
+}
+
+#[test]
+fn scale_1_1_odd_dimensions() {
+    // Non-MCU-aligned image size
+    let pixels: Vec<u8> = make_gradient(37, 29);
+    let jpeg = compress(&pixels, 37, 29, PixelFormat::Rgb, 90, Subsampling::S420).unwrap();
+    let img = decode_scaled(&jpeg, 1, 1);
+    assert_eq!(img.width, 37);
+    assert_eq!(img.height, 29);
+}
+
+// ===========================================================================
+// 1/2 scale (half size)
+// ===========================================================================
+
+#[test]
+fn scale_1_2_420_dimensions() {
+    let data = encode_gradient(320, 240, Subsampling::S420);
+    let img = decode_scaled(&data, 1, 2);
+    assert_eq!(img.width, 160);
+    assert_eq!(img.height, 120);
+    assert_eq!(img.data.len(), 160 * 120 * 3);
+}
+
+#[test]
+fn scale_1_2_444_dimensions() {
+    let data = encode_gradient(320, 240, Subsampling::S444);
+    let img = decode_scaled(&data, 1, 2);
+    assert_eq!(img.width, 160);
+    assert_eq!(img.height, 120);
+    assert_eq!(img.data.len(), 160 * 120 * 3);
+}
+
+#[test]
+fn scale_1_2_422_dimensions() {
+    let data = encode_gradient(320, 240, Subsampling::S422);
+    let img = decode_scaled(&data, 1, 2);
+    assert_eq!(img.width, 160);
+    assert_eq!(img.height, 120);
+    assert_eq!(img.data.len(), 160 * 120 * 3);
+}
+
+#[test]
+fn scale_1_2_grayscale_dimensions() {
+    let data = encode_grayscale_gradient(320, 240);
+    let img = decode_scaled(&data, 1, 2);
+    assert_eq!(img.width, 160);
+    assert_eq!(img.height, 120);
+    assert_eq!(img.pixel_format, PixelFormat::Grayscale);
+    assert_eq!(img.data.len(), 160 * 120);
+}
+
+#[test]
+fn scale_1_2_odd_dimensions() {
+    let pixels: Vec<u8> = make_gradient(37, 29);
+    let jpeg = compress(&pixels, 37, 29, PixelFormat::Rgb, 90, Subsampling::S420).unwrap();
+    let img = decode_scaled(&jpeg, 1, 2);
+    // ceil(37/2)=19, ceil(29/2)=15
+    assert_eq!(img.width, 19);
+    assert_eq!(img.height, 15);
+}
+
+#[test]
+fn scale_1_2_large_image() {
+    let data = include_bytes!("fixtures/gradient_640x480.jpg");
+    let img = decode_scaled(data, 1, 2);
+    assert_eq!(img.width, 320);
+    assert_eq!(img.height, 240);
+}
+
+#[test]
+fn scale_1_2_progressive() {
+    let data = include_bytes!("fixtures/photo_320x240_420_prog.jpg");
+    let img = decode_scaled(data, 1, 2);
+    assert_eq!(img.width, 160);
+    assert_eq!(img.height, 120);
+    assert_eq!(img.data.len(), 160 * 120 * 3);
+}
+
+// ===========================================================================
+// 1/4 scale (quarter size)
+// ===========================================================================
+
+#[test]
+fn scale_1_4_420_dimensions() {
+    let data = encode_gradient(320, 240, Subsampling::S420);
+    let img = decode_scaled(&data, 1, 4);
+    assert_eq!(img.width, 80);
+    assert_eq!(img.height, 60);
+    assert_eq!(img.data.len(), 80 * 60 * 3);
+}
+
+#[test]
+fn scale_1_4_444_dimensions() {
+    let data = encode_gradient(320, 240, Subsampling::S444);
+    let img = decode_scaled(&data, 1, 4);
+    assert_eq!(img.width, 80);
+    assert_eq!(img.height, 60);
+    assert_eq!(img.data.len(), 80 * 60 * 3);
+}
+
+#[test]
+fn scale_1_4_422_dimensions() {
+    let data = encode_gradient(320, 240, Subsampling::S422);
+    let img = decode_scaled(&data, 1, 4);
+    assert_eq!(img.width, 80);
+    assert_eq!(img.height, 60);
+    assert_eq!(img.data.len(), 80 * 60 * 3);
+}
+
+#[test]
+fn scale_1_4_grayscale_dimensions() {
+    let data = encode_grayscale_gradient(320, 240);
+    let img = decode_scaled(&data, 1, 4);
+    assert_eq!(img.width, 80);
+    assert_eq!(img.height, 60);
+    assert_eq!(img.pixel_format, PixelFormat::Grayscale);
+    assert_eq!(img.data.len(), 80 * 60);
+}
+
+#[test]
+fn scale_1_4_odd_dimensions() {
+    let pixels: Vec<u8> = make_gradient(37, 29);
+    let jpeg = compress(&pixels, 37, 29, PixelFormat::Rgb, 90, Subsampling::S420).unwrap();
+    let img = decode_scaled(&jpeg, 1, 4);
+    // ceil(37/4)=10, ceil(29/4)=8
+    assert_eq!(img.width, 10);
+    assert_eq!(img.height, 8);
+}
+
+#[test]
+fn scale_1_4_progressive() {
+    let data = include_bytes!("fixtures/photo_320x240_420_prog.jpg");
+    let img = decode_scaled(data, 1, 4);
+    assert_eq!(img.width, 80);
+    assert_eq!(img.height, 60);
+}
+
+// ===========================================================================
+// 1/8 scale (eighth size)
+// ===========================================================================
+
+#[test]
+fn scale_1_8_420_dimensions() {
+    let data = encode_gradient(320, 240, Subsampling::S420);
+    let img = decode_scaled(&data, 1, 8);
+    assert_eq!(img.width, 40);
+    assert_eq!(img.height, 30);
+    assert_eq!(img.data.len(), 40 * 30 * 3);
+}
+
+#[test]
+fn scale_1_8_444_dimensions() {
+    let data = encode_gradient(320, 240, Subsampling::S444);
+    let img = decode_scaled(&data, 1, 8);
+    assert_eq!(img.width, 40);
+    assert_eq!(img.height, 30);
+    assert_eq!(img.data.len(), 40 * 30 * 3);
+}
+
+#[test]
+fn scale_1_8_422_dimensions() {
+    let data = encode_gradient(320, 240, Subsampling::S422);
+    let img = decode_scaled(&data, 1, 8);
+    assert_eq!(img.width, 40);
+    assert_eq!(img.height, 30);
+    assert_eq!(img.data.len(), 40 * 30 * 3);
+}
+
+#[test]
+fn scale_1_8_grayscale_dimensions() {
+    let data = encode_grayscale_gradient(320, 240);
+    let img = decode_scaled(&data, 1, 8);
+    assert_eq!(img.width, 40);
+    assert_eq!(img.height, 30);
+    assert_eq!(img.pixel_format, PixelFormat::Grayscale);
+    assert_eq!(img.data.len(), 40 * 30);
+}
+
+#[test]
+fn scale_1_8_odd_dimensions() {
+    let pixels: Vec<u8> = make_gradient(37, 29);
+    let jpeg = compress(&pixels, 37, 29, PixelFormat::Rgb, 90, Subsampling::S420).unwrap();
+    let img = decode_scaled(&jpeg, 1, 8);
+    // ceil(37/8)=5, ceil(29/8)=4
+    assert_eq!(img.width, 5);
+    assert_eq!(img.height, 4);
+}
+
+#[test]
+fn scale_1_8_minimum_size() {
+    // 8x8 image scaled to 1/8 = 1x1
+    let data = include_bytes!("fixtures/gray_8x8.jpg");
+    let img = decode_scaled(data, 1, 8);
+    assert_eq!(img.width, 1);
+    assert_eq!(img.height, 1);
+}
+
+#[test]
+fn scale_1_8_large_image() {
+    let data = include_bytes!("fixtures/gradient_640x480.jpg");
+    let img = decode_scaled(data, 1, 8);
+    assert_eq!(img.width, 80);
+    assert_eq!(img.height, 60);
+}
+
+// ===========================================================================
+// Equivalent fraction forms produce same output as canonical forms
+// ===========================================================================
+
+#[test]
+fn scale_4_8_same_as_1_2() {
+    let data = include_bytes!("fixtures/photo_320x240_420.jpg");
+    let half = decode_scaled(data, 1, 2);
+    let four_eighth = decode_scaled(data, 4, 8);
+    assert_eq!(half.width, four_eighth.width);
+    assert_eq!(half.height, four_eighth.height);
+    assert_eq!(half.data, four_eighth.data);
+}
+
+#[test]
+fn scale_2_8_same_as_1_4() {
+    let data = include_bytes!("fixtures/photo_320x240_420.jpg");
+    let quarter = decode_scaled(data, 1, 4);
+    let two_eighth = decode_scaled(data, 2, 8);
+    assert_eq!(quarter.width, two_eighth.width);
+    assert_eq!(quarter.height, two_eighth.height);
+    assert_eq!(quarter.data, two_eighth.data);
+}
+
+#[test]
+fn scale_2_4_same_as_1_2() {
+    let data = include_bytes!("fixtures/photo_320x240_420.jpg");
+    let half = decode_scaled(data, 1, 2);
+    let two_fourths = decode_scaled(data, 2, 4);
+    assert_eq!(half.width, two_fourths.width);
+    assert_eq!(half.height, two_fourths.height);
+    assert_eq!(half.data, two_fourths.data);
+}
+
+// ===========================================================================
+// Intermediate (unsupported) scaling factors map to nearest supported IDCT
+//
+// libjpeg-turbo C supports 15 factors via M/8 IDCT. Our implementation only
+// supports 4 factors via standard reduced-IDCT (block sizes 8, 4, 2, 1).
+// The ScalingFactor::block_size() maps unsupported ratios to the nearest:
+//   ratio_x8 >= 5 -> block_size 8 (full)
+//   ratio_x8 3..=4 -> block_size 4 (half)
+//   ratio_x8 == 2 -> block_size 2 (quarter)
+//   ratio_x8 0..=1 -> block_size 1 (eighth)
+//
+// These tests document that intermediate factors produce output at the
+// corresponding supported block size, NOT at the exact requested dimensions.
+// ===========================================================================
+
+#[test]
+fn intermediate_scale_block_size_mapping() {
+    // Verify ScalingFactor::block_size() for all 15 C test factors
+    let cases: Vec<(u32, u32, usize)> = vec![
+        // (num, denom, expected_block_size)
+        (16, 8, 8), // 2.0x -> full IDCT
+        (15, 8, 8), // 1.875x -> full IDCT
+        (14, 8, 8), // 1.75x -> full IDCT
+        (13, 8, 8), // 1.625x -> full IDCT
+        (12, 8, 8), // 1.5x -> full IDCT
+        (11, 8, 8), // 1.375x -> full IDCT
+        (10, 8, 8), // 1.25x -> full IDCT
+        (9, 8, 8),  // 1.125x -> full IDCT
+        // 8/8 = 1.0x -> full IDCT (canonical 1/1)
+        (8, 8, 8),
+        (7, 8, 8), // 0.875x -> full IDCT (ratio_x8=7, >=5)
+        (6, 8, 8), // 0.75x -> full IDCT (ratio_x8=6, >=5)
+        (5, 8, 8), // 0.625x -> full IDCT (ratio_x8=5, >=5)
+        (4, 8, 4), // 0.5x -> half IDCT (ratio_x8=4)
+        (3, 8, 4), // 0.375x -> half IDCT (ratio_x8=3)
+        (2, 8, 2), // 0.25x -> quarter IDCT (ratio_x8=2)
+        (1, 8, 1), // 0.125x -> eighth IDCT (ratio_x8=1)
+    ];
+    for (num, denom, expected_block) in cases {
+        let sf = ScalingFactor::new(num, denom);
+        assert_eq!(
+            sf.block_size(),
+            expected_block,
+            "ScalingFactor({}/{}).block_size() should be {}, got {}",
+            num,
+            denom,
+            expected_block,
+            sf.block_size()
+        );
+    }
+}
+
+#[test]
+fn intermediate_7_8_decodes_at_full_size() {
+    // 7/8 maps to block_size 8 (full), so output uses full IDCT dimensions
+    // but scale_dim computes ceil(320*7/8)=280, ceil(240*7/8)=210
+    let data = encode_gradient(320, 240, Subsampling::S420);
+    let img = decode_scaled(&data, 7, 8);
+    let expected_w: usize = ScalingFactor::new(7, 8).scale_dim(320);
+    let expected_h: usize = ScalingFactor::new(7, 8).scale_dim(240);
+    // The decode should succeed regardless; verify dimensions are reasonable
+    assert!(img.width > 0, "decoded width should be positive");
+    assert!(img.height > 0, "decoded height should be positive");
+    // Document the actual dimensions produced
+    assert_eq!(
+        img.width, expected_w,
+        "7/8 scale width: expected scale_dim result {}, got {}",
+        expected_w, img.width
+    );
+    assert_eq!(
+        img.height, expected_h,
+        "7/8 scale height: expected scale_dim result {}, got {}",
+        expected_h, img.height
+    );
+}
+
+#[test]
+fn intermediate_3_8_decodes_at_half_idct() {
+    // 3/8 maps to block_size 4 (same as 1/2), scale_dim gives ceil(320*3/8)=120
+    let data = encode_gradient(320, 240, Subsampling::S420);
+    let img = decode_scaled(&data, 3, 8);
+    let expected_w: usize = ScalingFactor::new(3, 8).scale_dim(320);
+    let expected_h: usize = ScalingFactor::new(3, 8).scale_dim(240);
+    assert!(img.width > 0);
+    assert!(img.height > 0);
+    assert_eq!(img.width, expected_w);
+    assert_eq!(img.height, expected_h);
+}
+
+// ===========================================================================
+// Pixel content validation
+// ===========================================================================
+
+#[test]
+fn scaled_output_has_dynamic_range() {
+    // All 4 supported scale factors should produce non-uniform output from a real photo
+    let data = include_bytes!("fixtures/photo_320x240_420.jpg");
+    for (num, denom) in &[(1u32, 1u32), (1, 2), (1, 4), (1, 8)] {
+        let img = decode_scaled(data, *num, *denom);
+        let min = *img.data.iter().min().unwrap();
+        let max = *img.data.iter().max().unwrap();
+        assert!(
+            max - min > 30,
+            "scale {}/{}: expected dynamic range, got min={} max={}",
+            num,
+            denom,
+            min,
+            max
+        );
+    }
+}
+
+#[test]
+fn smaller_scale_produces_fewer_pixels() {
+    let data = include_bytes!("fixtures/photo_320x240_420.jpg");
+    let full = decode_scaled(data, 1, 1);
+    let half = decode_scaled(data, 1, 2);
+    let quarter = decode_scaled(data, 1, 4);
+    let eighth = decode_scaled(data, 1, 8);
+
+    assert!(full.data.len() > half.data.len());
+    assert!(half.data.len() > quarter.data.len());
+    assert!(quarter.data.len() > eighth.data.len());
+}
+
+#[test]
+fn scale_dimension_calculation_is_ceil_division() {
+    // Verify ScalingFactor::scale_dim computes ceil(dim * num / denom)
+    let cases: Vec<(usize, u32, u32, usize)> = vec![
+        (320, 1, 1, 320),
+        (320, 1, 2, 160),
+        (320, 1, 4, 80),
+        (320, 1, 8, 40),
+        (240, 1, 1, 240),
+        (240, 1, 2, 120),
+        (240, 1, 4, 60),
+        (240, 1, 8, 30),
+        // Odd sizes
+        (37, 1, 2, 19), // ceil(37/2)
+        (37, 1, 4, 10), // ceil(37/4)
+        (37, 1, 8, 5),  // ceil(37/8)
+        (29, 1, 2, 15), // ceil(29/2)
+        (29, 1, 4, 8),  // ceil(29/4)
+        (29, 1, 8, 4),  // ceil(29/8)
+    ];
+    for (dim, num, denom, expected) in cases {
+        let sf = ScalingFactor::new(num, denom);
+        assert_eq!(
+            sf.scale_dim(dim),
+            expected,
+            "scale_dim({}, {}/{}) should be {}",
+            dim,
+            num,
+            denom,
+            expected
+        );
+    }
+}
+
+// ===========================================================================
+// Real fixture images at all 4 supported scales
+// ===========================================================================
+
+#[test]
+fn fixture_photo_320x240_420_all_scales() {
+    let data = include_bytes!("fixtures/photo_320x240_420.jpg");
+    for (num, denom, ew, eh) in &[
+        (1u32, 1u32, 320usize, 240usize),
+        (1, 2, 160, 120),
+        (1, 4, 80, 60),
+        (1, 8, 40, 30),
+    ] {
+        let img = decode_scaled(data, *num, *denom);
+        assert_eq!(img.width, *ew, "scale {}/{} width", num, denom);
+        assert_eq!(img.height, *eh, "scale {}/{} height", num, denom);
+    }
+}
+
+#[test]
+fn fixture_photo_320x240_444_all_scales() {
+    let data = include_bytes!("fixtures/photo_320x240_444.jpg");
+    for (num, denom, ew, eh) in &[
+        (1u32, 1u32, 320usize, 240usize),
+        (1, 2, 160, 120),
+        (1, 4, 80, 60),
+        (1, 8, 40, 30),
+    ] {
+        let img = decode_scaled(data, *num, *denom);
+        assert_eq!(img.width, *ew, "scale {}/{} width", num, denom);
+        assert_eq!(img.height, *eh, "scale {}/{} height", num, denom);
+    }
+}
+
+#[test]
+fn fixture_gray_8x8_all_scales() {
+    let data = include_bytes!("fixtures/gray_8x8.jpg");
+    for (num, denom, ew, eh) in &[
+        (1u32, 1u32, 8usize, 8usize),
+        (1, 2, 4, 4),
+        (1, 4, 2, 2),
+        (1, 8, 1, 1),
+    ] {
+        let img = decode_scaled(data, *num, *denom);
+        assert_eq!(img.width, *ew, "scale {}/{} width", num, denom);
+        assert_eq!(img.height, *eh, "scale {}/{} height", num, denom);
+        assert_eq!(img.pixel_format, PixelFormat::Grayscale);
+    }
+}


### PR DESCRIPTION
## Summary
- Add 93 tests across 4 new test files covering single-dimension gaps identified by C test parity analysis
- **scaling_extended.rs** (37 tests): All 4 supported scaling factors (1/1, 1/2, 1/4, 1/8) across multiple subsampling modes, odd dimensions, progressive, equivalent fractions. Documents that intermediate C factors (15/8, 7/8, etc.) are not separately supported.
- **precision_extended.rs** (23 tests): Full coverage of 8/12/16-bit precision with all predictors, point transforms, SOF verification. Documents that arbitrary precisions (2-7, 9-11, 13-15) are not supported as separate encode modes but values fit within existing APIs.
- **crop_c_compat.rs** (19 tests): All 5 exact C test crop coordinates on 64x64 images with 444/420 subsampling and real photo fixture, with pixel-by-pixel verification against full decode.
- **restart_byte_unit.rs** (14 tests): Byte-unit restart interval (restart_blocks(1)), verifying DRI marker value=1, RST markers in entropy data, roundtrip across all subsampling modes.

Only test files added. No src/ changes.

## verify_test_parity.py output

```
======================================================================
TEST PARITY VERIFICATION REPORT
======================================================================

C estimated test cases:        44,125
Rust test count:                1,027
Rust test files:                   86

DIMENSION COVERAGE
  subsampling                 7/8   ( 87.5%)
  pixel_formats              12/12  (100.0%)
  dct_methods                 3/3   (100.0%)
  entropy_coding              5/5   (100.0%)
  scaling_factors             3/15  ( 20.0%)   -- only 4 supported via IDCT; all 4 tested
  precision                   3/15  ( 20.0%)   -- only 8/12/16 supported; all 3 tested
  transform_ops               8/8   (100.0%)
  crop_regions                5/5   (100.0%)
  restart                     3/4   ( 75.0%)   -- restart_blocks(1) now tested
```

Note: The script reports scaling as 3/15 and precision as 3/15 because it counts
C's 15 factors/precisions. Our implementation supports 4 scaling factors and 3
precision levels; all supported values are now tested with documentation of why
intermediate values are not separately supported.

## Test plan
- [x] All 93 new tests pass
- [x] Full cargo test suite passes (zero failures)
- [x] cargo fmt applied
- [x] No src/ files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)