### PR TITLE
fix: correct AC refine encoder and restore full progressive scan script

### DIFF
--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -2890,38 +2890,33 @@ fn encode_ac_refine_block(
     let mut r: usize = 0; // zero run length
     let mut correction_bits: Vec<u8> = Vec::new();
 
+    // Main loop: matches C jcphuff.c ENCODE_COEFS_AC_REFINE.
+    // ZRL check happens BEFORE processing each nonzero coefficient.
     for i in 0..band_len {
         let temp: u16 = absvals[i];
 
+        if temp == 0 {
+            r += 1;
+            continue;
+        }
+
+        // Nonzero: check ZRL before processing (key fix)
+        while r > 15 && (i as i32) <= eob_idx {
+            writer.write_bits(ac_table.ehufco[0xF0], ac_table.ehufsi[0xF0]);
+            r -= 16;
+            emit_buffered_bits(&correction_bits, writer);
+            correction_bits.clear();
+        }
+
         if temp > 1 {
-            // Previously nonzero: buffer its correction bit
             correction_bits.push((temp & 1) as u8);
-        } else if temp == 1 {
-            // Newly nonzero coefficient
-
-            // Emit ZRLs, but only while within the EOB boundary
-            while r > 15 && (i as i32) <= eob_idx {
-                writer.write_bits(ac_table.ehufco[0xF0], ac_table.ehufsi[0xF0]);
-                r -= 16;
-                // Emit buffered correction bits with this ZRL
-                emit_buffered_bits(&correction_bits, writer);
-                correction_bits.clear();
-            }
-
-            // Emit (run << 4) | 1
+        } else {
             let symbol: usize = (r << 4) | 1;
             writer.write_bits(ac_table.ehufco[symbol], ac_table.ehufsi[symbol]);
-
-            // Emit sign bit for newly-nonzero coefficient
             writer.write_bits(signs[i], 1);
-
-            // Emit correction bits associated with this code
             emit_buffered_bits(&correction_bits, writer);
             correction_bits.clear();
             r = 0;
-        } else {
-            // Zero coefficient: increment zero run
-            r += 1;
         }
     }
 

--- a/src/encode/progressive.rs
+++ b/src/encode/progressive.rs
@@ -20,97 +20,73 @@ pub struct ProgressiveScan {
 
 /// Generate a simple progressive scan script.
 ///
-/// Follows libjpeg-turbo's default progression for 1 or 3 components:
+/// Follows libjpeg-turbo's default progression (jcparam.c `jpeg_simple_progression`).
+/// Uses successive approximation for both DC and AC coefficients:
+///
 /// 1. DC first (all components interleaved), Al=1
-/// 2. AC scans per-component for spectral bands (1-5, 6-63)
-/// 3. DC refine (all components), Al=0
-/// 4. AC refine scans per-component
+/// 2. AC first scans per-component for bands (1-5, 6-63), Al=2
+/// 3. AC refine scans per-component (1-63), Ah=2, Al=1
+/// 4. DC refine (all components), Ah=1, Al=0
+/// 5. AC refine scans per-component (1-63), Ah=1, Al=0
 pub fn simple_progression(num_components: usize) -> Vec<ProgressiveScan> {
     let mut scans = Vec::new();
+    let all_comps: Vec<usize> = (0..num_components).collect();
 
-    if num_components == 1 {
-        // Grayscale: DC successive approximation, AC full precision per band
-        let comp = vec![0];
+    // DC first scan: all components, Ah=0, Al=1
+    scans.push(ProgressiveScan {
+        component_indices: all_comps.clone(),
+        ss: 0,
+        se: 0,
+        ah: 0,
+        al: 1,
+    });
 
-        // DC first, Al=1
+    // AC first scans: per-component, spectral bands, Ah=0, Al=2
+    for ci in 0..num_components {
         scans.push(ProgressiveScan {
-            component_indices: comp.clone(),
-            ss: 0,
-            se: 0,
-            ah: 0,
-            al: 1,
-        });
-
-        // AC 1-5, Al=0
-        scans.push(ProgressiveScan {
-            component_indices: comp.clone(),
+            component_indices: vec![ci],
             ss: 1,
             se: 5,
             ah: 0,
-            al: 0,
+            al: 2,
         });
-
-        // AC 6-63, Al=0
+    }
+    for ci in 0..num_components {
         scans.push(ProgressiveScan {
-            component_indices: comp.clone(),
+            component_indices: vec![ci],
             ss: 6,
             se: 63,
             ah: 0,
-            al: 0,
+            al: 2,
         });
+    }
 
-        // DC refine, Al=0
+    // AC refine: per-component, full band, Ah=2, Al=1
+    for ci in 0..num_components {
         scans.push(ProgressiveScan {
-            component_indices: comp,
-            ss: 0,
-            se: 0,
-            ah: 1,
-            al: 0,
-        });
-    } else {
-        // Color: interleaved DC, per-component AC
-        // Uses DC successive approximation (first + refine) but no AC successive
-        // approximation refine scans. AC refine encoding is complex and the
-        // standard Huffman tables lack EOBRUN symbols needed for proper batching.
-        let all_comps: Vec<usize> = (0..num_components).collect();
-
-        // DC first scan: all components, Al=1
-        scans.push(ProgressiveScan {
-            component_indices: all_comps.clone(),
-            ss: 0,
-            se: 0,
-            ah: 0,
+            component_indices: vec![ci],
+            ss: 1,
+            se: 63,
+            ah: 2,
             al: 1,
         });
+    }
 
-        // AC scans: per-component, spectral bands
-        for ci in 0..num_components {
-            // AC 1-5, Al=0 (full precision, no refine needed)
-            scans.push(ProgressiveScan {
-                component_indices: vec![ci],
-                ss: 1,
-                se: 5,
-                ah: 0,
-                al: 0,
-            });
-        }
+    // DC refine: all components, Ah=1, Al=0
+    scans.push(ProgressiveScan {
+        component_indices: all_comps,
+        ss: 0,
+        se: 0,
+        ah: 1,
+        al: 0,
+    });
 
-        for ci in 0..num_components {
-            // AC 6-63, Al=0 (full precision, no refine needed)
-            scans.push(ProgressiveScan {
-                component_indices: vec![ci],
-                ss: 6,
-                se: 63,
-                ah: 0,
-                al: 0,
-            });
-        }
-
-        // DC refine: all components, Al=0
+    // AC refine: per-component, full band, Ah=1, Al=0
+    for ci in 0..num_components {
         scans.push(ProgressiveScan {
-            component_indices: all_comps,
-            ss: 0,
-            se: 0,
+            component_indices: vec![ci],
+            ss: 1,
+            se: 63,
             ah: 1,
             al: 0,
         });
@@ -126,20 +102,31 @@ mod tests {
     #[test]
     fn simple_progression_grayscale() {
         let scans = simple_progression(1);
-        assert!(scans.len() >= 4);
-        // First scan should be DC
+        // 1 DC first + 2 AC first + 1 AC refine + 1 DC refine + 1 AC refine = 6
+        assert_eq!(scans.len(), 6);
         assert_eq!(scans[0].ss, 0);
         assert_eq!(scans[0].se, 0);
+        assert_eq!(scans[0].ah, 0);
+        assert_eq!(scans[0].al, 1);
+        assert_eq!(scans[1].al, 2);
+        assert_eq!(scans[3].ah, 2);
+        assert_eq!(scans[3].al, 1);
+        assert_eq!(scans[5].ah, 1);
+        assert_eq!(scans[5].al, 0);
     }
 
     #[test]
     fn simple_progression_3_components() {
         let scans = simple_progression(3);
-        assert!(scans.len() >= 8);
-        // First scan: DC, all components, Al=1
+        // 1 DC first + 6 AC first + 3 AC refine + 1 DC refine + 3 AC refine = 14
+        assert_eq!(scans.len(), 14);
         assert_eq!(scans[0].ss, 0);
         assert_eq!(scans[0].se, 0);
         assert_eq!(scans[0].component_indices.len(), 3);
         assert_eq!(scans[0].al, 1);
+        let last = &scans[13];
+        assert_eq!(last.ah, 1);
+        assert_eq!(last.al, 0);
+        assert_eq!(last.component_indices, vec![2]);
     }
 }

--- a/tests/progressive_enc.rs
+++ b/tests/progressive_enc.rs
@@ -43,10 +43,112 @@ fn progressive_has_sof2_marker() {
     let pixels = vec![128u8; 16 * 16 * 3];
     let jpeg =
         compress_progressive(&pixels, 16, 16, PixelFormat::Rgb, 75, Subsampling::S444).unwrap();
-    // SOI
     assert_eq!(jpeg[0], 0xFF);
     assert_eq!(jpeg[1], 0xD8);
-    // Should contain SOF2 (0xC2) marker
     let has_sof2 = jpeg.windows(2).any(|w| w[0] == 0xFF && w[1] == 0xC2);
     assert!(has_sof2, "progressive JPEG should contain SOF2 marker");
+}
+
+fn gradient_pixels(width: usize, height: usize, channels: usize) -> Vec<u8> {
+    let mut pixels = vec![0u8; width * height * channels];
+    for y in 0..height {
+        for x in 0..width {
+            let offset: usize = (y * width + x) * channels;
+            let r: u8 = ((x * 255) / width.max(1)) as u8;
+            let g: u8 = ((y * 255) / height.max(1)) as u8;
+            let b: u8 = (((x + y) * 127) / (width + height).max(1)) as u8;
+            if channels >= 3 {
+                pixels[offset] = r;
+                pixels[offset + 1] = g;
+                pixels[offset + 2] = b;
+            } else {
+                pixels[offset] = r;
+            }
+        }
+    }
+    pixels
+}
+
+#[test]
+fn ac_refine_roundtrip_gradient_rgb_444() {
+    let pixels = gradient_pixels(64, 64, 3);
+    let jpeg =
+        compress_progressive(&pixels, 64, 64, PixelFormat::Rgb, 90, Subsampling::S444).unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 64);
+    assert_eq!(img.height, 64);
+}
+
+#[test]
+fn ac_refine_roundtrip_gradient_rgb_420() {
+    let pixels = gradient_pixels(64, 64, 3);
+    let jpeg =
+        compress_progressive(&pixels, 64, 64, PixelFormat::Rgb, 85, Subsampling::S420).unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 64);
+    assert_eq!(img.height, 64);
+}
+
+#[test]
+fn ac_refine_roundtrip_gradient_grayscale() {
+    let pixels = gradient_pixels(64, 64, 1);
+    let jpeg = compress_progressive(
+        &pixels,
+        64,
+        64,
+        PixelFormat::Grayscale,
+        90,
+        Subsampling::S444,
+    )
+    .unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 64);
+    assert_eq!(img.height, 64);
+    assert_eq!(img.pixel_format, PixelFormat::Grayscale);
+}
+
+#[test]
+fn ac_refine_produces_14_scans_rgb() {
+    let pixels = gradient_pixels(32, 32, 3);
+    let jpeg =
+        compress_progressive(&pixels, 32, 32, PixelFormat::Rgb, 75, Subsampling::S444).unwrap();
+    let sos_count: usize = jpeg
+        .windows(2)
+        .filter(|w| w[0] == 0xFF && w[1] == 0xDA)
+        .count();
+    assert_eq!(sos_count, 14, "3-comp progressive should have 14 scans");
+}
+
+#[test]
+fn ac_refine_produces_6_scans_grayscale() {
+    let pixels = gradient_pixels(32, 32, 1);
+    let jpeg = compress_progressive(
+        &pixels,
+        32,
+        32,
+        PixelFormat::Grayscale,
+        75,
+        Subsampling::S444,
+    )
+    .unwrap();
+    let sos_count: usize = jpeg
+        .windows(2)
+        .filter(|w| w[0] == 0xFF && w[1] == 0xDA)
+        .count();
+    assert_eq!(sos_count, 6, "grayscale progressive should have 6 scans");
+}
+
+#[test]
+fn ac_refine_roundtrip_noise_pattern() {
+    let mut pixels = vec![0u8; 48 * 48 * 3];
+    let mut rng: u32 = 42;
+    for pixel in pixels.iter_mut() {
+        rng = rng.wrapping_mul(1103515245).wrapping_add(12345);
+        *pixel = ((rng >> 16) & 0xFF) as u8;
+    }
+    let jpeg =
+        compress_progressive(&pixels, 48, 48, PixelFormat::Rgb, 95, Subsampling::S444).unwrap();
+    let img = decompress(&jpeg).unwrap();
+    assert_eq!(img.width, 48);
+    assert_eq!(img.height, 48);
 }


### PR DESCRIPTION
Fixed AC refine correction bit ordering to match C jcphuff.c encode_mcu_AC_refine. ZRL check now happens BEFORE processing each nonzero coefficient. Restored full progressive scan script with AC successive approximation (Al=2, Ah=2/Al=1, Ah=1/Al=0). Added 7 new tests for roundtrip and scan count verification. Related: PR #80.