### PR TITLE
fix: transform byte-identical to C jpegtran (diff=0)

### DIFF
--- a/src/api/coefficient.rs
+++ b/src/api/coefficient.rs
@@ -438,11 +438,16 @@ pub fn transform_jpeg(data: &[u8], op: TransformOp) -> Result<Vec<u8>> {
     // Convert back to zigzag order for encoder.
     convert_all_to_zigzag(&mut coeffs.components);
 
-    // Swap dimensions if needed
+    // Swap dimensions and transpose quant tables for dimension-swapping ops.
+    // When DCT blocks are transposed, the quant table must also be transposed
+    // so that each coefficient position uses the correct quantization value.
     if swaps_dims {
         std::mem::swap(&mut coeffs.width, &mut coeffs.height);
         for comp in &mut coeffs.components {
             std::mem::swap(&mut comp.h_sampling, &mut comp.v_sampling);
+        }
+        for qt in &mut coeffs.quant_tables {
+            transpose_quant_table(qt);
         }
     }
 
@@ -729,6 +734,9 @@ pub fn transform_jpeg_with_options(data: &[u8], options: &TransformOptions) -> R
             for comp in &mut coeffs.components {
                 std::mem::swap(&mut comp.h_sampling, &mut comp.v_sampling);
             }
+            for qt in &mut coeffs.quant_tables {
+                transpose_quant_table(qt);
+            }
         }
 
         // Convert back to zigzag order for encoder.
@@ -944,6 +952,19 @@ fn write_coefficients_optimized(coeffs: &JpegCoefficients) -> Result<Vec<u8>> {
     marker_writer::write_eoi(&mut output);
 
     Ok(output)
+}
+
+/// Transpose a quantization table (8x8 matrix) in-place.
+/// Required for dimension-swapping transforms (transpose, rot90, rot270, transverse)
+/// so that each coefficient position uses the correct quantization value.
+fn transpose_quant_table(qt: &mut [u16; 64]) {
+    let mut transposed: [u16; 64] = [0u16; 64];
+    for row in 0..8 {
+        for col in 0..8 {
+            transposed[col * 8 + row] = qt[row * 8 + col];
+        }
+    }
+    *qt = transposed;
 }
 
 /// Convert a block from natural (row-major) order to zigzag order.

--- a/tests/cross_check_transform.rs
+++ b/tests/cross_check_transform.rs
@@ -269,14 +269,13 @@ fn rust_transform_matches_c_jpegtran() {
             name, rust_img.height, c_img.height
         );
 
-        // Lossless transforms produce identical DCT coefficients to C jpegtran.
-        // Huffman table generation may differ slightly between Rust and C,
-        // causing max_diff=1 at the decoded pixel level for some operations.
-        // The coefficients themselves are verified identical via file size match.
+        // Lossless transforms on MCU-aligned S444 images must produce
+        // byte-identical JPEG output to C jpegtran. Target: max_diff=0.
         let max_diff: u8 = pixel_max_diff(&rust_img.data, &c_img.data);
-        assert!(
-            max_diff <= 1,
-            "{}: decoded pixel max_diff={} (must be <= 1 vs C jpegtran). \
+        assert_eq!(
+            max_diff,
+            0,
+            "{}: decoded pixel max_diff={} (must be 0 vs C jpegtran). \
              Rust JPEG={} bytes, C JPEG={} bytes",
             name,
             max_diff,
@@ -458,9 +457,9 @@ fn transform_grayscale_cross_check() {
     let max_diff: u8 = pixel_max_diff(&rust_img.data, &c_img.data);
     // Grayscale transform drops chroma components; decoded luma must match
     // C jpegtran exactly. Target: max_diff=0.
-    assert!(
-        max_diff <= 1,
-        "grayscale transform: max_diff={} (must be <= 1 vs C jpegtran)",
+    assert_eq!(
+        max_diff, 0,
+        "grayscale transform: max_diff={} (must be 0 vs C jpegtran)",
         max_diff
     );
 }
@@ -544,9 +543,9 @@ fn transform_crop_cross_check() {
 
     let max_diff: u8 = pixel_max_diff(&rust_img.data, &c_img.data);
     // Crop on DCT blocks must match C jpegtran exactly. Target: max_diff=0.
-    assert!(
-        max_diff <= 1,
-        "crop transform: max_diff={} (must be <= 1 vs C jpegtran)",
+    assert_eq!(
+        max_diff, 0,
+        "crop transform: max_diff={} (must be 0 vs C jpegtran)",
         max_diff
     );
 }
@@ -826,9 +825,9 @@ fn transform_rotate_grayscale_cross_check() {
 
     let max_diff: u8 = pixel_max_diff(&rust_img.data, &c_img.data);
     // Rot180 + grayscale must match C jpegtran exactly. Target: max_diff=0.
-    assert!(
-        max_diff <= 1,
-        "rot180+grayscale: max_diff={} (must be <= 1 vs C jpegtran)",
+    assert_eq!(
+        max_diff, 0,
+        "rot180+grayscale: max_diff={} (must be 0 vs C jpegtran)",
         max_diff
     );
 }


### PR DESCRIPTION
## Summary
Transpose quant tables for dimension-swapping transforms so that each coefficient position uses the correct quantization value after block transposition.

All 7 transform ops now produce **byte-identical** JPEG output to C jpegtran:
```
HFlip:     bytes_eq=true
VFlip:     bytes_eq=true
Rot90:     bytes_eq=true
Rot180:    bytes_eq=true
Rot270:    bytes_eq=true
Transpose: bytes_eq=true
Transverse:bytes_eq=true
```

Tightened test assertions from `max_diff <= 1` back to `max_diff == 0`.

## Test plan
- [x] `cargo test` — 0 failed
- [x] All transforms byte-identical to C jpegtran `-copy none`

Depends on: #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)