### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libjpeg-turbo-rs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libjpeg-turbo-rs"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.87"
 description = "Pure Rust reimplementation of libjpeg-turbo with NEON/AVX2 SIMD acceleration"


### PR DESCRIPTION
## Summary
- Bump version from 0.2.1 to 0.3.0

## Changes since v0.2.0

### Bug Fixes
- Fix auto-decode 12-bit JPEG in 8-bit API (#134)
- Fix non-uniform chroma sampling factors in decode (#133)
- Resolve 15 real-world JPEG decode failures (#132)
- Resolve 8K decode overflow (mcu_count u16 → u32)
- SOF10 (arithmetic progressive) decode to match C (diff=0) (#126)
- S440/S411/S441 decode to match C libjpeg-turbo (diff=0)
- 12-bit decode to match C libjpeg-turbo (diff=0)
- Lossless transforms to match C jpegtran (max_diff ≤ 1)
- Transform byte-identical to C jpegtran (diff=0) (#121)
- Per-component IDCT sizes for scaled decode

### Performance
- NEON SIMD color conversion for RGBX/BGRX/XRGB/XBGR/ARGB/ABGR (#117)

### Testing
- 100+ C cross-validation tests added across all decode/encode/transform paths
- 61 real-world JPEG test images with C cross-validation
- Comprehensive metadata edge case validation (ICC, EXIF, COM)
- Extreme dimension, restart marker, bitstream structure validation
- Pre-commit hook with cargo fmt + clippy checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)