### PR TITLE
fix: correct progressive AC encoder for C djpeg compatibility

### DIFF
--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -2828,25 +2828,36 @@ fn encode_ac_first_block(
     let mut zero_run: u8 = 0;
 
     for k in ss..=se {
-        let ac = block[k] >> al;
-        if ac == 0 {
+        let coeff: i16 = block[k];
+        if coeff == 0 {
             zero_run += 1;
-        } else {
-            while zero_run >= 16 {
-                writer.write_bits(ac_table.ehufco[0xF0], ac_table.ehufsi[0xF0]);
-                zero_run -= 16;
-            }
-            let (mag, size) = encode_ac_value_prog(ac);
-            let symbol = ((zero_run as u16) << 4) | (size as u16);
-            writer.write_bits(
-                ac_table.ehufco[symbol as usize],
-                ac_table.ehufsi[symbol as usize],
-            );
-            if size > 0 {
-                writer.write_bits(mag, size);
-            }
-            zero_run = 0;
+            continue;
         }
+        // Per ITU-T T.81 and libjpeg-turbo jcphuff.c: the point transform
+        // for AC coefficients is integer division with rounding toward zero.
+        // We compute absolute value first, then shift. This matches C's
+        // `abs(coeff) >> Al` approach and avoids the rounding-toward-negative-
+        // infinity behavior of signed right shift.
+        let sign_mask: i16 = coeff >> 15;
+        let abs_coeff: i16 = (coeff ^ sign_mask) - sign_mask;
+        let temp: i16 = abs_coeff >> al;
+        if temp == 0 {
+            // Nonzero coefficient became zero after point transform
+            zero_run += 1;
+            continue;
+        }
+        // For negative coeff: emit one's complement of abs value (= bitwise complement)
+        let temp2: u16 = (sign_mask ^ temp) as u16;
+
+        while zero_run >= 16 {
+            writer.write_bits(ac_table.ehufco[0xF0], ac_table.ehufsi[0xF0]);
+            zero_run -= 16;
+        }
+        let nbits: u8 = 16 - (temp as u16).leading_zeros() as u8;
+        let symbol: usize = ((zero_run as usize) << 4) | (nbits as usize);
+        writer.write_bits(ac_table.ehufco[symbol], ac_table.ehufsi[symbol]);
+        writer.write_bits(temp2, nbits);
+        zero_run = 0;
     }
     if zero_run > 0 {
         // Trailing zeros: emit EOB
@@ -2854,8 +2865,9 @@ fn encode_ac_first_block(
     }
 }
 
-/// Encode one block for AC refine scan (ah!=0) with correction bit buffering.
+/// Encode one block for AC successive approximation refinement scan (ah!=0).
 ///
+/// Ported line-by-line from libjpeg-turbo jcphuff.c `encode_mcu_AC_refine`.
 /// Per ITU-T T.81 Figure G.7, previously-nonzero coefficients emit correction
 /// bits that must be associated with the next Huffman symbol (ZRL, EOB, or
 /// newly-nonzero code). We buffer these bits and emit them after each symbol.
@@ -2870,57 +2882,85 @@ fn encode_ac_refine_block(
     let band_len: usize = se - ss + 1;
 
     // Pre-pass: compute absolute shifted values and find EOB position.
-    let mut absvals: Vec<u16> = Vec::with_capacity(band_len);
-    let mut signs: Vec<u16> = Vec::with_capacity(band_len);
-    let mut eob_idx: i32 = -1; // index of last newly-nonzero coeff
+    // Matches C's encode_mcu_AC_refine_prepare / COMPUTE_ABSVALUES_AC_REFINE.
+    let mut absvals = [0u16; 64];
+    let mut sign_bits = [0u16; 64];
+    let mut eob: usize = 0; // index past last newly-nonzero coeff (0 = no newly-nonzero)
 
-    for k in ss..=se {
-        let coeff: i32 = block[k] as i32;
+    for i in 0..band_len {
+        let coeff: i32 = block[ss + i] as i32;
+        // Compute absolute value via sign-mask trick (matches C's portable abs)
         let sign_mask: i32 = coeff >> 31;
         let abs_coeff: i32 = (coeff ^ sign_mask) - sign_mask;
-        let shifted: u16 = (abs_coeff >> al) as u16;
-        absvals.push(shifted);
-        // sign bit: 1 = positive, 0 = negative
-        signs.push((sign_mask as u16).wrapping_add(1));
-        if shifted == 1 {
-            eob_idx = (absvals.len() as i32) - 1;
+        let temp: u16 = (abs_coeff >> al) as u16;
+        absvals[i] = temp;
+        // sign bit: 1 = positive (sign_mask=0 -> 0+1=1), 0 = negative (sign_mask=-1 -> -1+1=0)
+        sign_bits[i] = (sign_mask as u16).wrapping_add(1);
+        if temp == 1 {
+            eob = i + 1; // EOB = index+1 of last newly-nonzero coef
         }
     }
 
-    let mut r: usize = 0; // zero run length
-    let mut correction_bits: Vec<u8> = Vec::new();
+    // Main loop: matches C's ENCODE_COEFS_AC_REFINE.
+    // r = run length of zero coefficients
+    // correction_bits = buffered correction bits for previously-nonzero coefficients
+    let mut r: usize = 0;
+    let mut correction_bits: Vec<u8> = Vec::with_capacity(band_len);
+    let mut idx: usize = 0;
 
-    // Main loop: matches C jcphuff.c ENCODE_COEFS_AC_REFINE.
-    // ZRL check happens BEFORE processing each nonzero coefficient.
-    for i in 0..band_len {
-        let temp: u16 = absvals[i];
+    while idx < band_len {
+        let temp: u16 = absvals[idx];
 
         if temp == 0 {
+            // Zero coefficient: increment run length
             r += 1;
+            idx += 1;
             continue;
         }
 
-        // Nonzero: check ZRL before processing (key fix)
-        while r > 15 && (i as i32) <= eob_idx {
+        // Emit any required ZRLs, but not if they can be folded into EOB.
+        // C: `while (r > 15 && (cabsvalue <= EOBPTR))`
+        // EOBPTR points to the last newly-nonzero coeff. We use eob (index+1),
+        // so `idx < eob` means we're at or before the last newly-nonzero.
+        while r > 15 && idx < eob {
+            // Emit ZRL
             writer.write_bits(ac_table.ehufco[0xF0], ac_table.ehufsi[0xF0]);
             r -= 16;
+            // Emit buffered correction bits that must be associated with ZRL
             emit_buffered_bits(&correction_bits, writer);
             correction_bits.clear();
         }
 
+        // If the coef was previously nonzero, it only needs a correction bit.
+        // NOTE: a straight translation of the spec's figure G.7 would suggest
+        // that we also need to test r > 15. But if r > 15, we can only get
+        // here if idx >= eob, which implies that this coefficient is not 1.
         if temp > 1 {
+            // The correction bit is the next bit of the absolute value.
             correction_bits.push((temp & 1) as u8);
-        } else {
-            let symbol: usize = (r << 4) | 1;
-            writer.write_bits(ac_table.ehufco[symbol], ac_table.ehufsi[symbol]);
-            writer.write_bits(signs[i], 1);
-            emit_buffered_bits(&correction_bits, writer);
-            correction_bits.clear();
-            r = 0;
+            idx += 1;
+            continue;
         }
+
+        // temp == 1: newly-nonzero coefficient
+        // Count/emit Huffman symbol for run length / number of bits
+        let symbol: usize = (r << 4) | 1;
+        writer.write_bits(ac_table.ehufco[symbol], ac_table.ehufsi[symbol]);
+
+        // Emit output bit for newly-nonzero coef (sign bit)
+        // 1 = positive, 0 = negative (matches C: `(block[k] < 0) ? 0 : 1`)
+        writer.write_bits(sign_bits[idx], 1);
+
+        // Emit buffered correction bits that must be associated with this code
+        emit_buffered_bits(&correction_bits, writer);
+        correction_bits.clear();
+        r = 0;
+        idx += 1;
     }
 
-    // Trailing zeros or remaining correction bits: emit EOB with correction bits
+    // If there are trailing zeroes or remaining correction bits, emit EOB.
+    // C: `if (r > 0 || BR > 0) { entropy->EOBRUN++; entropy->BE += BR; }`
+    // We emit per-block EOB (EOBRUN=1) immediately instead of batching.
     if r > 0 || !correction_bits.is_empty() {
         writer.write_bits(ac_table.ehufco[0x00], ac_table.ehufsi[0x00]);
         emit_buffered_bits(&correction_bits, writer);
@@ -2940,21 +2980,6 @@ fn encode_dc_value_prog(diff: i16) -> (u16, u8) {
         (diff - 1) as u16
     };
     (magnitude_bits, category)
-}
-
-/// Encode AC value for progressive.
-fn encode_ac_value_prog(value: i16) -> (u16, u8) {
-    if value == 0 {
-        return (0, 0);
-    }
-    let abs_val = value.unsigned_abs();
-    let size = 16 - abs_val.leading_zeros() as u8;
-    let magnitude_bits = if value > 0 {
-        value as u16
-    } else {
-        (value - 1) as u16
-    };
-    (magnitude_bits, size)
 }
 
 /// Scale quantization table values by 8 to create divisor table for the islow FDCT.

--- a/tests/cross_encode_decode.rs
+++ b/tests/cross_encode_decode.rs
@@ -403,15 +403,11 @@ fn rust_encode_c_decode_progressive() {
         .output()
         .expect("failed to run djpeg");
 
-    if !output.status.success() {
-        // Progressive AC refine encoding may not yet be fully C-compatible.
-        // Our decoder handles it, but C djpeg may reject it.
-        eprintln!(
-            "NOTE: djpeg rejected Rust progressive JPEG (AC refine interop): {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-        return;
-    }
+    assert!(
+        output.status.success(),
+        "djpeg rejected Rust progressive JPEG: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
 
     let (dw, dh, c_pixels) = parse_ppm(tmp_ppm.path());
     assert_eq!(dw, w);
@@ -424,6 +420,74 @@ fn rust_encode_c_decode_progressive() {
         "progressive pixel diff too large: {}",
         max_diff
     );
+}
+
+/// Verify progressive AC refine scans produce valid bitstreams that C djpeg
+/// accepts. Tests multiple image sizes and quality levels to exercise
+/// different coefficient patterns (zero-run lengths, correction bit counts).
+#[test]
+fn progressive_ac_refine_c_djpeg_compatible() {
+    let djpeg: PathBuf = match djpeg_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: djpeg not found");
+            return;
+        }
+    };
+
+    // Test several configurations to cover edge cases in AC refine:
+    // - Small image: few MCUs, short runs
+    // - Larger image: more MCUs, longer runs
+    // - Low quality: larger quantization, fewer nonzero coefficients
+    // - High quality: more nonzero coefficients, more correction bits
+    let configs: &[(usize, usize, u8, Subsampling)] = &[
+        (8, 8, 75, Subsampling::S444),
+        (48, 48, 50, Subsampling::S444),
+        (48, 48, 95, Subsampling::S444),
+        (64, 64, 75, Subsampling::S444),
+        (100, 75, 85, Subsampling::S444),
+    ];
+
+    for &(w, h, quality, subsampling) in configs {
+        let label: String = format!("{}x{}_q{}_{:?}", w, h, quality, subsampling);
+        let pixels: Vec<u8> = generate_pattern(w, h);
+
+        let jpeg: Vec<u8> =
+            compress_progressive(&pixels, w, h, PixelFormat::Rgb, quality, subsampling)
+                .expect("Rust progressive encode failed");
+
+        let tmp_jpg: TempFile = TempFile::new(&format!("acref_{}.jpg", label));
+        let tmp_ppm: TempFile = TempFile::new(&format!("acref_{}.ppm", label));
+        std::fs::write(tmp_jpg.path(), &jpeg).expect("write tmp");
+
+        let output = Command::new(&djpeg)
+            .arg("-ppm")
+            .arg("-outfile")
+            .arg(tmp_ppm.path())
+            .arg(tmp_jpg.path())
+            .output()
+            .expect("failed to run djpeg");
+
+        assert!(
+            output.status.success(),
+            "{}: djpeg rejected progressive JPEG: {}",
+            label,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+
+        let (dw, dh, c_pixels) = parse_ppm(tmp_ppm.path());
+        assert_eq!(dw, w, "{}: width mismatch", label);
+        assert_eq!(dh, h, "{}: height mismatch", label);
+
+        let rust_img: Image = decompress_to(&jpeg, PixelFormat::Rgb).expect("Rust decode failed");
+        let max_diff: u8 = pixel_max_diff(&rust_img.data, &c_pixels);
+        assert!(
+            max_diff <= 2,
+            "{}: pixel max diff = {}, expected <= 2",
+            label,
+            max_diff
+        );
+    }
 }
 
 #[test]

--- a/tests/reference_hashes.json
+++ b/tests/reference_hashes.json
@@ -4,7 +4,7 @@
     "baseline_64x64_q75_444": "1b0ce96e215de1c7",
     "baseline_64x64_q50_420": "49a53eb14ad72140",
     "baseline_64x64_q100_420": "f7a8ba5b6e803a98",
-    "progressive_64x64_q75_444": "d2a55b238230f22c",
+    "progressive_64x64_q75_444": "84f7691632060b7a",
     "arithmetic_64x64_q75_420": "521864c705e4c01e",
     "arithmetic_progressive_64x64_q75_444": "49b837695f4ec2e8",
     "lossless_64x64_gray": "4a855cdf21a29695",


### PR DESCRIPTION
## Summary

- Fix progressive AC first encoder to use abs-then-shift for the point transform (matching C jcphuff.c), instead of signed right shift which rounds toward negative infinity
- The root cause: `coeff >> al` for negative values gave wrong zero/nonzero classification, causing AC refine scans to emit correction bits at different positions than C djpeg expected, resulting in "bad Huffman code" decoder errors
- Clean up AC refine encoder to match C's `encode_mcu_AC_refine` structure more closely
- Change progressive djpeg interop test from graceful skip to hard assert
- Add `progressive_ac_refine_c_djpeg_compatible` test covering 5 image configurations

## Test plan

- [x] `cargo test` -- all tests pass (zero failures)
- [x] `rust_encode_c_decode_progressive` -- djpeg accepts output (previously rejected with "bad Huffman code")
- [x] `progressive_ac_refine_c_djpeg_compatible` -- 5 configurations: 8x8/q75, 48x48/q50, 48x48/q95, 64x64/q75, 100x75/q85
- [x] Pixel-level comparison between Rust decode and C djpeg decode: max diff <= 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)