### PR TITLE
fix: match C libjpeg-turbo upsample behavior for 4:2:2 scaled decode

### DIFF
--- a/src/decode/pipeline.rs
+++ b/src/decode/pipeline.rs
@@ -3213,17 +3213,7 @@ impl<'a> Decoder<'a> {
                 // Upsample each chroma component independently using its own factors.
                 // This handles non-uniform chroma sampling (e.g. Cb=2x1, Cr=1x1)
                 // where each component needs a different upsample strategy.
-                for (
-                    comp_plane,
-                    comp_full,
-                    comp_w,
-                    comp_h,
-                    comp_hf,
-                    comp_vf,
-                    actual_w,
-                    actual_h,
-                    comp_bs,
-                ) in [
+                for (comp_plane, comp_full, comp_w, comp_h, comp_hf, comp_vf, actual_w, actual_h) in [
                     (
                         &component_planes[1],
                         &mut cb_full,
@@ -3233,7 +3223,6 @@ impl<'a> Decoder<'a> {
                         cb_v_factor,
                         actual_cb_w,
                         actual_cb_h,
-                        comp_block_sizes[1],
                     ),
                     (
                         &component_planes[2],
@@ -3244,13 +3233,15 @@ impl<'a> Decoder<'a> {
                         cr_v_factor,
                         actual_cr_w,
                         actual_cr_h,
-                        comp_block_sizes[2],
                     ),
                 ] {
-                    // C's merged upsample uses box filter when:
-                    // - actual chroma width <= 2 (SIMD fancy requires >= 3 columns)
-                    // - scaled decode with chroma still needing upsample (chroma IDCT < 8)
-                    let use_box_filter: bool = self.fast_upsample || actual_w <= 2 || comp_bs < 8;
+                    // C libjpeg-turbo uses box filter when:
+                    // - fast_upsample requested, OR
+                    // - actual chroma width <= 2 (fancy filter needs >= 3 columns), OR
+                    // - min_DCT_scaled_size == 1 (jdsample.c line 478: jdmainct.c
+                    //   doesn't support context rows at this size)
+                    let use_box_filter: bool =
+                        self.fast_upsample || actual_w <= 2 || block_size == 1;
 
                     if comp_hf == 1 && comp_vf == 1 {
                         // No upsampling needed for this component — copy directly.

--- a/tests/scaling_extended.rs
+++ b/tests/scaling_extended.rs
@@ -868,11 +868,8 @@ fn c_djpeg_scaling_422_full_scale_diff_zero() {
     let _ = std::fs::remove_file(&input_jpg);
 }
 
-/// Pixel comparison for 4:2:2 **scaled** decode (1/2, 1/4, 1/8) against C djpeg.
-/// Known issue: 4:2:2 scaled decode uses a different chroma IDCT sizing strategy
-/// than C libjpeg-turbo, producing measurable diffs. Measured max_diff=37 at 1/2.
+/// Pixel-exact comparison for 4:2:2 **scaled** decode (1/2, 1/4, 1/8) against C djpeg.
 #[test]
-#[ignore = "4:2:2 scaled decode has known diff vs C djpeg (max_diff=37 at 1/2 scale) — needs chroma IDCT fix"]
 fn c_djpeg_scaling_422_scaled_pixel_diff_zero() {
     let djpeg = match djpeg_path() {
         Some(p) => p,


### PR DESCRIPTION
## Summary
- Remove incorrect `comp_bs < 8` box filter fallback — C decides based on `downsampled_width`, not IDCT block size (was causing max_diff=37 at 1/2 scale)
- Force box filter when `min_DCT_scaled_size == 1` (1/8 scale) — matches C's jdsample.c line 478 constraint (was causing max_diff=10 at 1/8 scale)
- Un-ignore `c_djpeg_scaling_422_scaled_pixel_diff_zero` test — now pixel-exact (diff=0) at 1/2, 1/4, 1/8

## Test plan
- [x] `cargo test --test scaling_extended -- --include-ignored` — all 42 pass, 0 ignored
- [x] Full `cargo test` — all pass
- [x] `cargo clippy --lib -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)