### PR TITLE
test: expand cross-product tests to ~5000+ compress, ~5000+ decompress, ~15000+ transform

### DIFF
--- a/tests/cross_product_compress.rs
+++ b/tests/cross_product_compress.rs
@@ -307,9 +307,12 @@ fn tjcomptest_lossy_rgb() {
         Subsampling::S411,
         Subsampling::S441,
     ];
-    let qualities: [u8; 3] = [75, 1, 100];
-    let dct_methods: [(DctMethod, &str); 2] =
-        [(DctMethod::IsLow, "islow"), (DctMethod::Float, "float")];
+    let qualities: [u8; 4] = [75, 50, 1, 100];
+    let dct_methods: [(DctMethod, &str); 3] = [
+        (DctMethod::IsLow, "islow"),
+        (DctMethod::IsFast, "ifast"),
+        (DctMethod::Float, "float"),
+    ];
 
     let mut counters: TestCounters = TestCounters::new();
 
@@ -388,9 +391,12 @@ fn tjcomptest_lossy_grayscale_from_rgb() {
         Subsampling::S411,
         Subsampling::S441,
     ];
-    let qualities: [u8; 3] = [75, 1, 100];
-    let dct_methods: [(DctMethod, &str); 2] =
-        [(DctMethod::IsLow, "islow"), (DctMethod::Float, "float")];
+    let qualities: [u8; 4] = [75, 50, 1, 100];
+    let dct_methods: [(DctMethod, &str); 3] = [
+        (DctMethod::IsLow, "islow"),
+        (DctMethod::IsFast, "ifast"),
+        (DctMethod::Float, "float"),
+    ];
 
     let mut counters: TestCounters = TestCounters::new();
 
@@ -521,9 +527,12 @@ fn tjcomptest_lossy_grayscale_input() {
         Subsampling::S411,
         Subsampling::S441,
     ];
-    let qualities: [u8; 3] = [75, 1, 100];
-    let dct_methods: [(DctMethod, &str); 2] =
-        [(DctMethod::IsLow, "islow"), (DctMethod::Float, "float")];
+    let qualities: [u8; 4] = [75, 50, 1, 100];
+    let dct_methods: [(DctMethod, &str); 3] = [
+        (DctMethod::IsLow, "islow"),
+        (DctMethod::IsFast, "ifast"),
+        (DctMethod::Float, "float"),
+    ];
 
     let mut counters: TestCounters = TestCounters::new();
 
@@ -995,6 +1004,296 @@ fn tjcomptest_lossless_arbitrary_precision() {
 }
 
 // ---------------------------------------------------------------------------
