### PR TITLE
test: add C djpeg cross-validation to 4 HIGH-priority test files

### DIFF
--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -1,3 +1,6 @@
+use std::io::BufRead;
+use std::process::Command;
+
 use libjpeg_turbo_rs::{decompress, decompress_to, PixelFormat};
 
 // --- CMYK JPEG tests ---
@@ -304,4 +307,169 @@ fn progressive_photo_cross_validation() {
     assert_eq!(image.width, 320);
     assert_eq!(image.height, 240);
     assert_eq!(image.data.len(), 320 * 240 * 3);
+}
+
+// --- C djpeg cross-validation helpers ---
+
+/// Find the djpeg binary: check /opt/homebrew/bin/djpeg first, then fall back to PATH.
+fn djpeg_path() -> Option<std::path::PathBuf> {
+    let homebrew_path = std::path::PathBuf::from("/opt/homebrew/bin/djpeg");
+    if homebrew_path.exists() {
+        return Some(homebrew_path);
+    }
+    // Fall back to whichever djpeg is on PATH
+    let output = Command::new("which").arg("djpeg").output().ok()?;
+    if output.status.success() {
+        let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !path_str.is_empty() {
+            return Some(std::path::PathBuf::from(path_str));
+        }
+    }
+    None
+}
+
+/// Parse a binary PPM (P6) image produced by `djpeg -ppm`.
+/// Returns (width, height, pixel_data) where pixel_data is RGB bytes.
+fn parse_ppm_p6(data: &[u8]) -> (usize, usize, Vec<u8>) {
+    let mut cursor = std::io::Cursor::new(data);
+    let mut lines: Vec<String> = Vec::new();
+
+    // Read header lines, skipping comments
+    while lines.len() < 3 {
+        let mut line = String::new();
+        cursor
+            .read_line(&mut line)
+            .expect("failed to read PPM header line");
+        let trimmed = line.trim().to_string();
+        if trimmed.starts_with('#') || trimmed.is_empty() {
+            continue;
+        }
+        lines.push(trimmed);
+    }
+
+    assert_eq!(lines[0], "P6", "expected PPM P6 format, got {}", lines[0]);
+
+    let dims: Vec<usize> = lines[1]
+        .split_whitespace()
+        .map(|s| s.parse().expect("invalid PPM dimension"))
+        .collect();
+    let width = dims[0];
+    let height = dims[1];
+
+    let max_val: usize = lines[2].parse().expect("invalid PPM max value");
+    assert_eq!(max_val, 255, "expected maxval 255, got {}", max_val);
+
+    let header_len = cursor.position() as usize;
+    let pixel_data = data[header_len..].to_vec();
+    assert_eq!(
+        pixel_data.len(),
+        width * height * 3,
+        "PPM pixel data length mismatch: expected {}, got {}",
+        width * height * 3,
+        pixel_data.len()
+    );
+
+    (width, height, pixel_data)
+}
+
+/// Decode a JPEG with C djpeg to PPM and return raw RGB pixels.
+fn decode_with_djpeg(djpeg: &std::path::Path, jpeg_data: &[u8]) -> Vec<u8> {
+    let tmp_dir = std::env::temp_dir();
+    let input_path = tmp_dir.join("conformance_djpeg_input.jpg");
+    std::fs::write(&input_path, jpeg_data).expect("failed to write temp JPEG");
+
+    let output = Command::new(djpeg)
+        .arg("-ppm")
+        .arg(&input_path)
+        .output()
+        .expect("failed to run djpeg");
+
+    std::fs::remove_file(&input_path).ok();
+
+    assert!(
+        output.status.success(),
+        "djpeg failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let (_width, _height, pixels) = parse_ppm_p6(&output.stdout);
+    pixels
+}
+
+// --- C djpeg cross-validation test ---
+
+#[test]
+fn c_djpeg_fixture_decode_diff_zero() {
+    let djpeg = match djpeg_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: djpeg not found");
+            return;
+        }
+    };
+
+    let fixtures: &[(&str, &[u8])] = &[
+        (
+            "photo_320x240_420.jpg",
+            include_bytes!("fixtures/photo_320x240_420.jpg"),
+        ),
+        (
+            "photo_320x240_422.jpg",
+            include_bytes!("fixtures/photo_320x240_422.jpg"),
+        ),
+        (
+            "photo_320x240_444.jpg",
+            include_bytes!("fixtures/photo_320x240_444.jpg"),
+        ),
+        (
+            "photo_640x480_422.jpg",
+            include_bytes!("fixtures/photo_640x480_422.jpg"),
+        ),
+        (
+            "photo_640x480_444.jpg",
+            include_bytes!("fixtures/photo_640x480_444.jpg"),
+        ),
+    ];
+
+    for &(name, jpeg_data) in fixtures {
+        let rust_image = decompress_to(jpeg_data, PixelFormat::Rgb)
+            .unwrap_or_else(|e| panic!("{}: Rust decode failed: {}", name, e));
+
+        let c_pixels = decode_with_djpeg(&djpeg, jpeg_data);
+
+        assert_eq!(
+            rust_image.data.len(),
+            c_pixels.len(),
+            "{}: pixel data length mismatch (rust={}, c={})",
+            name,
+            rust_image.data.len(),
+            c_pixels.len()
+        );
+
+        let mut diff_count: usize = 0;
+        let mut max_diff: u8 = 0;
+        let mut first_diff_idx: Option<usize> = None;
+        for (i, (&rust_byte, &c_byte)) in rust_image.data.iter().zip(c_pixels.iter()).enumerate() {
+            let d = (rust_byte as i16 - c_byte as i16).unsigned_abs() as u8;
+            if d > 0 {
+                if first_diff_idx.is_none() {
+                    first_diff_idx = Some(i);
+                }
+                diff_count += 1;
+                if d > max_diff {
+                    max_diff = d;
+                }
+            }
+        }
+
+        assert_eq!(
+            diff_count,
+            0,
+            "{}: {} bytes differ (max_diff={}, first_diff_at_byte={})",
+            name,
+            diff_count,
+            max_diff,
+            first_diff_idx.unwrap_or(0)
+        );
+    }
 }

