### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libjpeg-turbo-rs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.87"
 description = "Pure Rust reimplementation of libjpeg-turbo with NEON/AVX2 SIMD acceleration"


### PR DESCRIPTION
## Summary

- Bump version to 0.2.1 for crates.io release
- Includes NEON SIMD color conversion for RGBX/BGRX/XRGB/XBGR/ARGB/ABGR (#117)

🤖 Generated with [Claude Code](https://claude.com/claude-code)