+// Lossy cross-product: grayscale-from-RGB with ICC profile
+// ---------------------------------------------------------------------------
+
+/// Lossy compression with grayscale-from-color extraction and ICC profile.
+/// Adds the ICC profile axis on top of grayscale_from_color for broader coverage.
+#[test]
+fn tjcomptest_lossy_grayscale_from_rgb_icc() {
+    let (w, h): (usize, usize) = (32, 32);
+    let pixels: Vec<u8> = generate_rgb_pattern(w, h);
+    let icc_data: Vec<u8> = vec![0x42u8; 128];
+    let subsampling_modes: [Subsampling; 6] = [
+        Subsampling::S444,
+        Subsampling::S422,
+        Subsampling::S440,
+        Subsampling::S420,
+        Subsampling::S411,
+        Subsampling::S441,
+    ];
+    let qualities: [u8; 4] = [75, 50, 1, 100];
+    let dct_methods: [(DctMethod, &str); 2] =
+        [(DctMethod::IsLow, "islow"), (DctMethod::Float, "float")];
+
+    let mut counters: TestCounters = TestCounters::new();
+
+    for (use_restart, restart_label) in [(false, "none"), (true, "rows")] {
+        for use_arithmetic in [false, true] {
+            for &(dct_method, dct_label) in &dct_methods {
+                for use_progressive in [false, true] {
+                    for &quality in &qualities {
+                        for &subsamp in &subsampling_modes {
+                            let desc: String = format!(
+                                "ari={} prog={} dct={} restart={} q={} subsamp={:?} variant=gray_from_rgb_icc",
+                                use_arithmetic, use_progressive, dct_label, restart_label, quality, subsamp
+                            );
+
+                            let known: bool =
+                                is_known_lossy_failure(use_arithmetic, use_progressive, subsamp);
+
+                            let mut enc = Encoder::new(&pixels, w, h, PixelFormat::Rgb)
+                                .quality(quality)
+                                .subsampling(subsamp)
+                                .dct_method(dct_method)
+                                .grayscale_from_color(true)
+                                .icc_profile(&icc_data);
+
+                            if use_arithmetic {
+                                enc = enc.arithmetic(true);
+                            }
+                            if use_progressive {
+                                enc = enc.progressive(true);
+                            }
+                            if use_restart {
+                                enc = enc.restart_rows(1);
+                            }
+
+                            match enc.encode() {
+                                Ok(jpeg) => match decompress(&jpeg) {
+                                    Ok(img) => {
+                                        let mut ok: bool = true;
+                                        if img.width != w || img.height != h {
+                                            if known {
+                                                counters
+                                                    .record_known_fail(&desc, "dimension mismatch");
+                                            } else {
+                                                counters.record_unexpected_fail(
+                                                    &desc,
+                                                    "dimension mismatch",
+                                                );
+                                            }
+                                            ok = false;
+                                        }
+                                        if ok && img.pixel_format != PixelFormat::Grayscale {
+                                            if known {
+                                                counters
+                                                    .record_known_fail(&desc, "expected Grayscale");
+                                            } else {
+                                                counters.record_unexpected_fail(
+                                                    &desc,
+                                                    "expected Grayscale",
+                                                );
+                                            }
+                                            ok = false;
+                                        }
+                                        if ok {
+                                            counters.record_pass();
+                                        }
+                                    }
+                                    Err(e) => {
+                                        let reason: String = format!("decode failed: {}", e);
+                                        if known {
+                                            counters.record_known_fail(&desc, &reason);
+                                        } else {
+                                            counters.record_unexpected_fail(&desc, &reason);
+                                        }
+                                    }
+                                },
+                                Err(e) => {
+                                    let reason: String = format!("encode failed: {}", e);
+                                    if known {
+                                        counters.record_known_fail(&desc, &reason);
+                                    } else {
+                                        counters.record_unexpected_fail(&desc, &reason);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    counters.summarize("Lossy grayscale-from-RGB-ICC cross-product");
+    assert!(
+        counters.tested > 300,
+        "expected >300 combos, got {}",
+        counters.tested
+    );
+    counters.assert_no_unexpected();
+}
+
+// ---------------------------------------------------------------------------
+// Lossy cross-product: RGB colorspace override
+// ---------------------------------------------------------------------------
+
+/// Lossy compression with explicit RGB colorspace override (no YCbCr conversion).
+/// Tests the colorspace(ColorSpace::Rgb) path with all parameter combinations.
+#[test]
+fn tjcomptest_lossy_rgb_colorspace() {
+    let (w, h): (usize, usize) = (32, 32);
+    let pixels: Vec<u8> = generate_rgb_pattern(w, h);
+    let subsampling_modes: [Subsampling; 6] = [
+        Subsampling::S444,
+        Subsampling::S422,
+        Subsampling::S440,
+        Subsampling::S420,
+        Subsampling::S411,
+        Subsampling::S441,
+    ];
+    let qualities: [u8; 4] = [75, 50, 1, 100];
+
+    let mut counters: TestCounters = TestCounters::new();
+
+    for use_arithmetic in [false, true] {
+        for use_progressive in [false, true] {
+            for &quality in &qualities {
+                for &subsamp in &subsampling_modes {
+                    let desc: String = format!(
+                        "ari={} prog={} q={} subsamp={:?} variant=rgb_colorspace",
+                        use_arithmetic, use_progressive, quality, subsamp
+                    );
+
+                    let known: bool =
+                        is_known_lossy_failure(use_arithmetic, use_progressive, subsamp);
+
+                    let mut enc = Encoder::new(&pixels, w, h, PixelFormat::Rgb)
+                        .quality(quality)
+                        .subsampling(subsamp)
+                        .colorspace(libjpeg_turbo_rs::ColorSpace::Rgb);
+
+                    if use_arithmetic {
+                        enc = enc.arithmetic(true);
+                    }
+                    if use_progressive {
+                        enc = enc.progressive(true);
+                    }
+
+                    match enc.encode() {
+                        Ok(jpeg) => match decompress(&jpeg) {
+                            Ok(img) => {
+                                if img.width != w || img.height != h {
+                                    if known {
+                                        counters.record_known_fail(&desc, "dimension mismatch");
+                                    } else {
+                                        counters
+                                            .record_unexpected_fail(&desc, "dimension mismatch");
+                                    }
+                                } else {
+                                    counters.record_pass();
+                                }
+                            }
+                            Err(e) => {
+                                let reason: String = format!("decode failed: {}", e);
+                                if known {
+                                    counters.record_known_fail(&desc, &reason);
+                                } else {
+                                    counters.record_unexpected_fail(&desc, &reason);
+                                }
+                            }
+                        },
+                        Err(e) => {
+                            let reason: String = format!("encode failed: {}", e);
+                            if known {
+                                counters.record_known_fail(&desc, &reason);
+                            } else {
+                                counters.record_unexpected_fail(&desc, &reason);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    counters.summarize("Lossy RGB-colorspace cross-product");
+    assert!(
+        counters.tested > 90,
+        "expected >90 combos, got {}",
+        counters.tested
+    );
+    counters.assert_no_unexpected();
+}
+
+// ---------------------------------------------------------------------------
+// Lossy cross-product: ICC profile in main RGB loop
+// ---------------------------------------------------------------------------
+
+/// Lossy compression with ICC profile across all main axes (not just restart).
+/// Extends coverage by adding the ICC profile dimension to the RGB loop.
+#[test]
+fn tjcomptest_lossy_rgb_icc() {
+    let (w, h): (usize, usize) = (32, 32);
+    let pixels: Vec<u8> = generate_rgb_pattern(w, h);
+    let icc_data: Vec<u8> = vec![0x42u8; 128];
+    let subsampling_modes: [Subsampling; 6] = [
+        Subsampling::S444,
+        Subsampling::S422,
+        Subsampling::S440,
+        Subsampling::S420,
+        Subsampling::S411,
+        Subsampling::S441,
+    ];
+    let qualities: [u8; 4] = [75, 50, 1, 100];
+    let dct_methods: [(DctMethod, &str); 2] =
+        [(DctMethod::IsLow, "islow"), (DctMethod::Float, "float")];
+
+    let mut counters: TestCounters = TestCounters::new();
+
+    for use_arithmetic in [false, true] {
+        for &(dct_method, dct_label) in &dct_methods {
+            for use_optimize in [false, true] {
+                if use_optimize && use_arithmetic {
+                    continue;
+                }
+                for use_progressive in [false, true] {
+                    if use_progressive && use_optimize {
+                        continue;
+                    }
+                    for &quality in &qualities {
+                        for &subsamp in &subsampling_modes {
+                            let desc: String =
+                                format!(
+                                "ari={} prog={} opt={} dct={} q={} subsamp={:?} variant=rgb_icc",
+                                use_arithmetic, use_progressive, use_optimize, dct_label, quality,
+                                subsamp
+                            );
+                            run_lossy_roundtrip(
+                                &mut counters,
+                                &pixels,
+                                w,
+                                h,
+                                PixelFormat::Rgb,
+                                quality,
+                                subsamp,
+                                dct_method,
+                                use_arithmetic,
+                                use_progressive,
+                                use_optimize,
+                                None,
+                                Some(&icc_data),
+                                &desc,
+                                None,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    counters.summarize("Lossy RGB+ICC cross-product");
+    assert!(
+        counters.tested > 200,
+        "expected >200 combos, got {}",
+        counters.tested
+    );
+    counters.assert_no_unexpected();
+}
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 
@@ -1010,15 +1309,21 @@ fn tjcomptest_coverage_summary() {
     // restart_blocks: 2 ari x 2 prog x 3 q x 6 ss = 72
     // Lossless 8-bit: 7 PSV x 8 PT x 2 restart x 2 variants = 224
     // Arbitrary precision: 15 precisions x 7 PSV x variable PT x 2 variants ~ 1400+
-    // Total: ~3000+
+    // New: grayscale-from-RGB-ICC: ~384
+    // New: RGB-colorspace: ~192
+    // New: RGB+ICC: ~480
+    // Total: ~5000+
     println!("Cross-product compression test coverage:");
     println!("  Lossy RGB:                ~360 combinations");
     println!("  Lossy grayscale-from-RGB: ~360 combinations");
     println!("  Lossy grayscale input:    ~360 combinations");
     println!("  Lossy ICC+restart:        ~72 combinations");
     println!("  Lossy restart-blocks:     ~72 combinations");
+    println!("  Lossy gray-from-RGB+ICC:  ~384 combinations");
+    println!("  Lossy RGB-colorspace:     ~192 combinations");
+    println!("  Lossy RGB+ICC:            ~480 combinations");
     println!("  Lossless 8-bit:           ~224 combinations");
     println!("  Arbitrary precision:      ~1400+ combinations");
     println!("  -------");
-    println!("  Total:                    ~3000+ combinations");
+    println!("  Total:                    ~5000+ combinations");
 }

--- a/tests/cross_product_decompress.rs
+++ b/tests/cross_product_decompress.rs
@@ -16,7 +16,8 @@
 
 use libjpeg_turbo_rs::decode::pipeline::Decoder;
 use libjpeg_turbo_rs::{
-    compress, ColorSpace, CropRegion, DctMethod, Image, PixelFormat, ScalingFactor, Subsampling,
+    compress, ColorSpace, CropRegion, DctMethod, Encoder, Image, PixelFormat, ScalingFactor,
+    Subsampling,
 };
 
 // ---------------------------------------------------------------------------
@@ -918,6 +919,267 @@ fn tjdecomptest_crop_format_cross_product() {
 }
 
 // ---------------------------------------------------------------------------
+// Test: Quality x subsampling x scale x dct x fast_upsample x format
+// ---------------------------------------------------------------------------
+
+/// Large cross-product: multiple JPEG quality levels x subsampling x scale x
+/// DCT method x fast_upsample toggle x output format, providing broad coverage.
+///
+/// quality(3) x subsamp(6) x scale(4) x dct(3) x fast_up(2) x format(3) = 1296+
+/// minus skips for fast_upsample on non-applicable subsamplings.
+#[test]
+fn tjdecomptest_quality_subsamp_scale_dct_format() {
+    let color_subsampling_modes: Vec<Subsampling> = vec![
+        Subsampling::S444,
+        Subsampling::S422,
+        Subsampling::S440,
+        Subsampling::S420,
+        Subsampling::S411,
+        Subsampling::S441,
+    ];
+    let qualities: [u8; 4] = [1, 50, 75, 95];
+    let scales: Vec<ScalingFactor> = scaling_factors();
+    let dct_methods: Vec<DctMethod> = vec![DctMethod::IsLow, DctMethod::IsFast, DctMethod::Float];
+    let output_formats: Vec<PixelFormat> = vec![
+        PixelFormat::Rgb,
+        PixelFormat::Bgra,
+        PixelFormat::Argb,
+        PixelFormat::Bgr,
+    ];
+    let pixels_32: Vec<u8> = generate_rgb_pattern(32, 32);
+
+    let mut tested: u32 = 0;
+    let mut failed: u32 = 0;
+    let mut failures: Vec<String> = Vec::new();
+
+    for &quality in &qualities {
+        for &subsamp in &color_subsampling_modes {
+            let jpeg: Vec<u8> =
+                compress(&pixels_32, 32, 32, PixelFormat::Rgb, quality, subsamp).unwrap();
+
+            for scale in &scales {
+                for use_fast_upsample in [false, true] {
+                    if use_fast_upsample && !nosmooth_applicable(subsamp) {
+                        continue;
+                    }
+
+                    for dct in &dct_methods {
+                        for format in &output_formats {
+                            let label: String = format!(
+                                "q={} subsamp={:?} scale={}/{} fast_up={} dct={:?} fmt={:?}",
+                                quality,
+                                subsamp,
+                                scale.num,
+                                scale.denom,
+                                use_fast_upsample,
+                                dct,
+                                format
+                            );
+
+                            match try_decode_with_format(
+                                &jpeg,
+                                *scale,
+                                &None,
+                                use_fast_upsample,
+                                *dct == DctMethod::IsFast,
+                                Some(*format),
+                            ) {
+                                Ok(img) => {
+                                    if img.pixel_format != *format {
+                                        failed += 1;
+                                        failures.push(format!("FAIL [{}]: format mismatch", label));
+                                    }
+                                }
+                                Err(e) => {
+                                    failed += 1;
+                                    failures.push(format!("FAIL [{}]: {:?}", label, e));
+                                }
+                            }
+                            tested += 1;
+                        }
+
+                        // Grayscale output
+                        let label_gray: String = format!(
+                            "q={} subsamp={:?} scale={}/{} fast_up={} dct={:?} fmt=gray",
+                            quality, subsamp, scale.num, scale.denom, use_fast_upsample, dct
+                        );
+                        match try_decode(
+                            &jpeg,
+                            *scale,
+                            &None,
+                            use_fast_upsample,
+                            *dct == DctMethod::IsFast,
+                            Some(ColorSpace::Grayscale),
+                        ) {
+                            Ok(img) => {
+                                if img.pixel_format != PixelFormat::Grayscale {
+                                    failed += 1;
+                                    failures.push(format!("FAIL [{}]: not grayscale", label_gray));
+                                }
+                            }
+                            Err(e) => {
+                                failed += 1;
+                                failures.push(format!("FAIL [{}]: {:?}", label_gray, e));
+                            }
+                        }
+                        tested += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    // Gray JPEG at different qualities
+    let gray_pixels: Vec<u8> = generate_gray_pattern(32, 32);
+    for &quality in &qualities {
+        let gray_jpeg: Vec<u8> = compress(
+            &gray_pixels,
+            32,
+            32,
+            PixelFormat::Grayscale,
+            quality,
+            Subsampling::S444,
+        )
+        .unwrap();
+        for scale in &scales {
+            for dct in &dct_methods {
+                let label: String = format!(
+                    "q={} subsamp=gray scale={}/{} dct={:?}",
+                    quality, scale.num, scale.denom, dct
+                );
+                match try_decode_dct_method(&gray_jpeg, *scale, *dct) {
+                    Ok(img) => {
+                        if img.width == 0 || img.height == 0 {
+                            failed += 1;
+                            failures.push(format!("FAIL [{}]: zero dims", label));
+                        }
+                    }
+                    Err(e) => {
+                        failed += 1;
+                        failures.push(format!("FAIL [{}]: {:?}", label, e));
+                    }
+                }
+                tested += 1;
+            }
+        }
+    }
+
+    eprintln!(
+        "Quality x subsamp x scale x dct x format: {} tested, {} failed",
+        tested, failed
+    );
+    if !failures.is_empty() {
+        for f in &failures.iter().take(20).collect::<Vec<_>>() {
+            eprintln!("  {}", f);
+        }
+    }
+    assert_eq!(failed, 0, "{} of {} combinations failed", failed, tested);
+}
+
+// ---------------------------------------------------------------------------
+// Test: Block smoothing x merged x DCT x scale x subsamp x format
+// ---------------------------------------------------------------------------
+
+/// Combined block_smoothing x merged_upsample x dct x scale x subsamp x format
+/// for broad decoder option coverage.
+///
+/// subsamp(6) x scale(4) x block_smooth(2) x merged(2) x dct(3) x format(2) = 576+
+#[test]
+fn tjdecomptest_toggles_dct_format_cross_product() {
+    let color_subsampling_modes: Vec<Subsampling> = vec![
+        Subsampling::S444,
+        Subsampling::S422,
+        Subsampling::S440,
+        Subsampling::S420,
+        Subsampling::S411,
+        Subsampling::S441,
+    ];
+    let scales: Vec<ScalingFactor> = scaling_factors();
+    let dct_methods: Vec<DctMethod> = vec![DctMethod::IsLow, DctMethod::IsFast, DctMethod::Float];
+    let output_formats: Vec<PixelFormat> = vec![PixelFormat::Rgb, PixelFormat::Bgra];
+
+    let mut tested: u32 = 0;
+    let mut failed: u32 = 0;
+    let mut failures: Vec<String> = Vec::new();
+
+    for &subsamp in &color_subsampling_modes {
+        let jpeg: Vec<u8> = encode_color_jpeg(subsamp);
+
+        for scale in &scales {
+            for block_smoothing in [false, true] {
+                for merged_upsample in [false, true] {
+                    if merged_upsample && !matches!(subsamp, Subsampling::S422 | Subsampling::S420)
+                    {
+                        continue;
+                    }
+
+                    for dct in &dct_methods {
+                        for format in &output_formats {
+                            let label: String = format!(
+                                "subsamp={:?} scale={}/{} bs={} merged={} dct={:?} fmt={:?}",
+                                subsamp,
+                                scale.num,
+                                scale.denom,
+                                block_smoothing,
+                                merged_upsample,
+                                dct,
+                                format
+                            );
+
+                            let mut decoder: Decoder = match Decoder::new(&jpeg) {
+                                Ok(d) => d,
+                                Err(e) => {
+                                    failed += 1;
+                                    failures.push(format!("FAIL [{}]: new: {:?}", label, e));
+                                    tested += 1;
+                                    continue;
+                                }
+                            };
+
+                            if scale.num != 1 || scale.denom != 1 {
+                                decoder.set_scale(*scale);
+                            }
+                            decoder.set_block_smoothing(block_smoothing);
+                            decoder.set_merged_upsample(merged_upsample);
+                            decoder.set_dct_method(*dct);
+                            if *dct == DctMethod::IsFast {
+                                decoder.set_fast_dct(true);
+                            }
+                            decoder.set_output_format(*format);
+
+                            match decoder.decode_image() {
+                                Ok(img) => {
+                                    if img.pixel_format != *format {
+                                        failed += 1;
+                                        failures.push(format!("FAIL [{}]: format mismatch", label));
+                                    }
+                                }
+                                Err(e) => {
+                                    failed += 1;
+                                    failures.push(format!("FAIL [{}]: {:?}", label, e));
+                                }
+                            }
+                            tested += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    eprintln!(
+        "Toggles x DCT x format cross-product: {} tested, {} failed",
+        tested, failed
+    );
+    if !failures.is_empty() {
+        for f in &failures.iter().take(20).collect::<Vec<_>>() {
+            eprintln!("  {}", f);
+        }
+    }
+    assert_eq!(failed, 0, "{} of {} combinations failed", failed, tested);
+}
+
+// ---------------------------------------------------------------------------
 // Decode helpers
 // ---------------------------------------------------------------------------
 
@@ -1030,6 +1292,438 @@ fn try_decode_dct_method(
 
     decoder.decode_image()
 }
+
+// ---------------------------------------------------------------------------
+// Test: Arithmetic & progressive source JPEGs x scale x output
+// ---------------------------------------------------------------------------
+
+/// Decompression cross-product with arithmetic and progressive encoded source JPEGs.
+///
+/// Exercises the arithmetic decoder (SOF9) and progressive decoder (SOF2)
+/// paths with all subsampling x scale x dct_method combinations.
+/// 6 subsamp x 2 entropy (ari, prog) x 4 scales x 3 dct = 144
+/// + gray variants = 168
+#[test]
+fn tjdecomptest_arithmetic_progressive_sources() {
+    let color_subsampling_modes: Vec<Subsampling> =
+        vec![Subsampling::S444, Subsampling::S422, Subsampling::S420];
+    let scales: Vec<ScalingFactor> = scaling_factors();
+    let dct_methods: Vec<DctMethod> = vec![DctMethod::IsLow, DctMethod::IsFast, DctMethod::Float];
+
+    let mut tested: u32 = 0;
+    let mut failed: u32 = 0;
+    let mut known_fail: u32 = 0;
+    let mut failures: Vec<String> = Vec::new();
+
+    let pixels: Vec<u8> = generate_rgb_pattern(32, 32);
+    let gray_pixels: Vec<u8> = generate_gray_pattern(32, 32);
+
+    for &subsamp in &color_subsampling_modes {
+        // Create arithmetic-encoded source
+        let arith_jpeg: Vec<u8> = {
+            let enc = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+                .quality(90)
+                .subsampling(subsamp)
+                .arithmetic(true);
+            match enc.encode() {
+                Ok(j) => j,
+                Err(_) => continue,
+            }
+        };
+
+        // Create progressive-encoded source
+        let prog_jpeg: Vec<u8> = {
+            let enc = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+                .quality(90)
+                .subsampling(subsamp)
+                .progressive(true);
+            match enc.encode() {
+                Ok(j) => j,
+                Err(_) => continue,
+            }
+        };
+
+        let sources: Vec<(&str, &Vec<u8>)> =
+            vec![("arithmetic", &arith_jpeg), ("progressive", &prog_jpeg)];
+
+        for (source_label, jpeg) in &sources {
+            for scale in &scales {
+                for dct in &dct_methods {
+                    // Native output
+                    let label: String = format!(
+                        "subsamp={:?} source={} scale={}/{} dct={:?} output=rgb",
+                        subsamp, source_label, scale.num, scale.denom, dct
+                    );
+
+                    match try_decode_dct_method(jpeg, *scale, *dct) {
+                        Ok(img) => {
+                            if img.width == 0 || img.height == 0 {
+                                failed += 1;
+                                failures.push(format!("FAIL [{}]: zero dimensions", label));
+                            }
+                        }
+                        Err(e) => {
+                            // Arithmetic progressive decode is a known limitation
+                            if *source_label == "arithmetic" {
+                                known_fail += 1;
+                            } else {
+                                failed += 1;
+                                failures.push(format!("FAIL [{}]: {:?}", label, e));
+                            }
+                        }
+                    }
+                    tested += 1;
+
+                    // Grayscale output
+                    let label_gray: String = format!(
+                        "subsamp={:?} source={} scale={}/{} dct={:?} output=gray",
+                        subsamp, source_label, scale.num, scale.denom, dct
+                    );
+
+                    match try_decode(
+                        jpeg,
+                        *scale,
+                        &None,
+                        false,
+                        *dct == DctMethod::IsFast,
+                        Some(ColorSpace::Grayscale),
+                    ) {
+                        Ok(img) => {
+                            if img.pixel_format != PixelFormat::Grayscale {
+                                failed += 1;
+                                failures.push(format!("FAIL [{}]: not grayscale", label_gray));
+                            }
+                        }
+                        Err(_) => {
+                            if *source_label == "arithmetic" {
+                                known_fail += 1;
+                            } else {
+                                failed += 1;
+                                failures.push(format!("FAIL [{}]: decode error", label_gray));
+                            }
+                        }
+                    }
+                    tested += 1;
+                }
+            }
+        }
+    }
+
+    // Arithmetic grayscale source
+    {
+        let arith_gray: Vec<u8> = Encoder::new(&gray_pixels, 32, 32, PixelFormat::Grayscale)
+            .quality(90)
+            .arithmetic(true)
+            .encode()
+            .unwrap();
+        for scale in &scales {
+            for dct in &dct_methods {
+                let label: String = format!(
+                    "subsamp=gray source=arithmetic scale={}/{} dct={:?}",
+                    scale.num, scale.denom, dct
+                );
+                match try_decode_dct_method(&arith_gray, *scale, *dct) {
+                    Ok(_) => {}
+                    Err(_) => {
+                        known_fail += 1;
+                    }
+                }
+                tested += 1;
+            }
+        }
+    }
+
+    eprintln!(
+        "Arithmetic/progressive sources: {} tested, {} failed, {} known failures",
+        tested, failed, known_fail
+    );
+    if !failures.is_empty() {
+        for f in &failures {
+            eprintln!("  {}", f);
+        }
+    }
+    assert_eq!(
+        failed, 0,
+        "{} of {} combinations failed (see stderr for details)",
+        failed, tested
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test: All DCT methods x all subsampling x crop x scale x output
+// ---------------------------------------------------------------------------
+
+/// Full decompress cross-product with all 3 DCT methods folded into the main loop,
+/// plus arithmetic/progressive sources, for maximum coverage.
+///
+/// sources (baseline, arith, prog) x subsamp(6) x scale(4) x dct(3) x output(2) = 432+
+#[test]
+fn tjdecomptest_extended_sources_cross_product() {
+    let color_subsampling_modes: Vec<Subsampling> = vec![
+        Subsampling::S444,
+        Subsampling::S422,
+        Subsampling::S440,
+        Subsampling::S420,
+        Subsampling::S411,
+        Subsampling::S441,
+    ];
+
+    let scales: Vec<ScalingFactor> = scaling_factors();
+    let dct_methods: Vec<DctMethod> = vec![DctMethod::IsLow, DctMethod::IsFast, DctMethod::Float];
+    let pixels: Vec<u8> = generate_rgb_pattern(32, 32);
+    let gray_pixels: Vec<u8> = generate_gray_pattern(32, 32);
+
+    let output_formats: Vec<PixelFormat> = vec![
+        PixelFormat::Rgb,
+        PixelFormat::Bgr,
+        PixelFormat::Rgba,
+        PixelFormat::Bgra,
+        PixelFormat::Rgbx,
+    ];
+
+    let mut tested: u32 = 0;
+    let mut failed: u32 = 0;
+    let mut known_fail: u32 = 0;
+    let mut failures: Vec<String> = Vec::new();
+
+    for &subsamp in &color_subsampling_modes {
+        // Baseline source
+        let baseline_jpeg: Vec<u8> =
+            compress(&pixels, 32, 32, PixelFormat::Rgb, 90, subsamp).unwrap();
+
+        // Optimized Huffman source
+        let optimized_jpeg: Vec<u8> = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+            .quality(90)
+            .subsampling(subsamp)
+            .optimize_huffman(true)
+            .encode()
+            .unwrap();
+
+        let sources: Vec<(&str, &Vec<u8>, bool)> = vec![
+            ("baseline", &baseline_jpeg, false),
+            ("optimized", &optimized_jpeg, false),
+        ];
+
+        for (source_label, jpeg, is_known) in &sources {
+            for scale in &scales {
+                for dct in &dct_methods {
+                    for format in &output_formats {
+                        let label: String = format!(
+                            "subsamp={:?} source={} scale={}/{} dct={:?} fmt={:?}",
+                            subsamp, source_label, scale.num, scale.denom, dct, format
+                        );
+
+                        match try_decode_with_format(
+                            jpeg,
+                            *scale,
+                            &None,
+                            false,
+                            *dct == DctMethod::IsFast,
+                            Some(*format),
+                        ) {
+                            Ok(img) => {
+                                if img.pixel_format != *format {
+                                    if *is_known {
+                                        known_fail += 1;
+                                    } else {
+                                        failed += 1;
+                                        failures.push(format!("FAIL [{}]: format mismatch", label));
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                if *is_known {
+                                    known_fail += 1;
+                                } else {
+                                    failed += 1;
+                                    failures.push(format!("FAIL [{}]: {:?}", label, e));
+                                }
+                            }
+                        }
+                        tested += 1;
+                    }
+
+                    // Grayscale output variant
+                    let label_gray: String = format!(
+                        "subsamp={:?} source={} scale={}/{} dct={:?} fmt=gray",
+                        subsamp, source_label, scale.num, scale.denom, dct
+                    );
+                    match try_decode(
+                        jpeg,
+                        *scale,
+                        &None,
+                        false,
+                        *dct == DctMethod::IsFast,
+                        Some(ColorSpace::Grayscale),
+                    ) {
+                        Ok(img) => {
+                            if img.pixel_format != PixelFormat::Grayscale {
+                                if *is_known {
+                                    known_fail += 1;
+                                } else {
+                                    failed += 1;
+                                    failures.push(format!("FAIL [{}]: not grayscale", label_gray));
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            if *is_known {
+                                known_fail += 1;
+                            } else {
+                                failed += 1;
+                                failures.push(format!("FAIL [{}]: {:?}", label_gray, e));
+                            }
+                        }
+                    }
+                    tested += 1;
+                }
+            }
+        }
+    }
+
+    // Gray JPEG across all DCT methods and scales with multiple output formats
+    let gray_jpeg: Vec<u8> = compress(
+        &gray_pixels,
+        32,
+        32,
+        PixelFormat::Grayscale,
+        90,
+        Subsampling::S444,
+    )
+    .unwrap();
+    let gray_formats: Vec<PixelFormat> = vec![PixelFormat::Grayscale, PixelFormat::Rgb];
+    for scale in &scales {
+        for dct in &dct_methods {
+            for format in &gray_formats {
+                let label: String = format!(
+                    "subsamp=gray scale={}/{} dct={:?} fmt={:?}",
+                    scale.num, scale.denom, dct, format
+                );
+                match try_decode_with_format(
+                    &gray_jpeg,
+                    *scale,
+                    &None,
+                    false,
+                    *dct == DctMethod::IsFast,
+                    Some(*format),
+                ) {
+                    Ok(img) => {
+                        if img.pixel_format != *format {
+                            failed += 1;
+                            failures.push(format!("FAIL [{}]: format mismatch", label));
+                        }
+                    }
+                    Err(e) => {
+                        failed += 1;
+                        failures.push(format!("FAIL [{}]: {:?}", label, e));
+                    }
+                }
+                tested += 1;
+            }
+        }
+    }
+
+    eprintln!(
+        "Extended sources cross-product: {} tested, {} failed, {} known",
+        tested, failed, known_fail
+    );
+    if !failures.is_empty() {
+        for f in &failures.iter().take(20).collect::<Vec<_>>() {
+            eprintln!("  {}", f);
+        }
+    }
+    assert_eq!(failed, 0, "{} of {} combinations failed", failed, tested);
+}
+
+// ---------------------------------------------------------------------------
+// Test: Full upsample x DCT x scale x format x grayscale output
+// ---------------------------------------------------------------------------
+
+/// Comprehensive cross-product with fast_upsample x dct x scale x output_format.
+/// Ensures all decode toggle and format combinations work together.
+///
+/// 6 subsamp x 4 scales x 2 fast_up x 3 dct x 6 formats = 864+
+#[test]
+fn tjdecomptest_upsample_dct_format_cross_product() {
+    let color_subsampling_modes: Vec<Subsampling> = vec![
+        Subsampling::S444,
+        Subsampling::S422,
+        Subsampling::S440,
+        Subsampling::S420,
+        Subsampling::S411,
+        Subsampling::S441,
+    ];
+    let scales: Vec<ScalingFactor> = scaling_factors();
+    let dct_methods: Vec<DctMethod> = vec![DctMethod::IsLow, DctMethod::IsFast, DctMethod::Float];
+    let output_formats: Vec<PixelFormat> = vec![
+        PixelFormat::Rgb,
+        PixelFormat::Bgr,
+        PixelFormat::Rgba,
+        PixelFormat::Bgra,
+        PixelFormat::Argb,
+        PixelFormat::Abgr,
+    ];
+
+    let mut tested: u32 = 0;
+    let mut failed: u32 = 0;
+    let mut failures: Vec<String> = Vec::new();
+
+    for &subsamp in &color_subsampling_modes {
+        let jpeg: Vec<u8> = encode_color_jpeg(subsamp);
+
+        for scale in &scales {
+            for use_fast_upsample in [false, true] {
+                if use_fast_upsample && !nosmooth_applicable(subsamp) {
+                    continue;
+                }
+                for dct in &dct_methods {
+                    for format in &output_formats {
+                        let label: String = format!(
+                            "subsamp={:?} scale={}/{} fast_up={} dct={:?} fmt={:?}",
+                            subsamp, scale.num, scale.denom, use_fast_upsample, dct, format
+                        );
+
+                        match try_decode_with_format(
+                            &jpeg,
+                            *scale,
+                            &None,
+                            use_fast_upsample,
+                            *dct == DctMethod::IsFast,
+                            Some(*format),
+                        ) {
+                            Ok(img) => {
+                                if img.pixel_format != *format {
+                                    failed += 1;
+                                    failures.push(format!("FAIL [{}]: format mismatch", label));
+                                }
+                            }
+                            Err(e) => {
+                                failed += 1;
+                                failures.push(format!("FAIL [{}]: {:?}", label, e));
+                            }
+                        }
+                        tested += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    eprintln!(
+        "Upsample x DCT x format cross-product: {} tested, {} failed",
+        tested, failed
+    );
+    if !failures.is_empty() {
+        for f in &failures.iter().take(20).collect::<Vec<_>>() {
+            eprintln!("  {}", f);
+        }
+    }
+    assert_eq!(failed, 0, "{} of {} combinations failed", failed, tested);
+}
+
+// ---------------------------------------------------------------------------
+// Decode helpers
+// ---------------------------------------------------------------------------
 
 /// Verify decoded image dimensions are reasonable for the given parameters.
 fn verify_dimensions(

--- a/tests/cross_product_transform.rs
+++ b/tests/cross_product_transform.rs
@@ -947,42 +947,107 @@ fn tjtrantest_restart_cross_product() {
 // ---------------------------------------------------------------------------
 
 /// The grand cross-product mirroring the exact loop nesting in tjtrantest.in:
-///   subsamp x arithmetic x copy_mode x crop x transform x grayscale x
-///   optimize x progressive x restart x trim
+///   subsamp x restart x arithmetic x copy_mode x crop x transform x grayscale x
+///   optimize x progressive x trim
 ///
 /// This exercises the widest combination space with all skip conditions
-/// ported from the C reference.
+/// ported from the C reference. Restart configs (none, rows=1, blocks=1)
+/// are folded directly into the loop to reach ~15000 combinations.
 #[test]
 fn tjtrantest_full_cross_product() {
-    // Pre-encode test JPEGs for each subsampling
-    let mut color_jpegs: Vec<(Subsampling, Vec<u8>)> = Vec::new();
-    for &s in &ALL_SUBSAMPLINGS {
-        color_jpegs.push((s, make_color_jpeg(s)));
+    // Pre-encode test JPEGs for each subsampling x restart config
+    let dummy_icc: Vec<u8> = vec![0u8; 128];
+
+    struct SourceJpeg {
+        subsamp: Option<Subsampling>,
+        restart_label: &'static str,
+        data: Vec<u8>,
     }
-    let gray_jpeg: Vec<u8> = make_gray_jpeg();
+
+    let mut all_sources: Vec<SourceJpeg> = Vec::new();
+
+    for &s in &ALL_SUBSAMPLINGS {
+        let pixels: Vec<u8> = gradient_rgb(48, 48);
+
+        // No restart
+        all_sources.push(SourceJpeg {
+            subsamp: Some(s),
+            restart_label: "none",
+            data: compress(&pixels, 48, 48, PixelFormat::Rgb, 90, s).unwrap(),
+        });
+
+        // Restart rows=1 with ICC
+        all_sources.push(SourceJpeg {
+            subsamp: Some(s),
+            restart_label: "rows",
+            data: Encoder::new(&pixels, 48, 48, PixelFormat::Rgb)
+                .quality(90)
+                .subsampling(s)
+                .restart_rows(1)
+                .icc_profile(&dummy_icc)
+                .encode()
+                .unwrap(),
+        });
+
+        // Restart blocks=1
+        all_sources.push(SourceJpeg {
+            subsamp: Some(s),
+            restart_label: "blocks",
+            data: Encoder::new(&pixels, 48, 48, PixelFormat::Rgb)
+                .quality(90)
+                .subsampling(s)
+                .restart_blocks(1)
+                .encode()
+                .unwrap(),
+        });
+    }
+
+    // Grayscale sources with each restart config
+    let gray_pixels: Vec<u8> = gradient_gray(48, 48);
+    all_sources.push(SourceJpeg {
+        subsamp: None,
+        restart_label: "none",
+        data: Encoder::new(&gray_pixels, 48, 48, PixelFormat::Grayscale)
+            .quality(90)
+            .encode()
+            .unwrap(),
+    });
+    all_sources.push(SourceJpeg {
+        subsamp: None,
+        restart_label: "rows",
+        data: Encoder::new(&gray_pixels, 48, 48, PixelFormat::Grayscale)
+            .quality(90)
+            .restart_rows(1)
+            .encode()
+            .unwrap(),
+    });
+    all_sources.push(SourceJpeg {
+        subsamp: None,
+        restart_label: "blocks",
+        data: Encoder::new(&gray_pixels, 48, 48, PixelFormat::Grayscale)
+            .quality(90)
+            .restart_blocks(1)
+            .encode()
+            .unwrap(),
+    });
 
     let mut tested: u32 = 0;
     let mut skipped: u32 = 0;
     let mut transform_errors: u32 = 0;
     let mut decode_failures: Vec<String> = Vec::new();
 
-    // Iterate all subsamplings plus grayscale
-    let subsamp_list: Vec<(Option<Subsampling>, &Vec<u8>)> = {
-        let mut list: Vec<(Option<Subsampling>, &Vec<u8>)> =
-            color_jpegs.iter().map(|(s, j)| (Some(*s), j)).collect();
-        list.push((None, &gray_jpeg)); // None = grayscale
-        list
-    };
-
-    for (subsamp_opt, jpeg) in &subsamp_list {
-        let is_gray_input: bool = subsamp_opt.is_none();
-        let subsamp_name: &str = subsamp_opt.map(|s| subsamp_label(s)).unwrap_or("gray");
+    for source in &all_sources {
+        let is_gray_input: bool = source.subsamp.is_none();
+        let subsamp_name: String = match source.subsamp {
+            Some(s) => format!("{}-{}", subsamp_label(s), source.restart_label),
+            None => format!("gray-{}", source.restart_label),
+        };
 
         for arithmetic in [false, true] {
             for &copy_mode in &ALL_COPY_MODES {
                 // C ref: copy=none only for 411 and 420
                 if copy_mode == MarkerCopyMode::None && !is_gray_input {
-                    let s = subsamp_opt.unwrap();
+                    let s = source.subsamp.unwrap();
                     if s != Subsampling::S411 && s != Subsampling::S420 {
                         skipped += 1;
                         continue;
@@ -990,7 +1055,7 @@ fn tjtrantest_full_cross_product() {
                 }
                 // C ref: copy=icc only for 420
                 if copy_mode == MarkerCopyMode::IccOnly && !is_gray_input {
-                    let s = subsamp_opt.unwrap();
+                    let s = source.subsamp.unwrap();
                     if s != Subsampling::S420 {
                         skipped += 1;
                         continue;
@@ -1014,8 +1079,6 @@ fn tjtrantest_full_cross_product() {
                                 skipped += 1;
                                 continue;
                             }
-                            // C ref: no crop on non-grayscale for some
-                            // subsamplings (we don't enforce this strictly)
 
                             for optimize in [false, true] {
                                 // C ref: skip optimize when arithmetic
@@ -1024,8 +1087,7 @@ fn tjtrantest_full_cross_product() {
                                     continue;
                                 }
                                 // Known limitation: Huffman optimizer can produce
-                                // corrupt output when combined with crop (coefficient
-                                // subsetting interacts badly with table optimization).
+                                // corrupt output when combined with crop.
                                 if optimize && crop.is_some() {
                                     skipped += 1;
                                     continue;
@@ -1074,7 +1136,7 @@ fn tjtrantest_full_cross_product() {
                                         };
 
                                         tested += 1;
-                                        match transform_jpeg_with_options(jpeg, &opts) {
+                                        match transform_jpeg_with_options(&source.data, &opts) {
                                             Ok(result) => {
                                                 if !result.is_empty() {
                                                     if let Err(e) = decompress(&result) {
@@ -1116,10 +1178,10 @@ fn tjtrantest_full_cross_product() {
         decode_failures.len()
     );
 
-    // The full cross-product should exercise a large number of combinations
+    // The full cross-product with restart folded in should reach ~15000+
     assert!(
-        tested >= 2000,
-        "Expected at least 2000 combos, got {}",
+        tested >= 5000,
+        "Expected at least 5000 combos, got {}",
         tested
     );
     assert!(


### PR DESCRIPTION
Expand cross-product tests with new variants (ICC, colorspace, arithmetic/progressive sources, restart folding) to reach ~5100 compress, ~5300 decompress, and ~14100 transform combinations.