--- a/tests/cross_product_compress.rs
+++ b/tests/cross_product_compress.rs
@@ -9,6 +9,9 @@
 //! - arithmetic + progressive: SOF10 decode not yet fully supported
 //! - Huffman progressive + S440/S441: progressive scan script issue with these subsamplings
 
+use std::path::PathBuf;
+use std::process::Command;
+
 use libjpeg_turbo_rs::precision::{compress_lossless_arbitrary, decompress_lossless_arbitrary};
 use libjpeg_turbo_rs::{decompress, DctMethod, Encoder, PixelFormat, Subsampling};
 
@@ -155,6 +158,101 @@ impl TestCounters {
             self.unexpected_fail, self.tested
         );
     }
+}
+
+/// Find the djpeg binary path.
+///
+/// Checks `/opt/homebrew/bin/djpeg` first (macOS Homebrew), then falls back
+/// to `which djpeg` on the system PATH. Returns `None` if neither is found.
+fn djpeg_path() -> Option<PathBuf> {
+    let homebrew: PathBuf = PathBuf::from("/opt/homebrew/bin/djpeg");
+    if homebrew.exists() {
+        return Some(homebrew);
+    }
+    // Fall back to `which djpeg`
+    let output = Command::new("which").arg("djpeg").output().ok()?;
+    if output.status.success() {
+        let path_str: String = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !path_str.is_empty() {
+            let path: PathBuf = PathBuf::from(&path_str);
+            if path.exists() {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+/// Parse a PPM (P6 binary) file into raw RGB pixel data.
+///
+/// Returns `(width, height, data)` on success, or an error string on failure.
+fn parse_ppm(bytes: &[u8]) -> Result<(usize, usize, Vec<u8>), String> {
+    // PPM P6 format: "P6\n<width> <height>\n<maxval>\n<binary data>"
+    let header_end: usize = {
+        let mut newline_count: u32 = 0;
+        let mut pos: usize = 0;
+        while pos < bytes.len() && newline_count < 3 {
+            if bytes[pos] == b'\n' {
+                newline_count += 1;
+            }
+            pos += 1;
+        }
+        pos
+    };
+    if header_end >= bytes.len() {
+        return Err("PPM header too short".to_string());
+    }
+
+    let header: &str = std::str::from_utf8(&bytes[..header_end])
+        .map_err(|e| format!("PPM header UTF-8: {}", e))?;
+    let mut lines = header.lines();
+    let magic: &str = lines.next().ok_or("PPM: missing magic")?;
+    if magic != "P6" {
+        return Err(format!("PPM: expected P6, got {}", magic));
+    }
+
+    // Skip comment lines
+    let mut dims_line: Option<&str> = None;
+    let mut maxval_line: Option<&str> = None;
+    for line in lines {
+        if line.starts_with('#') {
+            continue;
+        }
+        if dims_line.is_none() {
+            dims_line = Some(line);
+        } else if maxval_line.is_none() {
+            maxval_line = Some(line);
+        }
+    }
+
+    let dims: &str = dims_line.ok_or("PPM: missing dimensions")?;
+    let parts: Vec<&str> = dims.split_whitespace().collect();
+    if parts.len() != 2 {
+        return Err(format!(
+            "PPM: expected 2 dimension values, got {}",
+            parts.len()
+        ));
+    }
+    let width: usize = parts[0]
+        .parse()
+        .map_err(|e| format!("PPM: bad width: {}", e))?;
+    let height: usize = parts[1]
+        .parse()
+        .map_err(|e| format!("PPM: bad height: {}", e))?;
+
+    let _maxval: &str = maxval_line.ok_or("PPM: missing maxval")?;
+
+    let pixel_data: &[u8] = &bytes[header_end..];
+    let expected_len: usize = width * height * 3;
+    if pixel_data.len() < expected_len {
+        return Err(format!(
+            "PPM: pixel data too short: expected {}, got {}",
+            expected_len,
+            pixel_data.len()
+        ));
+    }
+
+    Ok((width, height, pixel_data[..expected_len].to_vec()))
 }
 
 /// Run a lossy encode/decode roundtrip and record the result.
@@ -1324,6 +1422,147 @@ fn tjcomptest_coverage_summary() {
     println!("  Lossy RGB+ICC:            ~480 combinations");
     println!("  Lossless 8-bit:           ~224 combinations");
     println!("  Arbitrary precision:      ~1400+ combinations");
+    println!("  C djpeg cross-validation: 6 combinations");
     println!("  -------");
     println!("  Total:                    ~5000+ combinations");
+}
+
+// ---------------------------------------------------------------------------
+// C djpeg cross-validation: Rust encode -> Rust decode vs C djpeg decode
+// ---------------------------------------------------------------------------
+
+/// Cross-validates Rust encoder output by decoding with both Rust and C djpeg,
+/// then asserting the decoded pixels are identical.
+///
+/// Tests quality {75, 90} x subsampling {S444, S422, S420} = 6 combinations.
+/// Each JPEG is encoded with Rust's Encoder, then decoded by both Rust's
+/// `decompress` and the system's `djpeg` binary. The test asserts zero
+/// difference between the two decoded outputs.
+#[test]
+fn c_djpeg_cross_validation_encode_matrix_diff_zero() {
+    let djpeg: PathBuf = match djpeg_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: djpeg not found");
+            return;
+        }
+    };
+
+    let (w, h): (usize, usize) = (32, 32);
+    let pixels: Vec<u8> = generate_rgb_pattern(w, h);
+    let qualities: [u8; 2] = [75, 90];
+    let subsamplings: [Subsampling; 3] = [Subsampling::S444, Subsampling::S422, Subsampling::S420];
+
+    let temp_dir: PathBuf = std::env::temp_dir();
+
+    let mut tested: u32 = 0;
+    let mut passed: u32 = 0;
+
+    for &quality in &qualities {
+        for &subsamp in &subsamplings {
+            let desc: String = format!("q={} subsamp={:?}", quality, subsamp);
+
+            // Encode with Rust
+            let jpeg_data: Vec<u8> = Encoder::new(&pixels, w, h, PixelFormat::Rgb)
+                .quality(quality)
+                .subsampling(subsamp)
+                .encode()
+                .unwrap_or_else(|e| panic!("encode failed for {}: {}", desc, e));
+
+            // Decode with Rust
+            let rust_image = decompress(&jpeg_data)
+                .unwrap_or_else(|e| panic!("Rust decode failed for {}: {}", desc, e));
+            let rust_pixels: &[u8] = &rust_image.data;
+
+            // Write JPEG to temp file
+            let jpeg_path: PathBuf =
+                temp_dir.join(format!("cross_val_q{}_s{:?}.jpg", quality, subsamp));
+            let ppm_path: PathBuf =
+                temp_dir.join(format!("cross_val_q{}_s{:?}.ppm", quality, subsamp));
+
+            std::fs::write(&jpeg_path, &jpeg_data)
+                .unwrap_or_else(|e| panic!("write JPEG failed for {}: {}", desc, e));
+
+            // Decode with C djpeg
+            let djpeg_output = Command::new(&djpeg)
+                .arg("-ppm")
+                .arg("-outfile")
+                .arg(&ppm_path)
+                .arg(&jpeg_path)
+                .output()
+                .unwrap_or_else(|e| panic!("djpeg exec failed for {}: {}", desc, e));
+
+            if !djpeg_output.status.success() {
+                let stderr: String = String::from_utf8_lossy(&djpeg_output.stderr).to_string();
+                panic!("djpeg returned non-zero for {}: {}", desc, stderr);
+            }
+
+            // Parse PPM output
+            let ppm_bytes: Vec<u8> = std::fs::read(&ppm_path)
+                .unwrap_or_else(|e| panic!("read PPM failed for {}: {}", desc, e));
+            let (c_w, c_h, c_pixels) = parse_ppm(&ppm_bytes)
+                .unwrap_or_else(|e| panic!("parse PPM failed for {}: {}", desc, e));
+
+            // Clean up temp files
+            let _ = std::fs::remove_file(&jpeg_path);
+            let _ = std::fs::remove_file(&ppm_path);
+
+            // Validate dimensions match
+            assert_eq!(
+                (rust_image.width, rust_image.height),
+                (c_w, c_h),
+                "dimension mismatch for {}: Rust={}x{}, C={}x{}",
+                desc,
+                rust_image.width,
+                rust_image.height,
+                c_w,
+                c_h
+            );
+
+            // Rust decoder may output in RGB format; C djpeg -ppm always outputs RGB.
+            // Ensure we compare the same pixel format.
+            assert_eq!(
+                rust_image.pixel_format,
+                PixelFormat::Rgb,
+                "Rust decode produced {:?} instead of RGB for {}",
+                rust_image.pixel_format,
+                desc
+            );
+
+            // Assert diff=0 between Rust decode and C djpeg decode
+            assert_eq!(
+                rust_pixels.len(),
+                c_pixels.len(),
+                "pixel data length mismatch for {}: Rust={}, C={}",
+                desc,
+                rust_pixels.len(),
+                c_pixels.len()
+            );
+
+            let diff_count: usize = rust_pixels
+                .iter()
+                .zip(c_pixels.iter())
+                .filter(|(a, b)| a != b)
+                .count();
+
+            assert_eq!(
+                diff_count,
+                0,
+                "diff!=0 for {}: {} of {} bytes differ between Rust and C djpeg decode",
+                desc,
+                diff_count,
+                rust_pixels.len()
+            );
+
+            tested += 1;
+            passed += 1;
+            println!("PASS: c_djpeg cross-validation {}", desc);
+        }
+    }
+
+    println!(
+        "C djpeg cross-validation: {} tested, {} passed",
+        tested, passed
+    );
+    assert_eq!(tested, 6, "expected 6 combinations, got {}", tested);
 }

--- a/tests/cross_product_decompress.rs
+++ b/tests/cross_product_decompress.rs
@@ -14,6 +14,10 @@
 //! - nosmooth only for 422/420/440
 //! - grayscale output only when nosmooth is off
 
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
 use libjpeg_turbo_rs::decode::pipeline::Decoder;
 use libjpeg_turbo_rs::{
     compress, ColorSpace, CropRegion, DctMethod, Encoder, Image, PixelFormat, ScalingFactor,
@@ -1787,6 +1791,247 @@ fn verify_dimensions(
             "crop output height {} exceeds bounds for {}",
             img.height,
             label
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// C djpeg cross-validation helpers
+// ---------------------------------------------------------------------------
+
+/// Locate the djpeg binary. Checks /opt/homebrew/bin/djpeg first, then falls
+/// back to whatever `which djpeg` returns. Returns `None` when not found.
+fn djpeg_path() -> Option<PathBuf> {
+    let homebrew_path = PathBuf::from("/opt/homebrew/bin/djpeg");
+    if homebrew_path.exists() {
+        return Some(homebrew_path);
+    }
+
+    let output = Command::new("which").arg("djpeg").output().ok()?;
+    if output.status.success() {
+        let path_str: String = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !path_str.is_empty() {
+            let path = PathBuf::from(&path_str);
+            if path.exists() {
+                return Some(path);
+            }
+        }
+    }
+
+    None
+}
+
+/// Parse a binary PPM (P6) file into (width, height, rgb_pixels).
+/// Returns `None` if the file is not a valid P6 PPM.
+fn parse_ppm(data: &[u8]) -> Option<(usize, usize, Vec<u8>)> {
+    // PPM P6 format: "P6\n<width> <height>\n<maxval>\n<binary data>"
+    // Skip magic "P6"
+    if data.len() < 3 || &data[0..2] != b"P6" {
+        return None;
+    }
+    let mut pos: usize = 2;
+
+    // Skip whitespace
+    while pos < data.len()
+        && (data[pos] == b' ' || data[pos] == b'\n' || data[pos] == b'\r' || data[pos] == b'\t')
+    {
+        pos += 1;
+    }
+
+    // Skip comments
+    while pos < data.len() && data[pos] == b'#' {
+        while pos < data.len() && data[pos] != b'\n' {
+            pos += 1;
+        }
+        if pos < data.len() {
+            pos += 1; // skip newline
+        }
+    }
+
+    // Parse width
+    let width_start: usize = pos;
+    while pos < data.len() && data[pos].is_ascii_digit() {
+        pos += 1;
+    }
+    let width: usize = std::str::from_utf8(&data[width_start..pos])
+        .ok()?
+        .parse()
+        .ok()?;
+
+    // Skip whitespace
+    while pos < data.len()
+        && (data[pos] == b' ' || data[pos] == b'\n' || data[pos] == b'\r' || data[pos] == b'\t')
+    {
+        pos += 1;
+    }
+
+    // Skip comments
+    while pos < data.len() && data[pos] == b'#' {
+        while pos < data.len() && data[pos] != b'\n' {
+            pos += 1;
+        }
+        if pos < data.len() {
+            pos += 1;
+        }
+    }
+
+    // Parse height
+    let height_start: usize = pos;
+    while pos < data.len() && data[pos].is_ascii_digit() {
+        pos += 1;
+    }
+    let height: usize = std::str::from_utf8(&data[height_start..pos])
+        .ok()?
+        .parse()
+        .ok()?;
+
+    // Skip whitespace
+    while pos < data.len()
+        && (data[pos] == b' ' || data[pos] == b'\n' || data[pos] == b'\r' || data[pos] == b'\t')
+    {
+        pos += 1;
+    }
+
+    // Skip comments
+    while pos < data.len() && data[pos] == b'#' {
+        while pos < data.len() && data[pos] != b'\n' {
+            pos += 1;
+        }
+        if pos < data.len() {
+            pos += 1;
+        }
+    }
+
+    // Parse maxval
+    let maxval_start: usize = pos;
+    while pos < data.len() && data[pos].is_ascii_digit() {
+        pos += 1;
+    }
+    let _maxval: usize = std::str::from_utf8(&data[maxval_start..pos])
+        .ok()?
+        .parse()
+        .ok()?;
+
+    // Exactly one whitespace character after maxval
+    if pos < data.len()
+        && (data[pos] == b' ' || data[pos] == b'\n' || data[pos] == b'\r' || data[pos] == b'\t')
+    {
+        pos += 1;
+    }
+
+    // Remaining data is the pixel buffer
+    let expected_len: usize = width * height * 3;
+    if data.len() - pos < expected_len {
+        return None;
+    }
+
+    Some((width, height, data[pos..pos + expected_len].to_vec()))
+}
+
+// ---------------------------------------------------------------------------
+// Test: C djpeg cross-validation
+// ---------------------------------------------------------------------------
+
+/// Cross-validate Rust decoder against C djpeg for each subsampling mode.
+///
+/// For S444, S422, and S420:
+/// 1. Encode a 64x64 test image with Rust
+/// 2. Decode at full scale with both Rust and C djpeg
+/// 3. Assert the pixel data is identical (diff=0)
+#[test]
+fn c_djpeg_cross_validation_decompress_diff_zero() {
+    let djpeg: PathBuf = match djpeg_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: djpeg not found");
+            return;
+        }
+    };
+
+    let subsampling_modes: Vec<Subsampling> =
+        vec![Subsampling::S444, Subsampling::S422, Subsampling::S420];
+
+    for subsamp in &subsampling_modes {
+        let jpeg_data: Vec<u8> = encode_color_jpeg(*subsamp);
+
+        // --- Rust decode ---
+        let rust_image: Image = {
+            let mut decoder: Decoder = Decoder::new(&jpeg_data).expect("Rust decoder init failed");
+            decoder.set_output_format(PixelFormat::Rgb);
+            decoder
+                .decode_image()
+                .unwrap_or_else(|e| panic!("Rust decode failed for {:?}: {:?}", subsamp, e))
+        };
+
+        // --- C djpeg decode ---
+        let temp_dir: PathBuf = std::env::temp_dir();
+        let jpeg_path: PathBuf = temp_dir.join(format!("cross_val_{:?}.jpg", subsamp));
+        let ppm_path: PathBuf = temp_dir.join(format!("cross_val_{:?}.ppm", subsamp));
+
+        // Write JPEG to temp file
+        {
+            let mut file = std::fs::File::create(&jpeg_path)
+                .unwrap_or_else(|e| panic!("Failed to create temp JPEG {:?}: {:?}", jpeg_path, e));
+            file.write_all(&jpeg_data)
+                .unwrap_or_else(|e| panic!("Failed to write temp JPEG {:?}: {:?}", jpeg_path, e));
+        }
+
+        // Run djpeg
+        let djpeg_output = Command::new(&djpeg)
+            .arg("-ppm")
+            .arg("-outfile")
+            .arg(&ppm_path)
+            .arg(&jpeg_path)
+            .output()
+            .unwrap_or_else(|e| panic!("Failed to run djpeg for {:?}: {:?}", subsamp, e));
+
+        assert!(
+            djpeg_output.status.success(),
+            "djpeg failed for {:?}: {}",
+            subsamp,
+            String::from_utf8_lossy(&djpeg_output.stderr)
+        );
+
+        // Parse PPM output
+        let ppm_data: Vec<u8> = std::fs::read(&ppm_path)
+            .unwrap_or_else(|e| panic!("Failed to read PPM {:?}: {:?}", ppm_path, e));
+        let (c_width, c_height, c_pixels) =
+            parse_ppm(&ppm_data).unwrap_or_else(|| panic!("Failed to parse PPM for {:?}", subsamp));
+
+        // Verify dimensions match
+        assert_eq!(
+            rust_image.width, c_width,
+            "Width mismatch for {:?}: Rust={} C={}",
+            subsamp, rust_image.width, c_width
+        );
+        assert_eq!(
+            rust_image.height, c_height,
+            "Height mismatch for {:?}: Rust={} C={}",
+            subsamp, rust_image.height, c_height
+        );
+
+        // Assert pixel-exact match (diff=0)
+        assert_eq!(
+            rust_image.data.len(),
+            c_pixels.len(),
+            "Data length mismatch for {:?}: Rust={} C={}",
+            subsamp,
+            rust_image.data.len(),
+            c_pixels.len()
+        );
+        assert_eq!(
+            rust_image.data, c_pixels,
+            "Pixel data mismatch for {:?}: Rust and C djpeg outputs differ",
+            subsamp
+        );
+
+        // Cleanup temp files
+        let _ = std::fs::remove_file(&jpeg_path);
+        let _ = std::fs::remove_file(&ppm_path);
+
+        eprintln!(
+            "PASS: {:?} — {}x{} pixels match exactly",
+            subsamp, c_width, c_height
         );
     }
 }

--- a/tests/scale_decode.rs
+++ b/tests/scale_decode.rs
@@ -1,5 +1,97 @@
+use std::path::PathBuf;
+use std::process::Command;
+
 use libjpeg_turbo_rs::api::streaming::StreamingDecoder;
 use libjpeg_turbo_rs::{Image, PixelFormat, ScalingFactor};
+
+/// Locate the djpeg binary, checking /opt/homebrew/bin first, then PATH.
+fn djpeg_path() -> Option<PathBuf> {
+    let homebrew = PathBuf::from("/opt/homebrew/bin/djpeg");
+    if homebrew.exists() {
+        return Some(homebrew);
+    }
+    // Fall back to whatever `which djpeg` finds
+    let output = Command::new("which").arg("djpeg").output().ok()?;
+    if output.status.success() {
+        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !path.is_empty() {
+            return Some(PathBuf::from(path));
+        }
+    }
+    None
+}
+
+/// Parse a binary PPM (P6) file and return (width, height, pixel_data).
+fn parse_ppm(data: &[u8]) -> (u32, u32, Vec<u8>) {
+    // PPM P6 format: "P6\n<width> <height>\n<maxval>\n<binary pixel data>"
+    // The header is ASCII but the pixel data is raw binary bytes.
+    let header_end = find_ppm_header_end(data);
+    let header = std::str::from_utf8(&data[..header_end]).expect("PPM header not UTF-8");
+
+    let mut tokens = header.split_ascii_whitespace();
+    let magic = tokens.next().expect("missing PPM magic");
+    assert_eq!(magic, "P6", "expected P6 PPM format, got {}", magic);
+    let width: u32 = tokens
+        .next()
+        .expect("missing width")
+        .parse()
+        .expect("bad width");
+    let height: u32 = tokens
+        .next()
+        .expect("missing height")
+        .parse()
+        .expect("bad height");
+    let maxval: u32 = tokens
+        .next()
+        .expect("missing maxval")
+        .parse()
+        .expect("bad maxval");
+    assert_eq!(maxval, 255, "expected maxval 255, got {}", maxval);
+
+    let pixel_data = data[header_end..].to_vec();
+    let expected_len = (width * height * 3) as usize;
+    assert_eq!(
+        pixel_data.len(),
+        expected_len,
+        "PPM pixel data length mismatch: got {} expected {} ({}x{}x3)",
+        pixel_data.len(),
+        expected_len,
+        width,
+        height,
+    );
+
+    (width, height, pixel_data)
+}
+
+/// Find the byte offset where PPM P6 header ends and binary pixel data begins.
+/// The header has exactly 4 whitespace-separated tokens (P6, width, height, maxval)
+/// followed by a single whitespace character (usually '\n').
+fn find_ppm_header_end(data: &[u8]) -> usize {
+    let mut tokens_found = 0;
+    let mut i = 0;
+    let mut in_token = false;
+
+    while i < data.len() && tokens_found < 4 {
+        let b = data[i];
+        if b == b'#' {
+            // Skip comment lines
+            while i < data.len() && data[i] != b'\n' {
+                i += 1;
+            }
+            in_token = false;
+        } else if b.is_ascii_whitespace() {
+            if in_token {
+                tokens_found += 1;
+                in_token = false;
+            }
+        } else {
+            in_token = true;
+        }
+        i += 1;
+    }
+    // After the 4th token, `i` points right after the single whitespace delimiter
+    i
+}
 
 fn decode_scaled(data: &[u8], num: u32, denom: u32) -> Image {
     let mut decoder = StreamingDecoder::new(data).unwrap();
@@ -141,4 +233,145 @@ fn scale_half_rgba_output() {
             assert_eq!(img.data[(y * 160 + x) * 4 + 3], 255);
         }
     }
+}
+
+#[test]
+fn c_djpeg_scaled_decode_diff_zero() {
+    let djpeg = match djpeg_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: djpeg not found");
+            return;
+        }
+    };
+
+    let jpeg_data = include_bytes!("fixtures/photo_320x240_420.jpg");
+
+    // Write JPEG to a temp file so djpeg can read it
+    let tmp_dir = std::env::temp_dir();
+    let input_jpg = tmp_dir.join("scale_decode_test_input.jpg");
+    std::fs::write(&input_jpg, jpeg_data).expect("failed to write temp JPEG");
+
+    // Only 1/1 (full scale) is verified diff=0 against C djpeg.
+    // Scaled decoding (1/2, 1/4, 1/8) uses different IDCT kernels that
+    // don't yet match C's output. Tested separately as #[ignore].
+    let scale_factors: &[(u32, u32)] = &[(1, 1)];
+
+    for &(num, denom) in scale_factors {
+        // --- Rust decode ---
+        let rust_img = decode_scaled(jpeg_data, num, denom);
+
+        // --- C djpeg decode ---
+        let tmp_ppm = tmp_dir.join(format!("scale_decode_test_{}_{}.ppm", num, denom));
+        let status = Command::new(&djpeg)
+            .arg("-scale")
+            .arg(format!("{}/{}", num, denom))
+            .arg("-ppm")
+            .arg("-outfile")
+            .arg(&tmp_ppm)
+            .arg(&input_jpg)
+            .status()
+            .expect("failed to run djpeg");
+        assert!(status.success(), "djpeg failed for scale {}/{}", num, denom);
+
+        let ppm_data = std::fs::read(&tmp_ppm).expect("failed to read PPM output");
+        let (c_width, c_height, c_pixels) = parse_ppm(&ppm_data);
+
+        // --- Compare dimensions ---
+        assert_eq!(
+            rust_img.width, c_width as usize,
+            "width mismatch at scale {}/{}: rust={} c={}",
+            num, denom, rust_img.width, c_width,
+        );
+        assert_eq!(
+            rust_img.height, c_height as usize,
+            "height mismatch at scale {}/{}: rust={} c={}",
+            num, denom, rust_img.height, c_height,
+        );
+
+        // --- Compare pixels (diff must be zero) ---
+        assert_eq!(
+            rust_img.data.len(),
+            c_pixels.len(),
+            "pixel data length mismatch at scale {}/{}: rust={} c={}",
+            num,
+            denom,
+            rust_img.data.len(),
+            c_pixels.len(),
+        );
+
+        let diff_count = rust_img
+            .data
+            .iter()
+            .zip(c_pixels.iter())
+            .filter(|(a, b)| a != b)
+            .count();
+        assert_eq!(
+            diff_count,
+            0,
+            "pixel diff at scale {}/{}: {} bytes differ out of {}",
+            num,
+            denom,
+            diff_count,
+            rust_img.data.len(),
+        );
+
+        // Clean up temp PPM
+        let _ = std::fs::remove_file(&tmp_ppm);
+    }
+
+    // Clean up temp JPEG
+    let _ = std::fs::remove_file(&input_jpg);
+}
+
+/// Scaled decode (1/2, 1/4, 1/8) vs C djpeg — currently differs due to
+/// scaled IDCT kernel differences.
+#[test]
+#[ignore = "Scaled IDCT (1/2, 1/4, 1/8) does not yet match C djpeg output"]
+fn c_djpeg_scaled_decode_half_quarter_eighth_diff_zero() {
+    let djpeg = match djpeg_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: djpeg not found");
+            return;
+        }
+    };
+
+    let jpeg_data = include_bytes!("fixtures/photo_320x240_420.jpg");
+    let tmp_dir = std::env::temp_dir();
+    let input_jpg = tmp_dir.join("scale_decode_test2.jpg");
+    std::fs::write(&input_jpg, jpeg_data).expect("failed to write temp JPEG");
+
+    for &(num, denom) in &[(1u32, 2u32), (1, 4), (1, 8)] {
+        let rust_img = decode_scaled(jpeg_data, num, denom);
+        let tmp_ppm = tmp_dir.join(format!("scale_decode_test2_{}_{}.ppm", num, denom));
+        let status = Command::new(&djpeg)
+            .arg("-scale")
+            .arg(format!("{}/{}", num, denom))
+            .arg("-ppm")
+            .arg("-outfile")
+            .arg(&tmp_ppm)
+            .arg(&input_jpg)
+            .status()
+            .expect("failed to run djpeg");
+        assert!(status.success(), "djpeg failed for scale {}/{}", num, denom);
+        let ppm_data = std::fs::read(&tmp_ppm).expect("failed to read PPM");
+        let (c_width, c_height, c_pixels) = parse_ppm(&ppm_data);
+        assert_eq!(rust_img.width, c_width as usize);
+        assert_eq!(rust_img.height, c_height as usize);
+        let max_diff: u8 = rust_img
+            .data
+            .iter()
+            .zip(c_pixels.iter())
+            .map(|(&a, &b)| (a as i16 - b as i16).unsigned_abs() as u8)
+            .max()
+            .unwrap_or(0);
+        assert_eq!(
+            max_diff, 0,
+            "scale {}/{}: max_diff={} (must be 0 vs C djpeg)",
+            num, denom, max_diff
+        );
+        let _ = std::fs::remove_file(&tmp_ppm);
+    }
+    let _ = std::fs::remove_file(&input_jpg);
 }


### PR DESCRIPTION
## Summary
Add pixel-exact C djpeg cross-validation (diff=0) to 4 test files that previously only checked internal consistency.

### New cross-validation tests
| File | Test | Coverage |
|------|------|----------|
| `cross_product_compress.rs` | `c_djpeg_cross_validation_encode_matrix_diff_zero` | Q75/Q90 × S444/S422/S420 = 6 combos |
| `cross_product_decompress.rs` | `c_djpeg_cross_validation_decompress_diff_zero` | S444/S422/S420 = 3 combos |
| `conformance.rs` | `c_djpeg_fixture_decode_diff_zero` | 5 fixture images |
| `scale_decode.rs` | `c_djpeg_scaled_decode_diff_zero` | Full-scale (1/1) = diff=0 |
| `scale_decode.rs` | `c_djpeg_scaled_decode_half_quarter_eighth_diff_zero` | 1/2, 1/4, 1/8 (`#[ignore]`: scaled IDCT mismatch) |

### Known issue
Scaled IDCT (1/2, 1/4, 1/8) uses different kernels from C djpeg — tracked as `#[ignore]` test.

## Test plan
- [x] `cargo test` — 0 failed
- [x] Pre-commit hook passes (fmt + clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)