### PR TITLE
test: tighten test tolerances and add C cross-validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,6 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: [check, test-lib]
-    # Some integration tests use include_bytes! from the gitignored references/
-    # directory, so they cannot compile in CI without that data.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -84,8 +81,6 @@ jobs:
     name: C Interop Tests
     runs-on: ubuntu-latest
     needs: [test-integration]
-    # Requires references/ directory and libjpeg-turbo-progs.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,19 @@ Rust port of libjpeg-turbo with equivalent or better performance.
 - **Optimize test execution speed.** Use `cargo test` with parallel execution (default behavior). Keep each test isolated — no shared mutable state.
 - **Skip tests when no runtime impact.** Non-runtime changes (docs, README, `.md`, CI pipeline config) should not trigger test runs.
 
+### C Cross-Validation (Mandatory)
+
+- **Every decode/encode/transform test MUST cross-validate against C libjpeg-turbo.** Target: diff=0 (pixel-identical to C djpeg/cjpeg/jpegtran output).
+- Use `djpeg` for decode comparison, `cjpeg` for encode comparison, `jpegtran` for transform comparison. Tool paths: check `/opt/homebrew/bin/` first, then `which`.
+- If C tools are not available, `eprintln!("SKIP: ... not found"); return;` is acceptable — but **never** for Rust-internal failures.
+
+### Strict Assertion Rules
+
+- **Never log diffs without asserting.** Every computed `max_diff`/`mean_diff` MUST have a corresponding `assert!`/`assert_eq!`. Logging without asserting is a meaningless test.
+- **Never silently skip on Rust errors.** `match result { Err(e) => { eprintln!("SKIP"); continue/return; } }` is **forbidden** for Rust library failures. Use `.expect()` or `.unwrap_or_else(|e| panic!(...))`. Silent skips hide bugs.
+- **Never use generous tolerances as placeholders.** If the implementation is not ready, use `#[ignore = "reason with issue number"]` instead of inflating tolerance (e.g., `mean_diff < 2048` for a 0–4095 range is meaningless).
+- **Tolerance must reflect measured reality + small margin**, not a guess. Measure the actual diff, then set tolerance to `actual + 1` or tighter. Document the measured value in a comment.
+
 ## Logging
 
 - Add structured logs at key decision points, state transitions, and external calls — not every line.

--- a/tests/cross_check_12bit.rs
+++ b/tests/cross_check_12bit.rs
@@ -209,13 +209,8 @@ fn rust_12bit_c_decode() {
         }
     }
 
-    let jpeg: Vec<u8> = match compress_12bit(&pixels, w, h, num_components, 90, Subsampling::S444) {
-        Ok(data) => data,
-        Err(e) => {
-            eprintln!("SKIP: compress_12bit failed: {}", e);
-            return;
-        }
-    };
+    let jpeg: Vec<u8> = compress_12bit(&pixels, w, h, num_components, 90, Subsampling::S444)
+        .expect("compress_12bit must succeed");
 
     let tmp_jpg: TempFile = TempFile::new("rust_12bit.jpg");
     let tmp_out: TempFile = TempFile::new("rust_12bit.pnm");
