### PR TITLE
chore: add pre-commit hook with cargo fmt + clippy

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Pre-commit hook: format check + clippy
+# Installed via: git config core.hooksPath .githooks
+
+set -e
+
+echo "[pre-commit] Running cargo fmt --check..."
+cargo fmt -- --check
+if [ $? -ne 0 ]; then
+    echo "[pre-commit] Format check failed. Run 'cargo fmt' first."
+    exit 1
+fi
+
+echo "[pre-commit] Running cargo clippy..."
+cargo clippy --lib -- -D warnings
+if [ $? -ne 0 ]; then
+    echo "[pre-commit] Clippy failed. Fix warnings before committing."
+    exit 1
+fi
+
+echo "[pre-commit] All checks passed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ When optimizing performance, follow the experiment-driven workflow in `experimen
 
 - All commits must use the local git config `user.name` and `user.email`.
 - All commits must include `Signed-off-by` line (always use `git commit -s`).
+- **Pre-commit hook**: `.githooks/pre-commit` runs `cargo fmt --check` and `cargo clippy --lib -- -D warnings` before every commit. Activate after clone: `git config core.hooksPath .githooks`. CI runs the same checks — local clippy (aarch64) and CI clippy (x86_64) can differ due to `#[cfg(target_arch)]` blocks, so fix warnings for all platforms.
 
 ## Branching & PR Workflow
 


### PR DESCRIPTION
## Summary
- Add `.githooks/pre-commit` that runs `cargo fmt --check` + `cargo clippy --lib -- -D warnings` before every commit
- Activate after clone: `git config core.hooksPath .githooks`
- Documented in CLAUDE.md

Prevents clippy regressions from reaching CI.

## Test plan
- [x] Pre-commit hook fires on `git commit` and blocks on clippy errors
- [x] `cargo clippy --lib -- -D warnings` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)