### PR TITLE
fix: lossless SOF3 color space handling to match C libjpeg-turbo

### DIFF
--- a/src/decode/pipeline.rs
+++ b/src/decode/pipeline.rs
@@ -2457,7 +2457,10 @@ impl<'a> Decoder<'a> {
         }
     }
 
-    /// Convert decoded lossless YCbCr component planes to output Image.
+    /// Convert decoded lossless RGB component planes to output Image.
+    ///
+    /// Lossless JPEG stores raw RGB values with no color conversion (matching
+    /// C libjpeg-turbo JCS_RGB behavior), so we output component values directly.
     fn lossless_output_color(
         &self,
         comp_planes: &[Vec<u16>],
@@ -2470,20 +2473,15 @@ impl<'a> Decoder<'a> {
         let bpp = out_format.bytes_per_pixel();
         let mut data = Vec::with_capacity(width * height * bpp);
 
-        for ((&y_pix, &cb_pix), &cr_pix) in comp_planes[0]
+        for ((&r_pix, &g_pix), &b_pix) in comp_planes[0]
             .iter()
             .zip(comp_planes[1].iter())
             .zip(comp_planes[2].iter())
         {
-            let y_val = y_pix as i32;
-            let cb_val = cb_pix as i32;
-            let cr_val = cr_pix as i32;
-
-            // YCbCr to RGB (JFIF convention: Y,Cb,Cr centered at 128)
-            let r = (y_val + ((cr_val - 128) * 359 + 128) / 256).clamp(0, 255) as u8;
-            let g = (y_val - ((cb_val - 128) * 88 + (cr_val - 128) * 183 - 128) / 256).clamp(0, 255)
-                as u8;
-            let b = (y_val + ((cb_val - 128) * 454 + 128) / 256).clamp(0, 255) as u8;
+            // Raw RGB: output component values directly (no color conversion)
+            let r: u8 = r_pix.min(255) as u8;
+            let g: u8 = g_pix.min(255) as u8;
+            let b: u8 = b_pix.min(255) as u8;
 
             match out_format {
                 PixelFormat::Rgb => {

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -1378,10 +1378,10 @@ fn compress_lossless_grayscale(
     Ok(output)
 }
 
-/// Encode a 3-component (RGB via YCbCr) interleaved lossless JPEG.
+/// Encode a 3-component RGB interleaved lossless JPEG.
 ///
-/// Converts RGB to YCbCr (JFIF convention), then encodes each component
-/// interleaved: for each pixel, encode Y diff, Cb diff, Cr diff.
+/// Stores raw RGB component values with no color conversion, matching
+/// C libjpeg-turbo behavior for lossless JPEG (JCS_RGB, no YCbCr conversion).
 fn compress_lossless_rgb(
     pixels: &[u8],
     width: usize,
@@ -1392,31 +1392,23 @@ fn compress_lossless_rgb(
     let precision: u8 = 8;
     let num_pixels: usize = width * height;
 
-    // Convert RGB to YCbCr planes
-    let mut y_plane: Vec<u8> = vec![0u8; num_pixels];
-    let mut cb_plane: Vec<u8> = vec![0u8; num_pixels];
-    let mut cr_plane: Vec<u8> = vec![0u8; num_pixels];
+    // Split interleaved RGB into separate planes (no color conversion)
+    let mut r_plane: Vec<u8> = vec![0u8; num_pixels];
+    let mut g_plane: Vec<u8> = vec![0u8; num_pixels];
+    let mut b_plane: Vec<u8> = vec![0u8; num_pixels];
 
-    for row in 0..height {
-        let row_start: usize = row * width * 3;
-        let plane_start: usize = row * width;
-        color::rgb_to_ycbcr_row(
-            &pixels[row_start..row_start + width * 3],
-            &mut y_plane[plane_start..plane_start + width],
-            &mut cb_plane[plane_start..plane_start + width],
-            &mut cr_plane[plane_start..plane_start + width],
-            width,
-        );
+    for i in 0..num_pixels {
+        r_plane[i] = pixels[i * 3];
+        g_plane[i] = pixels[i * 3 + 1];
+        b_plane[i] = pixels[i * 3 + 2];
     }
 
-    let planes: [&[u8]; 3] = [&y_plane, &cb_plane, &cr_plane];
+    let planes: [&[u8]; 3] = [&r_plane, &g_plane, &b_plane];
 
-    // Use luminance DC table for Y (table 0), chrominance DC table for Cb/Cr (table 1)
+    // Use luminance DC table for all 3 components (no chrominance table needed)
     let dc_table_luma: HuffTable =
         build_huff_table(&tables::DC_LUMINANCE_BITS, &tables::DC_LUMINANCE_VALUES);
-    let dc_table_chroma: HuffTable =
-        build_huff_table(&tables::DC_CHROMINANCE_BITS, &tables::DC_CHROMINANCE_VALUES);
-    let dc_tables: [&HuffTable; 3] = [&dc_table_luma, &dc_table_chroma, &dc_table_chroma];
+    let dc_tables: [&HuffTable; 3] = [&dc_table_luma, &dc_table_luma, &dc_table_luma];
 
     let mut bit_writer: BitWriter = BitWriter::new(num_pixels * 3);
 
@@ -1446,7 +1438,7 @@ fn compress_lossless_rgb(
 
     marker_writer::write_soi(&mut output);
 
-    // DC Huffman table 0 (luminance) for Y
+    // DC Huffman table 0 (luminance) for all 3 components
     marker_writer::write_dht(
         &mut output,
         0,
@@ -1455,20 +1447,11 @@ fn compress_lossless_rgb(
         &tables::DC_LUMINANCE_VALUES,
     );
 
-    // DC Huffman table 1 (chrominance) for Cb, Cr
-    marker_writer::write_dht(
-        &mut output,
-        0,
-        1,
-        &tables::DC_CHROMINANCE_BITS,
-        &tables::DC_CHROMINANCE_VALUES,
-    );
-
-    // SOF3 with 3 components: Y(id=1), Cb(id=2), Cr(id=3), all 1x1, qt=0
+    // SOF3 with 3 components: R(id=1), G(id=2), B(id=3), all 1x1, qt=0
     let components: Vec<(u8, u8, u8, u8)> = vec![
-        (1, 1, 1, 0), // Y: id=1, h=1, v=1, qt=0
-        (2, 1, 1, 0), // Cb: id=2, h=1, v=1, qt=0
-        (3, 1, 1, 0), // Cr: id=3, h=1, v=1, qt=0
+        (1, 1, 1, 0), // R: id=1, h=1, v=1, qt=0
+        (2, 1, 1, 0), // G: id=2, h=1, v=1, qt=0
+        (3, 1, 1, 0), // B: id=3, h=1, v=1, qt=0
     ];
     marker_writer::write_sof3(
         &mut output,
@@ -1478,11 +1461,11 @@ fn compress_lossless_rgb(
         &components,
     );
 
-    // SOS with 3 components: Y uses DC table 0, Cb/Cr use DC table 1
+    // SOS with 3 components: all use DC table 0
     let scan_components: Vec<(u8, u8)> = vec![
-        (1, 0), // Y -> DC table 0
-        (2, 1), // Cb -> DC table 1
-        (3, 1), // Cr -> DC table 1
+        (1, 0), // R -> DC table 0
+        (2, 0), // G -> DC table 0
+        (3, 0), // B -> DC table 0
     ];
     marker_writer::write_sos_lossless(&mut output, &scan_components, predictor, point_transform);
 
@@ -1619,7 +1602,10 @@ fn compress_lossless_arithmetic_grayscale(
     Ok(output)
 }
 
-/// Encode a 3-component (RGB via YCbCr) interleaved lossless JPEG with arithmetic coding.
+/// Encode a 3-component RGB interleaved lossless JPEG with arithmetic coding.
+///
+/// Stores raw RGB component values with no color conversion, matching
+/// C libjpeg-turbo behavior for lossless JPEG (JCS_RGB, no YCbCr conversion).
 fn compress_lossless_arithmetic_rgb(
     pixels: &[u8],
     width: usize,
@@ -1632,26 +1618,20 @@ fn compress_lossless_arithmetic_rgb(
     let precision: u8 = 8;
     let num_pixels: usize = width * height;
 
-    // Convert RGB to YCbCr planes
-    let mut y_plane: Vec<u8> = vec![0u8; num_pixels];
-    let mut cb_plane: Vec<u8> = vec![0u8; num_pixels];
-    let mut cr_plane: Vec<u8> = vec![0u8; num_pixels];
+    // Split interleaved RGB into separate planes (no color conversion)
+    let mut r_plane: Vec<u8> = vec![0u8; num_pixels];
+    let mut g_plane: Vec<u8> = vec![0u8; num_pixels];
+    let mut b_plane: Vec<u8> = vec![0u8; num_pixels];
 
-    for row in 0..height {
-        let row_start: usize = row * width * 3;
-        let plane_start: usize = row * width;
-        color::rgb_to_ycbcr_row(
-            &pixels[row_start..row_start + width * 3],
-            &mut y_plane[plane_start..plane_start + width],
-            &mut cb_plane[plane_start..plane_start + width],
-            &mut cr_plane[plane_start..plane_start + width],
-            width,
-        );
+    for i in 0..num_pixels {
+        r_plane[i] = pixels[i * 3];
+        g_plane[i] = pixels[i * 3 + 1];
+        b_plane[i] = pixels[i * 3 + 2];
     }
 
-    let planes: [&[u8]; 3] = [&y_plane, &cb_plane, &cr_plane];
-    // comp_idx 0=Y uses dc_tbl 0, comp_idx 1=Cb and 2=Cr use dc_tbl 1
-    let dc_tbls: [usize; 3] = [0, 1, 1];
+    let planes: [&[u8]; 3] = [&r_plane, &g_plane, &b_plane];
+    // All components use DC table 0 (no chrominance table)
+    let dc_tbls: [usize; 3] = [0, 0, 0];
 
     let mut arith_enc: ArithEncoder = ArithEncoder::new(num_pixels * 3);
 
@@ -1684,11 +1664,11 @@ fn compress_lossless_arithmetic_rgb(
 
     marker_writer::write_soi(&mut output);
 
-    // SOF11 with 3 components: Y(id=1), Cb(id=2), Cr(id=3), all 1x1, qt=0
+    // SOF11 with 3 components: R(id=1), G(id=2), B(id=3), all 1x1, qt=0
     let components: Vec<(u8, u8, u8, u8)> = vec![
-        (1, 1, 1, 0), // Y
-        (2, 1, 1, 0), // Cb
-        (3, 1, 1, 0), // Cr
+        (1, 1, 1, 0), // R
+        (2, 1, 1, 0), // G
+        (3, 1, 1, 0), // B
     ];
     marker_writer::write_sof11(
         &mut output,
@@ -1698,16 +1678,16 @@ fn compress_lossless_arithmetic_rgb(
         &components,
     );
 
-    // DAC marker for DC tables 0 and 1
+    // DAC marker for DC table 0 only
     let dc_params: [(u8, u8); 2] = [(0u8, 1u8), (0, 1)];
     let ac_params: [u8; 2] = [5u8, 5];
-    marker_writer::write_dac(&mut output, 2, &dc_params, 0, &ac_params);
+    marker_writer::write_dac(&mut output, 1, &dc_params, 0, &ac_params);
 
-    // SOS with 3 components: Y uses DC table 0, Cb/Cr use DC table 1
+    // SOS with 3 components: all use DC table 0
     let scan_components: Vec<(u8, u8)> = vec![
-        (1, 0), // Y -> DC table 0
-        (2, 1), // Cb -> DC table 1
-        (3, 1), // Cr -> DC table 1
+        (1, 0), // R -> DC table 0
+        (2, 0), // G -> DC table 0
+        (3, 0), // B -> DC table 0
     ];
     marker_writer::write_sos_lossless(&mut output, &scan_components, predictor, point_transform);
 

--- a/tests/cross_check_lossless.rs
+++ b/tests/cross_check_lossless.rs
@@ -191,16 +191,6 @@ fn read_ascii_number(data: &[u8], idx: usize) -> (usize, usize) {
     (val, end)
 }
 
-/// Maximum absolute per-channel difference between two pixel buffers.
-fn pixel_max_diff(a: &[u8], b: &[u8]) -> u8 {
-    assert_eq!(a.len(), b.len(), "pixel buffers must have equal length");
-    a.iter()
-        .zip(b.iter())
-        .map(|(&x, &y)| (x as i16 - y as i16).unsigned_abs() as u8)
-        .max()
-        .unwrap_or(0)
-}
-
 // ===========================================================================
 // Rust lossless encode -> C djpeg decode
 // ===========================================================================
@@ -282,23 +272,14 @@ fn rust_lossless_rgb_c_decode() {
     assert_eq!(dw, w, "width mismatch");
     assert_eq!(dh, h, "height mismatch");
 
-    // RGB lossless goes through YCbCr color conversion. The C decoder (djpeg)
-    // and our Rust decoder may use different YCbCr->RGB conversion formulas,
-    // leading to potentially large per-pixel differences. This is a known
-    // characteristic of lossless JPEG with color conversion -- the YCbCr
-    // coefficients are lossless, but the final RGB values depend on the
-    // decoder's color conversion implementation.
-    //
-    // We verify:
-    // 1. djpeg successfully decoded our output (confirmed by parse_ppm above)
-    // 2. Dimensions match
-    // 3. Rust decode of our own output is close to original (internal consistency)
+    assert_eq!(
+        c_pixels, pixels,
+        "C djpeg output should be pixel-exact for lossless RGB"
+    );
     let rust_img = decompress(&jpeg).expect("Rust decode of own lossless RGB output");
-    let rust_max_diff: u8 = pixel_max_diff(&rust_img.data, &pixels);
-    assert!(
-        rust_max_diff <= 2,
-        "Rust lossless RGB internal roundtrip: max diff {} (expected <= 2)",
-        rust_max_diff
+    assert_eq!(
+        rust_img.data, pixels,
+        "Rust lossless RGB roundtrip should be pixel-exact"
     );
 }
 

--- a/tests/lossless_encode.rs
+++ b/tests/lossless_encode.rs
@@ -47,8 +47,7 @@ fn lossless_encode_flat_image() {
 
 #[test]
 fn lossless_encode_rgb_roundtrip() {
-    // 3-component lossless roundtrip via YCbCr.
-    // Integer color conversion introduces up to +/- 2 per channel.
+    // 3-component lossless RGB roundtrip: raw RGB stored directly, no color conversion.
     let (w, h) = (8, 8);
     let mut pixels = vec![0u8; w * h * 3];
     for i in 0..w * h {
@@ -61,18 +60,10 @@ fn lossless_encode_rgb_roundtrip() {
     assert_eq!(img.width, w);
     assert_eq!(img.height, h);
     assert_eq!(img.data.len(), w * h * 3);
-    // Allow small rounding differences from YCbCr <-> RGB conversion
-    for (i, (&got, &expected)) in img.data.iter().zip(pixels.iter()).enumerate() {
-        let diff = (got as i16 - expected as i16).abs();
-        assert!(
-            diff <= 2,
-            "pixel byte {} differs by {}: expected {}, got {}",
-            i,
-            diff,
-            pixels[i],
-            img.data[i]
-        );
-    }
+    assert_eq!(
+        img.data, pixels,
+        "Lossless RGB roundtrip should be pixel-exact"
+    );
 }
 
 #[test]
@@ -705,49 +696,9 @@ fn c_djpeg_lossless_encode_extended_diff_zero() {
         assert_eq!(ppm_w, w, "RGB lossless: C width mismatch");
         assert_eq!(ppm_h, h, "RGB lossless: C height mismatch");
 
-        // Compute expected YCbCr from original RGB using the same JFIF conversion
-        // constants as the encoder (matching libjpeg-turbo's jccolor.c).
-        // C djpeg outputs raw YCbCr for lossless, so we compare against that.
-        let mut expected_ycbcr: Vec<u8> = vec![0u8; w * h * 3];
-        for i in 0..w * h {
-            let r: i32 = pixels[i * 3] as i32;
-            let g: i32 = pixels[i * 3 + 1] as i32;
-            let b: i32 = pixels[i * 3 + 2] as i32;
-            // JFIF RGB->YCbCr using libjpeg-turbo fixed-point constants
-            // (SCALEBITS=16, ONE_HALF=1<<15, CBCR_OFFSET=128<<16)
-            let one_half: i32 = 1 << 15;
-            let cbcr_offset: i32 = 128 << 16;
-            let y_val: i32 = (19595 * r + 38470 * g + 7471 * b + one_half) >> 16;
-            let cb_val: i32 =
-                (-11059 * r - 21709 * g + 32768 * b + cbcr_offset + one_half - 1) >> 16;
-            let cr_val: i32 = (32768 * r - 27439 * g - 5329 * b + cbcr_offset + one_half - 1) >> 16;
-            expected_ycbcr[i * 3] = y_val as u8;
-            expected_ycbcr[i * 3 + 1] = cb_val as u8;
-            expected_ycbcr[i * 3 + 2] = cr_val as u8;
-        }
-
         assert_eq!(
-            expected_ycbcr.len(),
-            c_pixels.len(),
-            "RGB lossless: YCbCr buffer length mismatch"
-        );
-
-        // Lossless: expected YCbCr must match C djpeg output exactly (diff=0)
-        let mut mismatch_count: usize = 0;
-        let mut max_diff: u8 = 0;
-        for i in 0..expected_ycbcr.len() {
-            let diff: u8 = (expected_ycbcr[i] as i16 - c_pixels[i] as i16).unsigned_abs() as u8;
-            if diff > max_diff {
-                max_diff = diff;
-            }
-            if diff != 0 {
-                mismatch_count += 1;
-            }
-        }
-        assert_eq!(
-            mismatch_count, 0,
-            "RGB lossless: expected YCbCr vs C djpeg must match exactly: {} mismatches, max_diff={}",
-            mismatch_count, max_diff
+            c_pixels, pixels,
+            "RGB lossless: C djpeg output must be pixel-exact with original RGB"
         );
     }
 


### PR DESCRIPTION
## Summary

- Remove RGB→YCbCr conversion in lossless JPEG encoder (both Huffman SOF3 and arithmetic SOF11)
- Remove YCbCr→RGB conversion in lossless JPEG decoder
- Store raw RGB component values directly, matching C libjpeg-turbo's JCS_RGB behavior for lossless JPEG
- All lossless RGB cross-validation tests now pass with pixel-exact (diff=0) results against C djpeg

Closes #151

## Test plan

- [x] `cargo test --test cross_check_lossless` — 9 passed (includes pixel-exact C djpeg cross-validation)
- [x] `cargo test --test lossless_encode` — 20 passed (includes C djpeg extended diff=0 validation)
- [x] `cargo clippy --lib -- -D warnings` — no warnings
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)