@@ -355,6 +350,7 @@ fn c_12bit_cjpeg_precision_rust_decode() {
 // ===========================================================================
 
 #[test]
+#[ignore = "12-bit IDCT broken: max_diff=3127, mean_diff=1012 vs C djpeg, see issue #112"]
 fn pixel_match_12bit_c_reference() {
     let djpeg: PathBuf = match djpeg_path() {
         Some(p) => p,
@@ -375,15 +371,10 @@ fn pixel_match_12bit_c_reference() {
         return;
     }
 
-    // Decode with Rust
+    // Decode with Rust — must not fail
     let jpeg_data: Vec<u8> = std::fs::read(&ref_path).expect("read testorig12.jpg");
-    let rust_img = match decompress_12bit(&jpeg_data) {
-        Ok(img) => img,
-        Err(e) => {
-            eprintln!("SKIP: Rust decompress_12bit failed: {}", e);
-            return;
-        }
-    };
+    let rust_img =
+        decompress_12bit(&jpeg_data).expect("Rust decompress_12bit must succeed on testorig12.jpg");
 
     // Decode with C djpeg
     let tmp_out: TempFile = TempFile::new("c_12bit_ref.pnm");
@@ -449,13 +440,11 @@ fn pixel_match_12bit_c_reference() {
             maxval, max_diff, mean_diff
         );
 
-        // Our 12-bit IDCT may differ from C libjpeg-turbo's implementation.
-        // Allow a generous tolerance that still catches catastrophic failures.
-        // TODO(12bit-idct): tighten tolerance once 12-bit IDCT matches C reference
-        assert!(
-            mean_diff < 2048.0,
-            "12-bit mean diff unreasonably large: {:.2} (suggests decoder is broken, not just imprecise)",
-            mean_diff
+        // 12-bit decode must match C djpeg exactly. Target: max_diff=0.
+        assert_eq!(
+            max_diff, 0,
+            "12-bit pixel max_diff={} (must be 0 vs C djpeg, mean_diff={:.2})",
+            max_diff, mean_diff
         );
     } else if maxval == 255 {
         // djpeg produced 8-bit output from 12-bit JPEG.
@@ -504,22 +493,10 @@ fn rust_12bit_roundtrip_encode_decode() {
         }
     }
 
-    let jpeg: Vec<u8> = match compress_12bit(&pixels, w, h, num_components, 100, Subsampling::S444)
-    {
-        Ok(data) => data,
-        Err(e) => {
-            eprintln!("SKIP: compress_12bit failed: {}", e);
-            return;
-        }
-    };
+    let jpeg: Vec<u8> = compress_12bit(&pixels, w, h, num_components, 100, Subsampling::S444)
+        .expect("compress_12bit must succeed");
 
-    let img = match decompress_12bit(&jpeg) {
-        Ok(img) => img,
-        Err(e) => {
-            eprintln!("SKIP: decompress_12bit failed: {}", e);
-            return;
-        }
-    };
+    let img = decompress_12bit(&jpeg).expect("decompress_12bit must succeed on own output");
 
     assert_eq!(img.width, w);
     assert_eq!(img.height, h);

--- a/tests/cross_check_transform.rs
+++ b/tests/cross_check_transform.rs
@@ -202,6 +202,7 @@ fn transform_name(op: TransformOp) -> &'static str {
 // ===========================================================================
 
 #[test]
+#[ignore = "Transform produces wrong output vs C jpegtran (max_diff=255 for rot90/rot270/transverse), see issue #112"]
 fn rust_transform_matches_c_jpegtran() {
     let jpegtran: PathBuf = match jpegtran_path() {
         Some(p) => p,
@@ -226,14 +227,9 @@ fn rust_transform_matches_c_jpegtran() {
     for op in transforms {
         let name: &str = transform_name(op);
 
-        // Rust transform
-        let rust_result: Vec<u8> = match transform(&source_jpeg, op) {
-            Ok(data) => data,
-            Err(e) => {
-                eprintln!("SKIP: Rust transform {} failed: {}", name, e);
-                continue;
-            }
-        };
+        // Rust transform — must not fail for any supported operation
+        let rust_result: Vec<u8> = transform(&source_jpeg, op)
+            .unwrap_or_else(|e| panic!("Rust transform {} must succeed: {}", name, e));
 
         // C jpegtran
         let tmp_in: TempFile = TempFile::new(&format!("{}_in.jpg", name));
@@ -274,29 +270,19 @@ fn rust_transform_matches_c_jpegtran() {
             name, rust_img.height, c_img.height
         );
 
-        // Lossless transforms operate on DCT coefficients. Our implementation
-        // and C jpegtran may differ in how they handle partial MCU blocks,
-        // coefficient re-encoding, and rounding. Even with MCU-aligned images
-        // and S444, the coefficient round-trip through read -> transform -> write
-        // can introduce differences from quantization table rounding.
+        // Lossless transforms on MCU-aligned S444 images must produce
+        // pixel-identical output to C jpegtran. Target: max_diff=0.
         let max_diff: u8 = pixel_max_diff(&rust_img.data, &c_img.data);
-        let mean_diff: f64 = rust_img
-            .data
-            .iter()
-            .zip(c_img.data.iter())
-            .map(|(&a, &b)| (a as i16 - b as i16).unsigned_abs() as f64)
-            .sum::<f64>()
-            / rust_img.data.len().max(1) as f64;
-        eprintln!(
-            "{}: Rust={}x{} vs C={}x{} pixel max_diff={} mean_diff={:.2}",
-            name, rust_img.width, rust_img.height, c_img.width, c_img.height, max_diff, mean_diff
+        assert_eq!(
+            max_diff,
+            0,
+            "{}: decoded pixel max_diff={} (must be 0 vs C jpegtran). \
+             Rust JPEG={} bytes, C JPEG={} bytes",
+            name,
+            max_diff,
+            rust_result.len(),
+            c_result.len()
         );
-        // Verify both produce valid decodable output with matching dimensions.
-        // Pixel differences are logged for debugging but not strictly asserted
-        // because our coefficient read/write pipeline may differ from jpegtran's
-        // in rounding and quantization handling.
-        // TODO(transform-fidelity): tighten pixel tolerance once coefficient
-        // round-trip matches C reference exactly.
     }
 }
 
@@ -364,6 +350,7 @@ fn c_jpegtran_output_rust_decode() {
 // ===========================================================================
 
 #[test]
+#[ignore = "Transform produces wrong JPEG bytes vs C jpegtran, see issue #112"]
 fn rust_transform_output_c_djpeg() {
     let djpeg: PathBuf = match djpeg_path() {
         Some(p) => p,
@@ -375,14 +362,9 @@ fn rust_transform_output_c_djpeg() {
 
     let source_jpeg: Vec<u8> = get_test_jpeg();
 
-    // Apply horizontal flip with Rust
-    let flipped: Vec<u8> = match transform(&source_jpeg, TransformOp::HFlip) {
-        Ok(data) => data,
-        Err(e) => {
-            eprintln!("SKIP: Rust hflip failed: {}", e);
-            return;
-        }
-    };
+    // Apply horizontal flip with Rust — must succeed
+    let flipped: Vec<u8> =
+        transform(&source_jpeg, TransformOp::HFlip).expect("Rust hflip must succeed");
 
     let tmp_jpg: TempFile = TempFile::new("rust_hflip.jpg");
     let tmp_ppm: TempFile = TempFile::new("rust_hflip.ppm");
@@ -421,6 +403,7 @@ fn rust_transform_output_c_djpeg() {
 // ===========================================================================
 
 #[test]
+#[ignore = "Transform grayscale diff != 0 vs C jpegtran, see issue #112"]
 fn transform_grayscale_cross_check() {
     let jpegtran: PathBuf = match jpegtran_path() {
         Some(p) => p,
@@ -432,8 +415,8 @@ fn transform_grayscale_cross_check() {
 
     let source_jpeg: Vec<u8> = get_test_jpeg();
 
-    // Rust: grayscale transform
-    let rust_gray: Vec<u8> = match transform_jpeg_with_options(
+    // Rust: grayscale transform — must succeed
+    let rust_gray: Vec<u8> = transform_jpeg_with_options(
         &source_jpeg,
         &TransformOptions {
             op: TransformOp::None,
@@ -441,13 +424,8 @@ fn transform_grayscale_cross_check() {
             copy_markers: MarkerCopyMode::None,
             ..Default::default()
         },
-    ) {
-        Ok(data) => data,
-        Err(e) => {
-            eprintln!("SKIP: Rust grayscale transform failed: {}", e);
-            return;
-        }
-    };
+    )
+    .expect("Rust grayscale transform must succeed");
 
     // C: jpegtran -grayscale
     let tmp_in: TempFile = TempFile::new("gray_in.jpg");
@@ -480,11 +458,11 @@ fn transform_grayscale_cross_check() {
     assert_eq!(rust_img.width, c_img.width, "grayscale width mismatch");
     assert_eq!(rust_img.height, c_img.height, "grayscale height mismatch");
     let max_diff: u8 = pixel_max_diff(&rust_img.data, &c_img.data);
-    // Grayscale drops chroma components. Small differences can occur from
-    // coefficient re-encoding and Huffman table differences.
-    assert!(
-        max_diff <= 10,
-        "grayscale transform pixels differ too much (max_diff={}, expected <= 10)",
+    // Grayscale transform drops chroma components; decoded luma must match
+    // C jpegtran exactly. Target: max_diff=0.
+    assert_eq!(
+        max_diff, 0,
+        "grayscale transform: max_diff={} (must be 0 vs C jpegtran)",
         max_diff
     );
 }
@@ -494,6 +472,7 @@ fn transform_grayscale_cross_check() {
 // ===========================================================================
 
 #[test]
+#[ignore = "Transform crop diff != 0 vs C jpegtran, see issue #112"]
 fn transform_crop_cross_check() {
     let jpegtran: PathBuf = match jpegtran_path() {
         Some(p) => p,
@@ -513,8 +492,8 @@ fn transform_crop_cross_check() {
         height: 16,
     };
 
-    // Rust: transform with crop
-    let rust_cropped: Vec<u8> = match transform_jpeg_with_options(
+    // Rust: transform with crop — must succeed
+    let rust_cropped: Vec<u8> = transform_jpeg_with_options(
         &source_jpeg,
         &TransformOptions {
             op: TransformOp::None,
@@ -522,13 +501,8 @@ fn transform_crop_cross_check() {
             copy_markers: MarkerCopyMode::None,
             ..Default::default()
         },
-    ) {
-        Ok(data) => data,
-        Err(e) => {
-            eprintln!("SKIP: Rust crop transform failed: {}", e);
-            return;
-        }
-    };
+    )
+    .expect("Rust crop transform must succeed");
 
     // C: jpegtran -crop WxH+X+Y
     let tmp_in: TempFile = TempFile::new("crop_in.jpg");
@@ -572,10 +546,10 @@ fn transform_crop_cross_check() {
     );
 
     let max_diff: u8 = pixel_max_diff(&rust_img.data, &c_img.data);
-    // Crop operates on DCT blocks; small differences from re-encoding.
-    assert!(
-        max_diff <= 10,
-        "crop transform pixels differ too much (max_diff={}, expected <= 10)",
+    // Crop on DCT blocks must match C jpegtran exactly. Target: max_diff=0.
+    assert_eq!(
+        max_diff, 0,
+        "crop transform: max_diff={} (must be 0 vs C jpegtran)",
         max_diff
     );
 }
@@ -585,6 +559,7 @@ fn transform_crop_cross_check() {
 // ===========================================================================
 
 #[test]
+#[ignore = "Transform optimize diff != 0 vs C jpegtran, see issue #112"]
 fn transform_optimize_cross_check() {
     let jpegtran: PathBuf = match jpegtran_path() {
         Some(p) => p,
@@ -603,8 +578,8 @@ fn transform_optimize_cross_check() {
 
     let source_jpeg: Vec<u8> = get_test_jpeg();
 
-    // Rust: transform with optimize
-    let rust_opt: Vec<u8> = match transform_jpeg_with_options(
+    // Rust: transform with optimize — must succeed
+    let rust_opt: Vec<u8> = transform_jpeg_with_options(
         &source_jpeg,
         &TransformOptions {
             op: TransformOp::None,
@@ -612,13 +587,8 @@ fn transform_optimize_cross_check() {
             copy_markers: MarkerCopyMode::None,
             ..Default::default()
         },
-    ) {
-        Ok(data) => data,
-        Err(e) => {
-            eprintln!("SKIP: Rust optimize transform failed: {}", e);
-            return;
-        }
-    };
+    )
+    .expect("Rust optimize transform must succeed");
 
     // Verify djpeg can decode our optimized output
     let tmp_jpg: TempFile = TempFile::new("opt_rust.jpg");
@@ -694,6 +664,7 @@ fn transform_optimize_cross_check() {
 // ===========================================================================
 
 #[test]
+#[ignore = "Transform progressive diff != 0 vs C jpegtran, see issue #112"]
 fn transform_progressive_cross_check() {
     let jpegtran: PathBuf = match jpegtran_path() {
         Some(p) => p,
@@ -712,8 +683,8 @@ fn transform_progressive_cross_check() {
 
     let source_jpeg: Vec<u8> = get_test_jpeg();
 
-    // Rust: transform with progressive
-    let rust_prog: Vec<u8> = match transform_jpeg_with_options(
+    // Rust: transform with progressive — must succeed
+    let rust_prog: Vec<u8> = transform_jpeg_with_options(
         &source_jpeg,
         &TransformOptions {
             op: TransformOp::None,
@@ -721,13 +692,8 @@ fn transform_progressive_cross_check() {
             copy_markers: MarkerCopyMode::None,
             ..Default::default()
         },
-    ) {
-        Ok(data) => data,
-        Err(e) => {
-            eprintln!("SKIP: Rust progressive transform failed: {}", e);
-            return;
-        }
-    };
+    )
+    .expect("Rust progressive transform must succeed");
 
     // Verify djpeg can decode our progressive output
     let tmp_jpg: TempFile = TempFile::new("prog_rust.jpg");
@@ -808,6 +774,7 @@ fn transform_progressive_cross_check() {
 // ===========================================================================
 
 #[test]
+#[ignore = "Rot180+grayscale diff != 0 vs C jpegtran, see issue #112"]
 fn transform_rotate_grayscale_cross_check() {
     let jpegtran: PathBuf = match jpegtran_path() {
         Some(p) => p,
@@ -819,8 +786,8 @@ fn transform_rotate_grayscale_cross_check() {
 
     let source_jpeg: Vec<u8> = get_test_jpeg();
 
-    // Rust: rotate 180 + grayscale
-    let rust_result: Vec<u8> = match transform_jpeg_with_options(
+    // Rust: rotate 180 + grayscale — must succeed
+    let rust_result: Vec<u8> = transform_jpeg_with_options(
         &source_jpeg,
         &TransformOptions {
             op: TransformOp::Rot180,
@@ -828,13 +795,8 @@ fn transform_rotate_grayscale_cross_check() {
             copy_markers: MarkerCopyMode::None,
             ..Default::default()
         },
-    ) {
-        Ok(data) => data,
-        Err(e) => {
-            eprintln!("SKIP: Rust rot180+grayscale failed: {}", e);
-            return;
-        }
-    };
+    )
+    .expect("Rust rot180+grayscale transform must succeed");
 
     // C: jpegtran -rotate 180 -grayscale
     let tmp_in: TempFile = TempFile::new("rotgray_in.jpg");
@@ -869,11 +831,10 @@ fn transform_rotate_grayscale_cross_check() {
     assert_eq!(rust_img.height, c_img.height, "height mismatch");
 
     let max_diff: u8 = pixel_max_diff(&rust_img.data, &c_img.data);
-    // Grayscale conversion drops chroma; small differences from coefficient
-    // re-encoding and Huffman table construction differences between Rust and C.
-    assert!(
-        max_diff <= 30,
-        "rot180+grayscale: pixels differ too much (max_diff={}, expected <= 30)",
+    // Rot180 + grayscale must match C jpegtran exactly. Target: max_diff=0.
+    assert_eq!(
+        max_diff, 0,
+        "rot180+grayscale: max_diff={} (must be 0 vs C jpegtran)",
         max_diff
     );
 }
@@ -908,13 +869,8 @@ fn all_transforms_both_decoders_valid() {
     for op in transforms {
         let name: &str = transform_name(op);
 
-        let transformed: Vec<u8> = match transform(&source_jpeg, op) {
-            Ok(data) => data,
-            Err(e) => {
-                eprintln!("SKIP: Rust transform {} failed: {}", name, e);
-                continue;
-            }
-        };
+        let transformed: Vec<u8> = transform(&source_jpeg, op)
+            .unwrap_or_else(|e| panic!("Rust transform {} must succeed: {}", name, e));
 
         // Verify Rust can decode
         let rust_img = decompress(&transformed)

--- a/tests/cross_encoder_compat.rs
+++ b/tests/cross_encoder_compat.rs
@@ -4,6 +4,9 @@
 //! (reference test images), and that our encoder produces spec-compliant output
 //! that round-trips correctly.
 
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
 use libjpeg_turbo_rs::api::streaming::StreamingDecoder;
 use libjpeg_turbo_rs::{
     compress, compress_arithmetic, decompress, decompress_to, Image, PixelFormat, ScalingFactor,
@@ -244,10 +247,16 @@ fn c_arithmetic_pixel_similarity_to_baseline() {
     let baseline: Image = decompress_to(&baseline_data, PixelFormat::Rgb).unwrap();
     let arith: Image = decompress_to(&arith_data, PixelFormat::Rgb).unwrap();
 
-    // Both are encoded from the same source, so pixel values should be similar.
-    // Arithmetic coding does not change pixel values when the source is the same,
-    // but they were likely encoded with different quality or different entropy coder,
-    // so we allow a generous tolerance on mean absolute difference.
+    // Both are encoded from the same source with different entropy coders.
+    // Quantization tables may differ, so decoded pixels will not be identical,
+    // but should be very close. Actual measured: max_diff=17, mean_diff=0.31.
+    let max_diff: u8 = baseline
+        .data
+        .iter()
+        .zip(arith.data.iter())
+        .map(|(&a, &b)| (a as i16 - b as i16).unsigned_abs() as u8)
+        .max()
+        .unwrap_or(0);
     let total_diff: u64 = baseline
         .data
         .iter()
@@ -256,9 +265,14 @@ fn c_arithmetic_pixel_similarity_to_baseline() {
         .sum();
     let mean_diff: f64 = total_diff as f64 / baseline.data.len() as f64;
     assert!(
-        mean_diff < 100.0,
-        "baseline vs arithmetic mean pixel diff too large: {:.2}",
+        mean_diff < 1.0,
+        "baseline vs arithmetic mean pixel diff too large: {:.2} (expected < 1.0)",
         mean_diff
+    );
+    assert!(
+        max_diff <= 20,
+        "baseline vs arithmetic max pixel diff too large: {} (expected <= 20)",
+        max_diff
     );
 }
 
@@ -492,9 +506,10 @@ fn encode_q100_high_psnr() {
     let decoded: Image = decompress_to(&jpeg, PixelFormat::Rgb).unwrap();
 
     let psnr_val: f64 = psnr(&pixels, &decoded.data);
+    // Q100 with S444 should be near-lossless. Actual measured: ~51 dB.
     assert!(
-        psnr_val > 40.0,
-        "Q100 PSNR should be > 40 dB, got {:.1} dB",
+        psnr_val > 45.0,
+        "Q100 PSNR should be > 45 dB, got {:.1} dB",
         psnr_val
     );
 }
@@ -704,5 +719,187 @@ fn c_testorig_rgba_matches_rgb_channels() {
         assert_eq!(rgb_r, rgba_r, "pixel {}: R mismatch", p);
         assert_eq!(rgb_g, rgba_g, "pixel {}: G mismatch", p);
         assert_eq!(rgb_b, rgba_b, "pixel {}: B mismatch", p);
+    }
+}
+
+// ===========================================================================
+// Section 9: C djpeg cross-validation — Rust decode must match C decode exactly
+// ===========================================================================
+
+fn djpeg_path() -> Option<PathBuf> {
+    let homebrew: PathBuf = PathBuf::from("/opt/homebrew/bin/djpeg");
+    if homebrew.exists() {
+        return Some(homebrew);
+    }
+    Command::new("which")
+        .arg("djpeg")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| PathBuf::from(String::from_utf8_lossy(&o.stdout).trim().to_string()))
+}
+
+fn parse_ppm(path: &Path) -> (usize, usize, Vec<u8>) {
+    let raw: Vec<u8> = std::fs::read(path).expect("failed to read PPM");
+    assert!(&raw[0..2] == b"P6", "not P6 PPM");
+    let mut idx: usize = 2;
+    loop {
+        while idx < raw.len() && raw[idx].is_ascii_whitespace() {
+            idx += 1;
+        }
+        if idx < raw.len() && raw[idx] == b'#' {
+            while idx < raw.len() && raw[idx] != b'\n' {
+                idx += 1;
+            }
+        } else {
+            break;
+        }
+    }
+    let (w, next) = read_ppm_number(&raw, idx);
+    idx = next;
+    while idx < raw.len() && raw[idx].is_ascii_whitespace() {
+        idx += 1;
+    }
+    let (h, next) = read_ppm_number(&raw, idx);
+    idx = next;
+    while idx < raw.len() && raw[idx].is_ascii_whitespace() {
+        idx += 1;
+    }
+    let (_maxval, next) = read_ppm_number(&raw, idx);
+    idx = next + 1;
+    (w, h, raw[idx..idx + w * h * 3].to_vec())
+}
+
+fn read_ppm_number(data: &[u8], idx: usize) -> (usize, usize) {
+    let mut end: usize = idx;
+    while end < data.len() && data[end].is_ascii_digit() {
+        end += 1;
+    }
+    (
+        std::str::from_utf8(&data[idx..end])
+            .unwrap()
+            .parse()
+            .unwrap(),
+        end,
+    )
+}
+
+/// Cross-validate: Rust decode of C-encoded reference images must produce
+/// pixel-identical output to C djpeg. Target: max_diff=0.
+#[test]
+fn c_djpeg_cross_validation_decode_diff_zero() {
+    let djpeg: PathBuf = match djpeg_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: djpeg not found");
+            return;
+        }
+    };
+
+    let reference_images: &[&str] = &["testorig.jpg", "testimgari.jpg", "testimgint.jpg"];
+
+    for &name in reference_images {
+        let jpeg_path: String = reference_path(name);
+        let data: Vec<u8> = match std::fs::read(&jpeg_path) {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+
+        // C djpeg decode
+        let tmp_ppm: String = format!("/tmp/ljt_cross_{}.ppm", name);
+        let output = Command::new(&djpeg)
+            .arg("-ppm")
+            .arg("-outfile")
+            .arg(&tmp_ppm)
+            .arg(&jpeg_path)
+            .output()
+            .expect("failed to run djpeg");
+        assert!(
+            output.status.success(),
+            "djpeg failed on {}: {}",
+            name,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let (cw, ch, c_pixels) = parse_ppm(Path::new(&tmp_ppm));
+        std::fs::remove_file(&tmp_ppm).ok();
+
+        // Rust decode
+        let rust_img: Image = decompress_to(&data, PixelFormat::Rgb)
+            .unwrap_or_else(|e| panic!("Rust decode {} failed: {}", name, e));
+
+        assert_eq!(cw, rust_img.width, "{}: width mismatch", name);
+        assert_eq!(ch, rust_img.height, "{}: height mismatch", name);
+
+        let max_diff: u8 = c_pixels
+            .iter()
+            .zip(rust_img.data.iter())
+            .map(|(&a, &b)| (a as i16 - b as i16).unsigned_abs() as u8)
+            .max()
+            .unwrap_or(0);
+        assert_eq!(
+            max_diff, 0,
+            "{}: Rust vs C djpeg decode max_diff={} (must be 0)",
+            name, max_diff
+        );
+    }
+}
+
+/// Cross-validate: Rust encode then C djpeg decode must match Rust decode.
+/// Target: max_diff=0.
+#[test]
+fn c_djpeg_cross_validation_encode_roundtrip_diff_zero() {
+    let djpeg: PathBuf = match djpeg_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: djpeg not found");
+            return;
+        }
+    };
+
+    let (w, h): (usize, usize) = (64, 48);
+    let pixels: Vec<u8> = make_test_pattern(w, h);
+
+    let quality_subsamp: &[(u8, Subsampling)] = &[
+        (75, Subsampling::S444),
+        (75, Subsampling::S422),
+        (75, Subsampling::S420),
+        (90, Subsampling::S444),
+        (100, Subsampling::S444),
+    ];
+
+    for &(q, ss) in quality_subsamp {
+        let label: String = format!("Q{} {:?}", q, ss);
+        let jpeg: Vec<u8> = compress(&pixels, w, h, PixelFormat::Rgb, q, ss).unwrap();
+
+        // Rust decode
+        let rust_dec: Image = decompress_to(&jpeg, PixelFormat::Rgb).unwrap();
+
+        // C djpeg decode
+        let tmp_jpg: String = format!("/tmp/ljt_enc_{}_{:?}.jpg", q, ss);
+        let tmp_ppm: String = format!("/tmp/ljt_enc_{}_{:?}.ppm", q, ss);
+        std::fs::write(&tmp_jpg, &jpeg).unwrap();
+        let output = Command::new(&djpeg)
+            .arg("-ppm")
+            .arg("-outfile")
+            .arg(&tmp_ppm)
+            .arg(&tmp_jpg)
+            .output()
+            .expect("failed to run djpeg");
+        assert!(output.status.success(), "{}: djpeg failed", label);
+        let (_, _, c_pixels) = parse_ppm(Path::new(&tmp_ppm));
+        std::fs::remove_file(&tmp_jpg).ok();
+        std::fs::remove_file(&tmp_ppm).ok();
+
+        let max_diff: u8 = c_pixels
+            .iter()
+            .zip(rust_dec.data.iter())
+            .map(|(&a, &b)| (a as i16 - b as i16).unsigned_abs() as u8)
+            .max()
+            .unwrap_or(0);
+        assert_eq!(
+            max_diff, 0,
+            "{}: Rust encode → C djpeg decode vs Rust decode max_diff={} (must be 0)",
+            label, max_diff
+        );
     }
 }

--- a/tests/encode_boundaries.rs
+++ b/tests/encode_boundaries.rs
@@ -1,4 +1,7 @@
-use libjpeg_turbo_rs::{compress, decompress, Encoder, PixelFormat, Subsampling};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use libjpeg_turbo_rs::{decompress, decompress_to, Encoder, PixelFormat, Subsampling};
 
 /// All 7 subsampling modes.
 const ALL_SUBSAMPLINGS: [Subsampling; 7] = [
@@ -83,9 +86,10 @@ fn quality_100_high_psnr() {
     assert_eq!(image.height, 32);
 
     let psnr = psnr_rgb(&pixels, &image.data);
+    // Q100 with S444 should be near-lossless. Actual measured: ~51 dB.
     assert!(
-        psnr > 30.0,
-        "quality=100 should produce high PSNR (>30 dB), got {:.1} dB",
+        psnr > 45.0,
+        "quality=100 should produce near-lossless PSNR (>45 dB), got {:.1} dB",
         psnr
     );
 }
@@ -378,4 +382,146 @@ fn quality_affects_file_size() {
         jpeg_q100.len(),
         jpeg_q1.len()
     );
+}
+
+// --- C djpeg cross-validation ---
+
+fn djpeg_path() -> Option<PathBuf> {
+    let homebrew: PathBuf = PathBuf::from("/opt/homebrew/bin/djpeg");
+    if homebrew.exists() {
+        return Some(homebrew);
+    }
+    Command::new("which")
+        .arg("djpeg")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| PathBuf::from(String::from_utf8_lossy(&o.stdout).trim().to_string()))
+}
+
+fn parse_ppm(path: &Path) -> (usize, usize, Vec<u8>) {
+    let raw: Vec<u8> = std::fs::read(path).expect("failed to read PPM");
+    assert!(&raw[0..2] == b"P6", "not P6 PPM");
+    let mut idx: usize = 2;
+    loop {
+        while idx < raw.len() && raw[idx].is_ascii_whitespace() {
+            idx += 1;
+        }
+        if idx < raw.len() && raw[idx] == b'#' {
+            while idx < raw.len() && raw[idx] != b'\n' {
+                idx += 1;
+            }
+        } else {
+            break;
+        }
+    }
+    let (w, next) = read_ppm_num(&raw, idx);
+    idx = next;
+    while idx < raw.len() && raw[idx].is_ascii_whitespace() {
+        idx += 1;
+    }
+    let (h, next) = read_ppm_num(&raw, idx);
+    idx = next;
+    while idx < raw.len() && raw[idx].is_ascii_whitespace() {
+        idx += 1;
+    }
+    let (_maxval, next) = read_ppm_num(&raw, idx);
+    idx = next + 1;
+    (w, h, raw[idx..idx + w * h * 3].to_vec())
+}
+
+fn read_ppm_num(data: &[u8], idx: usize) -> (usize, usize) {
+    let mut end: usize = idx;
+    while end < data.len() && data[end].is_ascii_digit() {
+        end += 1;
+    }
+    (
+        std::str::from_utf8(&data[idx..end])
+            .unwrap()
+            .parse()
+            .unwrap(),
+        end,
+    )
+}
+
+fn c_djpeg_cross_validate_subsampling(djpeg: &Path, ss: Subsampling) {
+    let pixels: Vec<u8> = (0..32 * 32 * 3)
+        .map(|i| ((i * 37 + 13) % 256) as u8)
+        .collect();
+
+    let jpeg: Vec<u8> = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+        .quality(90)
+        .subsampling(ss)
+        .encode()
+        .unwrap();
+
+    let rust_dec = decompress_to(&jpeg, PixelFormat::Rgb).unwrap();
+
+    let tmp_jpg: String = format!("/tmp/ljt_eb_{:?}.jpg", ss);
+    let tmp_ppm: String = format!("/tmp/ljt_eb_{:?}.ppm", ss);
+    std::fs::write(&tmp_jpg, &jpeg).unwrap();
+
+    let output = Command::new(djpeg)
+        .arg("-ppm")
+        .arg("-outfile")
+        .arg(&tmp_ppm)
+        .arg(&tmp_jpg)
+        .output()
+        .expect("failed to run djpeg");
+    assert!(output.status.success(), "djpeg failed for {:?}", ss);
+
+    let (_, _, c_pixels) = parse_ppm(Path::new(&tmp_ppm));
+    std::fs::remove_file(&tmp_jpg).ok();
+    std::fs::remove_file(&tmp_ppm).ok();
+
+    let max_diff: u8 = c_pixels
+        .iter()
+        .zip(rust_dec.data.iter())
+        .map(|(&a, &b)| (a as i16 - b as i16).unsigned_abs() as u8)
+        .max()
+        .unwrap_or(0);
+    assert_eq!(
+        max_diff, 0,
+        "{:?}: C djpeg vs Rust decode max_diff={} (must be 0)",
+        ss, max_diff
+    );
+}
+
+/// C djpeg cross-validation for S444/S422/S420 — must match exactly.
+#[test]
+fn c_djpeg_cross_validation_common_subsamplings_diff_zero() {
+    let djpeg: PathBuf = match djpeg_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: djpeg not found");
+            return;
+        }
+    };
+    for &ss in &[Subsampling::S444, Subsampling::S422, Subsampling::S420] {
+        c_djpeg_cross_validate_subsampling(&djpeg, ss);
+    }
+}
+
+/// C djpeg cross-validation for S440 — currently has max_diff=2 (decode bug).
+#[test]
+#[ignore = "S440 decode has max_diff=2 vs C djpeg — upsample bug, see issue #112"]
+fn c_djpeg_cross_validation_s440_diff_zero() {
+    let djpeg: PathBuf = djpeg_path().expect("djpeg required");
+    c_djpeg_cross_validate_subsampling(&djpeg, Subsampling::S440);
+}
+
+/// C djpeg cross-validation for S411 — currently has max_diff=43 (decode bug).
+#[test]
+#[ignore = "S411 decode has max_diff=43 vs C djpeg — upsample bug, see issue #112"]
+fn c_djpeg_cross_validation_s411_diff_zero() {
+    let djpeg: PathBuf = djpeg_path().expect("djpeg required");
+    c_djpeg_cross_validate_subsampling(&djpeg, Subsampling::S411);
+}
+
+/// C djpeg cross-validation for S441 — currently has max_diff=41 (decode bug).
+#[test]
+#[ignore = "S441 decode has max_diff=41 vs C djpeg — upsample bug, see issue #112"]
+fn c_djpeg_cross_validation_s441_diff_zero() {
+    let djpeg: PathBuf = djpeg_path().expect("djpeg required");
+    c_djpeg_cross_validate_subsampling(&djpeg, Subsampling::S441);
 }

--- a/tests/error_recovery.rs
+++ b/tests/error_recovery.rs
@@ -1,4 +1,4 @@
-use libjpeg_turbo_rs::{decompress, decompress_lenient, DecodeWarning};
+use libjpeg_turbo_rs::{decompress, decompress_lenient};
 
 #[test]
 fn valid_jpeg_lenient_no_warnings() {
@@ -69,14 +69,12 @@ fn corrupt_middle_lenient_recovers() {
     for i in mid..mid + 100 {
         data[i] = 0x00;
     }
-    let result = decompress_lenient(&data);
-    // Should either succeed with warnings or succeed without warnings
-    // (corruption may land in non-critical area)
-    if let Ok(img) = result {
-        assert_eq!(img.width, 320);
-        assert_eq!(img.height, 240);
-        assert_eq!(img.data.len(), 320 * 240 * 3);
-    }
+    // Lenient decoder must recover from mid-stream corruption.
+    let img =
+        decompress_lenient(&data).expect("lenient decoder must recover from mid-stream corruption");
+    assert_eq!(img.width, 320);
+    assert_eq!(img.height, 240);
+    assert_eq!(img.data.len(), 320 * 240 * 3);
 }
 
 #[test]
@@ -84,12 +82,16 @@ fn very_short_truncation_lenient() {
     let data = include_bytes!("fixtures/photo_320x240_420.jpg");
     // Keep only markers and very beginning of entropy data
     let truncated = &data[..500.min(data.len())];
+    // Data this short (500 bytes) may not contain enough markers to decode.
+    // C djpeg also fails on this input. The requirement is: no panic.
+    // If it does succeed, verify output consistency.
     let result = decompress_lenient(truncated);
-    // Should return partial image, not panic
     if let Ok(img) = result {
         assert_eq!(
             img.data.len(),
-            img.width * img.height * img.pixel_format.bytes_per_pixel()
+            img.width * img.height * img.pixel_format.bytes_per_pixel(),
+            "very short truncation: output buffer size mismatch"
         );
     }
+    // Err is acceptable — C djpeg also fails on 500-byte truncation.
 }

--- a/tests/pixel_formats.rs
+++ b/tests/pixel_formats.rs
@@ -280,9 +280,10 @@ fn rgbx_encode_decode_color_accuracy() {
         let r = img.data[i * 4] as i16;
         let g = img.data[i * 4 + 1] as i16;
         let b = img.data[i * 4 + 2] as i16;
-        assert!((r - 200).abs() < 5, "R channel deviation too large: {r}");
-        assert!((g - 100).abs() < 5, "G channel deviation too large: {g}");
-        assert!((b - 50).abs() < 5, "B channel deviation too large: {b}");
+        // Q100 roundtrip per-channel error should be minimal (JPEG lossy, max ~3).
+        assert!((r - 200).abs() <= 3, "R channel deviation too large: {r}");
+        assert!((g - 100).abs() <= 3, "G channel deviation too large: {g}");
+        assert!((b - 50).abs() <= 3, "B channel deviation too large: {b}");
         assert_eq!(img.data[i * 4 + 3], 255, "padding should be 255");
     }
 }
@@ -309,9 +310,10 @@ fn argb_channel_ordering_roundtrip() {
         let g = img.data[i * 4 + 2] as i16;
         let b = img.data[i * 4 + 3] as i16;
         assert_eq!(a, 255, "alpha should be 255");
-        assert!((r - 200).abs() < 5, "R channel deviation too large: {r}");
-        assert!((g - 100).abs() < 5, "G channel deviation too large: {g}");
-        assert!((b - 50).abs() < 5, "B channel deviation too large: {b}");
+        // Q100 roundtrip per-channel error should be minimal (JPEG lossy, max ~3).
+        assert!((r - 200).abs() <= 3, "R channel deviation too large: {r}");
+        assert!((g - 100).abs() <= 3, "G channel deviation too large: {g}");
+        assert!((b - 50).abs() <= 3, "B channel deviation too large: {b}");
     }
 }
 

--- a/tests/tjunittest_yuv.rs
+++ b/tests/tjunittest_yuv.rs
@@ -38,16 +38,28 @@ fn yuv_roundtrip_helper(subsamp: Subsampling) {
     );
     let decoded: Vec<u8> = yuv::decode_yuv(&yuv_packed, w, h, subsamp, PixelFormat::Rgb).unwrap();
     assert_eq!(decoded.len(), original.len());
-    for i in 0..original.len() {
-        let diff: i16 = original[i] as i16 - decoded[i] as i16;
-        assert!(
-            diff.abs() <= 12,
-            "YUV {:?} byte {} diff={}",
-            subsamp,
-            i,
-            diff
-        );
-    }
+    // RGB→YUV→RGB has inherent integer rounding losses.
+    // Measured actuals: S444=1, S422=4, S420=5, S440=3, S411=7, S441=7.
+    let max_diff: i16 = original
+        .iter()
+        .zip(decoded.iter())
+        .map(|(&a, &b)| (a as i16 - b as i16).abs())
+        .max()
+        .unwrap_or(0);
+    let tolerance: i16 = match subsamp {
+        Subsampling::S444 => 1,
+        Subsampling::S440 => 3,
+        Subsampling::S422 => 4,
+        Subsampling::S420 => 5,
+        _ => 7, // S411, S441
+    };
+    assert!(
+        max_diff <= tolerance,
+        "YUV {:?} max_diff={} (expected <= {})",
+        subsamp,
+        max_diff,
+        tolerance
+    );
 }
 
 #[test]
@@ -83,18 +95,29 @@ fn tjunittest_yuv_roundtrip_various_sizes() {
             let yuv: Vec<u8> = yuv::encode_yuv(&orig, w, h, PixelFormat::Rgb, ss).unwrap();
             let dec: Vec<u8> = yuv::decode_yuv(&yuv, w, h, ss, PixelFormat::Rgb).unwrap();
             assert_eq!(dec.len(), orig.len(), "{}x{} {:?}", w, h, ss);
-            for i in 0..orig.len() {
-                let diff: i16 = orig[i] as i16 - dec[i] as i16;
-                assert!(
-                    diff.abs() <= 12,
-                    "{}x{} {:?} byte {} diff={}",
-                    w,
-                    h,
-                    ss,
-                    i,
-                    diff
-                );
-            }
+            // RGB→YUV→RGB roundtrip loss is inherent to chroma subsampling.
+            // Loss varies by content and image size (small images have larger
+            // relative error from subsampling boundary effects).
+            // Measured: S444 max=1, S420 max=12 (at 16x16 gradient).
+            let max_diff: i16 = orig
+                .iter()
+                .zip(dec.iter())
+                .map(|(&a, &b)| (a as i16 - b as i16).abs())
+                .max()
+                .unwrap_or(0);
+            let tolerance: i16 = match ss {
+                Subsampling::S444 => 1,
+                _ => 12, // Chroma subsampling inherent loss
+            };
+            assert!(
+                max_diff <= tolerance,
+                "{}x{} {:?} max_diff={} (expected <= {})",
+                w,
+                h,
+                ss,
+                max_diff,
+                tolerance
+            );
         }
     }
 }
@@ -159,16 +182,27 @@ fn compress_from_yuv_helper(subsamp: Subsampling) {
     assert_eq!((img.width, img.height), (w, h));
     let direct: Vec<u8> = compress(&orig, w, h, PixelFormat::Rgb, 90, subsamp).unwrap();
     let dimg = decompress_to(&direct, PixelFormat::Rgb).unwrap();
-    for i in 0..orig.len() {
-        let diff: i16 = img.data[i] as i16 - dimg.data[i] as i16;
-        assert!(
-            diff.abs() <= 12,
-            "yuv vs direct {:?} byte {} diff={}",
-            subsamp,
-            i,
-            diff
-        );
-    }
+    // YUV-path and direct-path encode the same source at same quality.
+    // Decoded pixels should be very close. Differences come from
+    // integer rounding in RGB→YUV conversion.
+    let max_diff: i16 = img
+        .data
+        .iter()
+        .zip(dimg.data.iter())
+        .map(|(&a, &b)| (a as i16 - b as i16).abs())
+        .max()
+        .unwrap_or(0);
+    let tolerance: i16 = match subsamp {
+        Subsampling::S444 => 1,
+        _ => 5,
+    };
+    assert!(
+        max_diff <= tolerance,
+        "yuv vs direct {:?} max_diff={} (expected <= {})",
+        subsamp,
+        max_diff,
+        tolerance
+    );
 }
 
 #[test]
@@ -192,16 +226,25 @@ fn decompress_to_yuv_helper(subsamp: Subsampling) {
     let (yuv, yw, yh, ys) = yuv::decompress_to_yuv(&jpeg).unwrap();
     let via: Vec<u8> = yuv::decode_yuv(&yuv, yw, yh, ys, PixelFormat::Rgb).unwrap();
     assert_eq!(via.len(), direct.len());
-    for i in 0..direct.len() {
-        let diff: i16 = via[i] as i16 - direct[i] as i16;
-        assert!(
-            diff.abs() <= 12,
-            "yuv decode {:?} byte {} diff={}",
-            subsamp,
-            i,
-            diff
-        );
-    }
+    // JPEG→YUV→RGB vs JPEG→RGB directly: differences come from
+    // merged upsample+color vs separate YUV decode+color paths.
+    let max_diff: i16 = via
+        .iter()
+        .zip(direct.iter())
+        .map(|(&a, &b)| (a as i16 - b as i16).abs())
+        .max()
+        .unwrap_or(0);
+    let tolerance: i16 = match subsamp {
+        Subsampling::S444 => 1,
+        _ => 5,
+    };
+    assert!(
+        max_diff <= tolerance,
+        "yuv decode {:?} max_diff={} (expected <= {})",
+        subsamp,
+        max_diff,
+        tolerance
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Tighten all loose test tolerances that allowed broken implementations to pass silently
- Add C djpeg/jpegtran cross-validation tests (target: diff=0 vs C libjpeg-turbo)
- Convert silent `eprintln!("SKIP") + continue/return` patterns to proper `panic!`/`expect`
- Remove `continue-on-error: true` from Integration and C Interop CI jobs

## Bugs discovered (11 `#[ignore]` tests added)
| Area | Current diff vs C | Severity |
|------|------------------|----------|
| Transform (rot90/rot270/transverse) | max_diff=255 | Critical — completely wrong output |
| 12-bit IDCT | max_diff=3127 | Critical — decoder broken |
| S411 decode | max_diff=43 | High — upsample bug |
| S441 decode | max_diff=41 | High — upsample bug |
| S440 decode | max_diff=2 | Medium — minor upsample bug |

## Already passing diff=0 vs C
- Decode: testorig.jpg, testimgari.jpg, testimgint.jpg — all diff=0
- Encode+Decode: Q75/Q90/Q100 × S444/S422/S420 — all diff=0

## Test plan
- [x] `cargo test` — all pass (533 passed, 11 ignored)
- [x] `cargo fmt` — clean
- [ ] CI passes on ubuntu-latest

Relates: #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)