### PR TITLE
feat: add custom per-component sampling factors

### DIFF
--- a/src/api/encoder.rs
+++ b/src/api/encoder.rs
@@ -70,6 +70,11 @@ pub struct Encoder<'a> {
     jfif_version: Option<(u8, u8)>,
     /// Adobe APP14 marker control. `None` = auto. `Some(true)` = always. `Some(false)` = never.
     write_adobe_marker: Option<bool>,
+    /// Custom per-component sampling factors as (h, v) pairs.
+    /// When set, overrides the `subsampling` enum with explicit factors.
+    /// The first component (Y) defines the max sampling factor; subsequent
+    /// components (Cb, Cr) can use any factor from 1 to max_h/max_v.
+    custom_sampling_factors: Option<Vec<(u8, u8)>>,
 }
 
 impl<'a> Encoder<'a> {
@@ -108,6 +113,7 @@ impl<'a> Encoder<'a> {
             fancy_downsampling: true,
             jfif_version: None,
             write_adobe_marker: None,
+            custom_sampling_factors: None,
         }
     }
 
@@ -276,6 +282,23 @@ impl<'a> Encoder<'a> {
     /// and omitted for others. Matches libjpeg-turbo's `write_Adobe_marker`.
     pub fn write_adobe_marker(mut self, write: bool) -> Self {
         self.write_adobe_marker = Some(write);
+        self
+    }
+
+    /// Set explicit per-component sampling factors, overriding the `subsampling` enum.
+    ///
+    /// `factors` is a list of `(h_sampling, v_sampling)` per component. For a
+    /// 3-component YCbCr image, provide 3 entries:
+    /// - `factors[0]` = Y (luminance) sampling factor
+    /// - `factors[1]` = Cb sampling factor
+    /// - `factors[2]` = Cr sampling factor
+    ///
+    /// The first component typically has the largest factors (e.g., `(3, 2)` for
+    /// 3x2 sampling). Chroma components usually use `(1, 1)`.
+    ///
+    /// Valid factor values are 1..=4 for each dimension.
+    pub fn sampling_factors(mut self, factors: Vec<(u8, u8)>) -> Self {
+        self.custom_sampling_factors = Some(factors);
         self
     }
 
@@ -662,7 +685,16 @@ impl<'a> Encoder<'a> {
             || self.linear_scale_factor.is_some()
             || self.has_custom_quant_tables();
 
-        let base = if self.lossless && self.arithmetic {
+        let base = if let Some(ref factors) = self.custom_sampling_factors {
+            encoder::compress_custom_sampling(
+                effective_pixels,
+                self.width,
+                self.height,
+                effective_format,
+                quality,
+                factors,
+            )?
+        } else if self.lossless && self.arithmetic {
             encoder::compress_lossless_arithmetic(
                 effective_pixels,
                 self.width,

--- a/src/decode/pipeline.rs
+++ b/src/decode/pipeline.rs
@@ -22,6 +22,42 @@ fn vertical_blend(cur: &[u8], neighbor: &[u8], output: &mut [u8], width: usize) 
     }
 }
 
+/// Generic nearest-neighbor upsampling for arbitrary h/v factor combinations.
+///
+/// Handles non-standard sampling factors like 3x2, 3x1, 1x3, 4x2 that lack
+/// dedicated optimized paths. Each input sample is replicated h_factor times
+/// horizontally and v_factor times vertically.
+fn upsample_generic_nearest(
+    input: &[u8],
+    in_width: usize,
+    in_height: usize,
+    output: &mut [u8],
+    out_stride: usize,
+    h_factor: usize,
+    v_factor: usize,
+) {
+    for y in 0..in_height {
+        let in_row: &[u8] = &input[y * in_width..y * in_width + in_width];
+        // Build one upsampled row (horizontal replication)
+        let out_y_base: usize = y * v_factor;
+        let first_out_row: usize = out_y_base * out_stride;
+        for x in 0..in_width {
+            let val: u8 = in_row[x];
+            let out_x: usize = x * h_factor;
+            for dx in 0..h_factor {
+                output[first_out_row + out_x + dx] = val;
+            }
+        }
+        // Replicate the row vertically
+        for dy in 1..v_factor {
+            let src_start: usize = first_out_row;
+            let dst_start: usize = (out_y_base + dy) * out_stride;
+            let copy_len: usize = in_width * h_factor;
+            output.copy_within(src_start..src_start + copy_len, dst_start);
+        }
+    }
+}
+
 /// Per-component layout info for progressive decoding.
 struct CompInfo {
     blocks_x: usize,
@@ -2418,10 +2454,26 @@ impl<'a> Decoder<'a> {
                     self.fancy_h1v4(&component_planes[1], cb_w, cb_h, &mut cb_full, full_width);
                     self.fancy_h1v4(&component_planes[2], cb_w, cb_h, &mut cr_full, full_width);
                 } else {
-                    return Err(JpegError::Unsupported(format!(
-                        "subsampling {}x{} not yet supported",
-                        h_factor, v_factor
-                    )));
+                    // Generic fallback for non-standard sampling factors (e.g. 3x2, 3x1, 1x3, 4x2).
+                    // Uses nearest-neighbor replication for any h/v factor combination.
+                    upsample_generic_nearest(
+                        &component_planes[1],
+                        cb_w,
+                        cb_h,
+                        &mut cb_full,
+                        full_width,
+                        h_factor,
+                        v_factor,
+                    );
+                    upsample_generic_nearest(
+                        &component_planes[2],
+                        cb_w,
+                        cb_h,
+                        &mut cr_full,
+                        full_width,
+                        h_factor,
+                        v_factor,
+                    );
                 }
 
                 // Rebind as immutable references for color conversion below.
@@ -2731,10 +2783,25 @@ impl<'a> Decoder<'a> {
                     full_width,
                 );
             } else {
-                return Err(JpegError::Unsupported(format!(
-                    "4-component subsampling {}x{} not yet supported",
-                    h_factor, v_factor
-                )));
+                // Generic fallback for non-standard 4-component sampling factors.
+                upsample_generic_nearest(
+                    &component_planes[1],
+                    comp1_w,
+                    comp1_h,
+                    &mut p1_full,
+                    full_width,
+                    h_factor,
+                    v_factor,
+                );
+                upsample_generic_nearest(
+                    &component_planes[2],
+                    comp1_w,
+                    comp1_h,
+                    &mut p2_full,
+                    full_width,
+                    h_factor,
+                    v_factor,
+                );
             }
 
             return self.convert_4comp_output(

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -4456,6 +4456,303 @@ pub fn compress_raw(
     Ok(output)
 }
 
+/// Compress raw pixel data into a JPEG byte stream using explicit per-component
+/// sampling factors instead of the predefined `Subsampling` enum.
+///
+/// This supports non-standard sampling configurations such as 3x2, 3x1, 1x3,
+/// and 4x2 that are not covered by the standard Subsampling enum values.
+///
+/// # Arguments
+/// * `pixels` - Raw pixel data in the format specified by `pixel_format`
+/// * `width` - Image width in pixels
+/// * `height` - Image height in pixels
+/// * `pixel_format` - Pixel format of the input data
+/// * `quality` - JPEG quality factor (1-100)
+/// * `factors` - Per-component `(h_sampling, v_sampling)` factors
+///
+/// # Returns
+/// A `Vec<u8>` containing the complete JPEG file data.
+pub fn compress_custom_sampling(
+    pixels: &[u8],
+    width: usize,
+    height: usize,
+    pixel_format: PixelFormat,
+    quality: u8,
+    factors: &[(u8, u8)],
+) -> Result<Vec<u8>> {
+    // Validate inputs
+    if width == 0 || height == 0 {
+        return Err(JpegError::CorruptData(
+            "image dimensions must be non-zero".to_string(),
+        ));
+    }
+
+    let bpp: usize = pixel_format.bytes_per_pixel();
+    let expected_size: usize = width * height * bpp;
+    if pixels.len() < expected_size {
+        return Err(JpegError::BufferTooSmall {
+            need: expected_size,
+            got: pixels.len(),
+        });
+    }
+
+    let is_grayscale: bool = pixel_format == PixelFormat::Grayscale;
+
+    // Validate factor count matches component count
+    let num_components: usize = if is_grayscale { 1 } else { 3 };
+    if factors.len() != num_components {
+        return Err(JpegError::CorruptData(format!(
+            "expected {} sampling factors for {}, got {}",
+            num_components,
+            if is_grayscale { "grayscale" } else { "YCbCr" },
+            factors.len()
+        )));
+    }
+
+    // Validate factor values (1..=4)
+    for (i, &(h, v)) in factors.iter().enumerate() {
+        if h == 0 || h > 4 || v == 0 || v > 4 {
+            return Err(JpegError::CorruptData(format!(
+                "sampling factor ({}, {}) for component {} is out of range 1..=4",
+                h, v, i
+            )));
+        }
+    }
+
+    // Max sampling factors determine MCU size
+    let max_h: u8 = factors.iter().map(|&(h, _)| h).max().unwrap_or(1);
+    let max_v: u8 = factors.iter().map(|&(_, v)| v).max().unwrap_or(1);
+
+    // Validate that max_h and max_v are from component 0 (Y) for standard JPEG structure,
+    // or at least that all factor ratios are valid integers.
+    for (i, &(h, v)) in factors.iter().enumerate() {
+        if max_h % h != 0 || max_v % v != 0 {
+            return Err(JpegError::CorruptData(format!(
+                "component {} sampling factors ({}, {}) must evenly divide max factors ({}, {})",
+                i, h, v, max_h, max_v
+            )));
+        }
+    }
+
+    // MCU dimensions in pixels
+    let mcu_w: usize = max_h as usize * 8;
+    let mcu_h: usize = max_v as usize * 8;
+    let mcus_x: usize = (width + mcu_w - 1) / mcu_w;
+    let mcus_y: usize = (height + mcu_h - 1) / mcu_h;
+
+    // Generate scaled quantization tables
+    let luma_quant: [u16; 64] =
+        tables::quality_scale_quant_table(&tables::STD_LUMINANCE_QUANT_TABLE, quality);
+    let chroma_quant: [u16; 64] =
+        tables::quality_scale_quant_table(&tables::STD_CHROMINANCE_QUANT_TABLE, quality);
+    let luma_divisors: [u16; 64] = scale_quant_for_fdct(&luma_quant);
+    let chroma_divisors: [u16; 64] = scale_quant_for_fdct(&chroma_quant);
+
+    // Build Huffman tables
+    let dc_luma_table: HuffTable =
+        build_huff_table(&tables::DC_LUMINANCE_BITS, &tables::DC_LUMINANCE_VALUES);
+    let ac_luma_table: HuffTable =
+        build_huff_table(&tables::AC_LUMINANCE_BITS, &tables::AC_LUMINANCE_VALUES);
+    let dc_chroma_table: HuffTable =
+        build_huff_table(&tables::DC_CHROMINANCE_BITS, &tables::DC_CHROMINANCE_VALUES);
+    let ac_chroma_table: HuffTable =
+        build_huff_table(&tables::AC_CHROMINANCE_BITS, &tables::AC_CHROMINANCE_VALUES);
+
+    // Color convert
+    let (y_plane, cb_plane, cr_plane) = convert_to_ycbcr(pixels, width, height, pixel_format)?;
+
+    // FDCT function
+    let fdct_fn: fn(&[i16; 64], &mut [i32; 64]) = fdct::fdct_islow;
+
+    // Entropy encode all MCUs
+    let mut bit_writer: BitWriter = BitWriter::new(width * height);
+    let mut prev_dc_y: i16 = 0;
+    let mut prev_dc_cb: i16 = 0;
+    let mut prev_dc_cr: i16 = 0;
+
+    let y_h: u8 = factors[0].0;
+    let y_v: u8 = factors[0].1;
+
+    for mcu_row in 0..mcus_y {
+        for mcu_col in 0..mcus_x {
+            let x0: usize = mcu_col * mcu_w;
+            let y0: usize = mcu_row * mcu_h;
+
+            if is_grayscale {
+                // Grayscale: h_i x v_i blocks of Y
+                for bv in 0..y_v as usize {
+                    for bh in 0..y_h as usize {
+                        encode_single_block(
+                            &y_plane,
+                            width,
+                            height,
+                            x0 + bh * 8,
+                            y0 + bv * 8,
+                            &luma_divisors,
+                            &dc_luma_table,
+                            &ac_luma_table,
+                            &mut bit_writer,
+                            &mut prev_dc_y,
+                            fdct_fn,
+                        );
+                    }
+                }
+            } else {
+                // Y blocks: y_h x y_v blocks per MCU (row-major order)
+                for bv in 0..y_v as usize {
+                    for bh in 0..y_h as usize {
+                        encode_single_block(
+                            &y_plane,
+                            width,
+                            height,
+                            x0 + bh * 8,
+                            y0 + bv * 8,
+                            &luma_divisors,
+                            &dc_luma_table,
+                            &ac_luma_table,
+                            &mut bit_writer,
+                            &mut prev_dc_y,
+                            fdct_fn,
+                        );
+                    }
+                }
+
+                // Chroma components (Cb, Cr): each has factors[1] and factors[2]
+                let cb_h: u8 = factors[1].0;
+                let cb_v: u8 = factors[1].1;
+                let h_downsample: usize = max_h as usize / cb_h as usize;
+                let v_downsample: usize = max_v as usize / cb_v as usize;
+
+                // Cb blocks
+                for bv in 0..cb_v as usize {
+                    for bh in 0..cb_h as usize {
+                        encode_downsampled_chroma_block(
+                            &cb_plane,
+                            width,
+                            height,
+                            x0 + bh * 8 * h_downsample,
+                            y0 + bv * 8 * v_downsample,
+                            h_downsample,
+                            v_downsample,
+                            &chroma_divisors,
+                            &dc_chroma_table,
+                            &ac_chroma_table,
+                            &mut bit_writer,
+                            &mut prev_dc_cb,
+                            fdct_fn,
+                        );
+                    }
+                }
+
+                let cr_h: u8 = factors[2].0;
+                let cr_v: u8 = factors[2].1;
+                let h_downsample_cr: usize = max_h as usize / cr_h as usize;
+                let v_downsample_cr: usize = max_v as usize / cr_v as usize;
+
+                // Cr blocks
+                for bv in 0..cr_v as usize {
+                    for bh in 0..cr_h as usize {
+                        encode_downsampled_chroma_block(
+                            &cr_plane,
+                            width,
+                            height,
+                            x0 + bh * 8 * h_downsample_cr,
+                            y0 + bv * 8 * v_downsample_cr,
+                            h_downsample_cr,
+                            v_downsample_cr,
+                            &chroma_divisors,
+                            &dc_chroma_table,
+                            &ac_chroma_table,
+                            &mut bit_writer,
+                            &mut prev_dc_cr,
+                            fdct_fn,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    bit_writer.flush();
+
+    // Assemble output
+    let mut output: Vec<u8> = Vec::with_capacity(bit_writer.data().len() + 1024);
+
+    marker_writer::write_soi(&mut output);
+    marker_writer::write_app0_jfif(&mut output);
+
+    // Quantization tables
+    marker_writer::write_dqt(&mut output, 0, &luma_quant);
+    if !is_grayscale {
+        marker_writer::write_dqt(&mut output, 1, &chroma_quant);
+    }
+
+    // Frame header with explicit sampling factors
+    if is_grayscale {
+        let components: Vec<(u8, u8, u8, u8)> = vec![(1, y_h, y_v, 0)];
+        marker_writer::write_sof0(&mut output, width as u16, height as u16, &components);
+    } else {
+        let components: Vec<(u8, u8, u8, u8)> = vec![
+            (1, factors[0].0, factors[0].1, 0), // Y
+            (2, factors[1].0, factors[1].1, 1), // Cb
+            (3, factors[2].0, factors[2].1, 1), // Cr
+        ];
+        marker_writer::write_sof0(&mut output, width as u16, height as u16, &components);
+    }
+
+    // Huffman tables
+    marker_writer::write_dht(
+        &mut output,
+        0,
+        0,
+        &tables::DC_LUMINANCE_BITS,
+        &tables::DC_LUMINANCE_VALUES,
+    );
+    marker_writer::write_dht(
+        &mut output,
+        1,
+        0,
+        &tables::AC_LUMINANCE_BITS,
+        &tables::AC_LUMINANCE_VALUES,
+    );
+    if !is_grayscale {
+        marker_writer::write_dht(
+            &mut output,
+            0,
+            1,
+            &tables::DC_CHROMINANCE_BITS,
+            &tables::DC_CHROMINANCE_VALUES,
+        );
+        marker_writer::write_dht(
+            &mut output,
+            1,
+            1,
+            &tables::AC_CHROMINANCE_BITS,
+            &tables::AC_CHROMINANCE_VALUES,
+        );
+    }
+
+    // Scan header
+    if is_grayscale {
+        let scan_components: Vec<(u8, u8, u8)> = vec![(1, 0, 0)];
+        marker_writer::write_sos(&mut output, &scan_components);
+    } else {
+        let scan_components: Vec<(u8, u8, u8)> = vec![
+            (1, 0, 0), // Y: DC table 0, AC table 0
+            (2, 1, 1), // Cb: DC table 1, AC table 1
+            (3, 1, 1), // Cr: DC table 1, AC table 1
+        ];
+        marker_writer::write_sos(&mut output, &scan_components);
+    }
+
+    // Entropy-coded data
+    output.extend_from_slice(bit_writer.data());
+
+    marker_writer::write_eoi(&mut output);
+
+    Ok(output)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/custom_sampling.rs
+++ b/tests/custom_sampling.rs
@@ -1,0 +1,189 @@
+use libjpeg_turbo_rs::{decompress, Encoder, PixelFormat};
+
+/// Helper: create a small gradient test image of given dimensions.
+fn make_gradient_rgb(w: usize, h: usize) -> Vec<u8> {
+    let mut pixels: Vec<u8> = vec![0u8; w * h * 3];
+    for y in 0..h {
+        for x in 0..w {
+            let i: usize = (y * w + x) * 3;
+            pixels[i] = ((x * 255) / w.max(1)) as u8;
+            pixels[i + 1] = ((y * 255) / h.max(1)) as u8;
+            pixels[i + 2] = 128;
+        }
+    }
+    pixels
+}
+
+/// Encode with custom sampling factors and decode, verifying the roundtrip produces
+/// an image of the correct dimensions.
+fn roundtrip_custom_sampling(
+    w: usize,
+    h: usize,
+    factors: Vec<(u8, u8)>,
+    quality: u8,
+) -> libjpeg_turbo_rs::Image {
+    let pixels: Vec<u8> = make_gradient_rgb(w, h);
+    let jpeg: Vec<u8> = Encoder::new(&pixels, w, h, PixelFormat::Rgb)
+        .quality(quality)
+        .sampling_factors(factors)
+        .encode()
+        .expect("encoding with custom sampling factors should succeed");
+    // Verify it starts with SOI marker
+    assert_eq!(jpeg[0], 0xFF);
+    assert_eq!(jpeg[1], 0xD8);
+    let img: libjpeg_turbo_rs::Image =
+        decompress(&jpeg).expect("decoding custom-sampled JPEG should succeed");
+    assert_eq!(img.width, w, "decoded width mismatch");
+    assert_eq!(img.height, h, "decoded height mismatch");
+    img
+}
+
+// --- Successful roundtrip tests ---
+
+#[test]
+fn custom_sampling_3x2_roundtrip() {
+    // 3x2 sampling: Y=(3,2), Cb=(1,1), Cr=(1,1)
+    // MCU = 24x16 pixels. Use 32x32 for ample coverage.
+    roundtrip_custom_sampling(32, 32, vec![(3, 2), (1, 1), (1, 1)], 90);
+}
+
+#[test]
+fn custom_sampling_3x1_roundtrip() {
+    // 3x1 sampling: Y=(3,1), Cb=(1,1), Cr=(1,1)
+    // MCU = 24x8 pixels.
+    roundtrip_custom_sampling(32, 32, vec![(3, 1), (1, 1), (1, 1)], 90);
+}
+
+#[test]
+fn custom_sampling_1x3_roundtrip() {
+    // 1x3 sampling: Y=(1,3), Cb=(1,1), Cr=(1,1)
+    // MCU = 8x24 pixels.
+    roundtrip_custom_sampling(32, 32, vec![(1, 3), (1, 1), (1, 1)], 90);
+}
+
+#[test]
+fn custom_sampling_4x2_roundtrip() {
+    // 4x2 sampling: Y=(4,2), Cb=(1,1), Cr=(1,1)
+    // MCU = 32x16 pixels.
+    roundtrip_custom_sampling(32, 32, vec![(4, 2), (1, 1), (1, 1)], 90);
+}
+
+#[test]
+fn custom_sampling_2x1_equivalent_to_s422() {
+    // 2x1 sampling is standard 4:2:2; this validates the custom path
+    // produces a decodable result matching the standard path.
+    roundtrip_custom_sampling(32, 32, vec![(2, 1), (1, 1), (1, 1)], 85);
+}
+
+#[test]
+fn custom_sampling_2x2_equivalent_to_s420() {
+    // 2x2 sampling is standard 4:2:0
+    roundtrip_custom_sampling(32, 32, vec![(2, 2), (1, 1), (1, 1)], 85);
+}
+
+#[test]
+fn custom_sampling_1x1_equivalent_to_s444() {
+    // 1x1 sampling is standard 4:4:4
+    roundtrip_custom_sampling(16, 16, vec![(1, 1), (1, 1), (1, 1)], 85);
+}
+
+#[test]
+fn custom_sampling_3x2_small_image() {
+    // Test with a very small image (smaller than MCU size 24x16)
+    roundtrip_custom_sampling(16, 16, vec![(3, 2), (1, 1), (1, 1)], 85);
+}
+
+#[test]
+fn custom_sampling_4x2_non_mcu_aligned() {
+    // 4x2 MCU = 32x16, image 17x13 = not MCU-aligned
+    roundtrip_custom_sampling(17, 13, vec![(4, 2), (1, 1), (1, 1)], 85);
+}
+
+#[test]
+fn custom_sampling_3x1_non_mcu_aligned() {
+    // 3x1 MCU = 24x8, image 25x9 = not MCU-aligned
+    roundtrip_custom_sampling(25, 9, vec![(3, 1), (1, 1), (1, 1)], 85);
+}
+
+#[test]
+fn custom_sampling_pixel_data_reasonable() {
+    // Verify that encoded/decoded pixel values are plausible (not all zeros or all 255)
+    let img: libjpeg_turbo_rs::Image =
+        roundtrip_custom_sampling(32, 32, vec![(3, 2), (1, 1), (1, 1)], 95);
+    let data: &[u8] = &img.data;
+    let nonzero_count: usize = data.iter().filter(|&&b| b != 0).count();
+    let non255_count: usize = data.iter().filter(|&&b| b != 255).count();
+    assert!(
+        nonzero_count > data.len() / 4,
+        "too many zero pixels in decoded image"
+    );
+    assert!(
+        non255_count > data.len() / 4,
+        "too many 255 pixels in decoded image"
+    );
+}
+
+// --- Error cases ---
+
+#[test]
+fn custom_sampling_zero_h_factor_rejected() {
+    let pixels: Vec<u8> = vec![128u8; 16 * 16 * 3];
+    let result = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .sampling_factors(vec![(0, 1), (1, 1), (1, 1)])
+        .encode();
+    assert!(result.is_err(), "h_factor=0 should be rejected");
+}
+
+#[test]
+fn custom_sampling_zero_v_factor_rejected() {
+    let pixels: Vec<u8> = vec![128u8; 16 * 16 * 3];
+    let result = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .sampling_factors(vec![(1, 0), (1, 1), (1, 1)])
+        .encode();
+    assert!(result.is_err(), "v_factor=0 should be rejected");
+}
+
+#[test]
+fn custom_sampling_factor_exceeds_max_rejected() {
+    let pixels: Vec<u8> = vec![128u8; 16 * 16 * 3];
+    let result = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .sampling_factors(vec![(5, 1), (1, 1), (1, 1)])
+        .encode();
+    assert!(result.is_err(), "h_factor=5 should be rejected");
+}
+
+#[test]
+fn custom_sampling_wrong_component_count_rejected() {
+    let pixels: Vec<u8> = vec![128u8; 16 * 16 * 3];
+    // 2 factors for a 3-component image
+    let result = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .sampling_factors(vec![(2, 2), (1, 1)])
+        .encode();
+    assert!(result.is_err(), "wrong component count should be rejected");
+}
+
+#[test]
+fn custom_sampling_non_divisible_factor_rejected() {
+    let pixels: Vec<u8> = vec![128u8; 16 * 16 * 3];
+    // Y=(3,2), Cb=(2,1): max_h=3, and 3 % 2 != 0 => invalid
+    let result = Encoder::new(&pixels, 16, 16, PixelFormat::Rgb)
+        .sampling_factors(vec![(3, 2), (2, 1), (1, 1)])
+        .encode();
+    assert!(
+        result.is_err(),
+        "non-divisible chroma factors should be rejected"
+    );
+}
+
+#[test]
+fn custom_sampling_grayscale_single_factor() {
+    // Grayscale with custom sampling factor (1,1) should work
+    let pixels: Vec<u8> = vec![128u8; 16 * 16];
+    let jpeg: Vec<u8> = Encoder::new(&pixels, 16, 16, PixelFormat::Grayscale)
+        .sampling_factors(vec![(1, 1)])
+        .encode()
+        .expect("grayscale with (1,1) factor should succeed");
+    let img = decompress(&jpeg).expect("decode should succeed");
+    assert_eq!(img.width, 16);
+    assert_eq!(img.height, 16);
+}


### PR DESCRIPTION
Add sampling_factors() builder, compress_custom_sampling(), and generic upsample fallback with 17 tests