### PR TITLE
fix: resolve all clippy warnings

### DIFF
--- a/src/api/precision.rs
+++ b/src/api/precision.rs
@@ -477,20 +477,12 @@ fn fancy_upsample_12bit(
     if h_factor == 2 && v_factor == 2 {
         // Fused h2v2: matches C h2v2_fancy_upsample exactly.
         for y in 0..in_h {
-            let row0 = |x: usize| input[y * in_stride + x] as i32;
-            let above = |x: usize| {
-                if y > 0 {
-                    input[(y - 1) * in_stride + x] as i32
-                } else {
-                    row0(x)
-                }
-            };
-            let below = |x: usize| {
-                if y + 1 < in_h {
-                    input[(y + 1) * in_stride + x] as i32
-                } else {
-                    row0(x)
-                }
+            let cur_off: usize = y * in_stride;
+            let above_off: usize = if y > 0 { (y - 1) * in_stride } else { cur_off };
+            let below_off: usize = if y + 1 < in_h {
+                (y + 1) * in_stride
+            } else {
+                cur_off
             };
 
             for v in 0..2 {
@@ -499,14 +491,8 @@ fn fancy_upsample_12bit(
                     break;
                 }
                 // inptr0 = nearest row, inptr1 = farther row
-                let (near, far): (Box<dyn Fn(usize) -> i32>, Box<dyn Fn(usize) -> i32>) = if v == 0
-                {
-                    (Box::new(|x| row0(x)), Box::new(|x| above(x)))
-                } else {
-                    (Box::new(|x| row0(x)), Box::new(|x| below(x)))
-                };
-
-                let colsum = |x: usize| near(x) * 3 + far(x);
+                let far_off: usize = if v == 0 { above_off } else { below_off };
+                let colsum = |x: usize| input[cur_off + x] as i32 * 3 + input[far_off + x] as i32;
 
                 if in_w == 0 {
                     continue;
@@ -867,8 +853,8 @@ pub fn decompress_12bit(data: &[u8]) -> Result<Image12> {
     } else {
         for y in 0..height {
             for x in 0..width {
-                for c in 0..num_components {
-                    result.push(full_planes[c][y * width + x]);
+                for plane in &full_planes[..num_components] {
+                    result.push(plane[y * width + x]);
                 }
             }
         }

--- a/src/decode/pipeline.rs
+++ b/src/decode/pipeline.rs
@@ -498,6 +498,7 @@ impl<'a> Decoder<'a> {
             PixelFormat::Rgba => self.ycbcr_to_rgba_row(y, cb, cr, out, width),
             PixelFormat::Bgr => self.ycbcr_to_bgr_row(y, cb, cr, out, width),
             PixelFormat::Bgra => self.ycbcr_to_bgra_row(y, cb, cr, out, width),
+            #[allow(unreachable_code)]
             PixelFormat::Rgbx => {
                 #[cfg(all(target_arch = "aarch64", feature = "simd"))]
                 {
@@ -516,6 +517,7 @@ impl<'a> Decoder<'a> {
                 }
                 crate::decode::color::ycbcr_to_generic_4bpp_row(y, cb, cr, out, width, 0, 1, 2, 3)
             }
+            #[allow(unreachable_code)]
             PixelFormat::Bgrx => {
                 #[cfg(all(target_arch = "aarch64", feature = "simd"))]
                 {
@@ -534,6 +536,7 @@ impl<'a> Decoder<'a> {
                 }
                 crate::decode::color::ycbcr_to_generic_4bpp_row(y, cb, cr, out, width, 2, 1, 0, 3)
             }
+            #[allow(unreachable_code)]
             PixelFormat::Xrgb => {
                 #[cfg(all(target_arch = "aarch64", feature = "simd"))]
                 {
@@ -552,6 +555,7 @@ impl<'a> Decoder<'a> {
                 }
                 crate::decode::color::ycbcr_to_generic_4bpp_row(y, cb, cr, out, width, 1, 2, 3, 0)
             }
+            #[allow(unreachable_code)]
             PixelFormat::Xbgr => {
                 #[cfg(all(target_arch = "aarch64", feature = "simd"))]
                 {
@@ -570,6 +574,7 @@ impl<'a> Decoder<'a> {
                 }
                 crate::decode::color::ycbcr_to_generic_4bpp_row(y, cb, cr, out, width, 3, 2, 1, 0)
             }
+            #[allow(unreachable_code)]
             PixelFormat::Argb => {
                 #[cfg(all(target_arch = "aarch64", feature = "simd"))]
                 {
@@ -588,6 +593,7 @@ impl<'a> Decoder<'a> {
                 }
                 crate::decode::color::ycbcr_to_generic_4bpp_row(y, cb, cr, out, width, 1, 2, 3, 0)
             }
+            #[allow(unreachable_code)]
             PixelFormat::Abgr => {
                 #[cfg(all(target_arch = "aarch64", feature = "simd"))]
                 {


### PR DESCRIPTION
## Summary
Fix all 12 clippy errors so CI Clippy job passes cleanly.

- 6x `unreachable_code`: NEON SIMD match arms in pipeline.rs — `#[allow(unreachable_code)]`
- 1x `complex type`: `Box<dyn Fn>` in precision.rs h2v2 upsample — replaced with offset-based indexing
- 4x `redundant closure`: `|x| f(x)` → direct indexing
- 1x `loop variable only used to index`: `for c in 0..n` → `for plane in &full_planes[..n]`

## Test plan
- [x] `cargo clippy --lib -- -D warnings` — 0 errors
- [x] `cargo test` — 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)