### PR TITLE
fix: wire fdct_ifast_raw + AA&N divisors + EOBRUN for ifast/progressive parity

### DIFF
--- a/src/encode/fdct.rs
+++ b/src/encode/fdct.rs
@@ -509,6 +509,19 @@ pub fn fdct_float(input: &[i16; 64], output: &mut [i32; 64]) {
     }
 }
 
+/// AA&N (Arai, Agui, Nakajima) scale factors for the ifast FDCT, pre-computed
+/// as 14-bit fixed-point values. Each entry is `scalefactor[row] * scalefactor[col]`
+/// where `scalefactor[0] = 1` and `scalefactor[k] = cos(k*PI/16) * sqrt(2)` for k=1..7.
+///
+/// Source: libjpeg-turbo `jcdctmgr.c` lines 289–299.
+pub const AANSCALES: [u16; 64] = [
+    16384, 22725, 21407, 19266, 16384, 12873, 8867, 4520, 22725, 31521, 29692, 26722, 22725, 17855,
+    12299, 6270, 21407, 29692, 27969, 25172, 21407, 16819, 11585, 5906, 19266, 26722, 25172, 22654,
+    19266, 15137, 10426, 5315, 16384, 22725, 21407, 19266, 16384, 12873, 8867, 4520, 12873, 17855,
+    16819, 15137, 12873, 10114, 6967, 3552, 8867, 12299, 11585, 10426, 8867, 6967, 4799, 2446,
+    4520, 6270, 5906, 5315, 4520, 3552, 2446, 1247,
+];
+
 /// Returns the appropriate FDCT function for the given DCT method.
 pub fn select_fdct(method: crate::common::types::DctMethod) -> fn(&[i16; 64], &mut [i32; 64]) {
     match method {

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -61,11 +61,19 @@ pub fn compress(
     let chroma_quant =
         tables::quality_scale_quant_table(&tables::STD_CHROMINANCE_QUANT_TABLE, quality);
 
-    // The islow FDCT leaves a factor-of-8 scaling in its output. To absorb this,
-    // the divisor tables used during quantization multiply the quant values by 8,
-    // matching libjpeg-turbo's jcdctmgr.c (quantval[i] << 3).
-    let luma_divisors = scale_quant_for_fdct(&luma_quant);
-    let chroma_divisors = scale_quant_for_fdct(&chroma_quant);
+    // Divisor tables scale quant values for the chosen FDCT method.
+    // IsLow: multiply by 8 (islow leaves factor-of-8 in output).
+    // IsFast: multiply by AA&N scale factors (ifast_raw leaves AA&N-scaled output).
+    let luma_divisors = if dct_method == DctMethod::IsFast {
+        scale_quant_for_ifast(&luma_quant)
+    } else {
+        scale_quant_for_fdct(&luma_quant)
+    };
+    let chroma_divisors = if dct_method == DctMethod::IsFast {
+        scale_quant_for_ifast(&chroma_quant)
+    } else {
+        scale_quant_for_fdct(&chroma_quant)
+    };
 
     // Build Huffman tables
     let dc_luma_table = build_huff_table(&tables::DC_LUMINANCE_BITS, &tables::DC_LUMINANCE_VALUES);
@@ -95,14 +103,12 @@ pub fn compress(
     let mcus_x: usize = width.div_ceil(mcu_w);
     let mcus_y: usize = height.div_ceil(mcu_h);
 
-    // NEON fused FDCT+quantize for IsLow (the common case and only NEON-supported variant).
-    // IsFast/Float fall back to scalar fdct_islow — matches public API behavior.
-    let fdct_quantize_fn: fn(&mut [i16; 64], &QuantDivisors, &mut [i16; 64]) =
-        if dct_method == DctMethod::IsLow {
-            enc_simd.fdct_quantize
-        } else {
-            crate::simd::scalar::scalar_fdct_quantize
-        };
+    // Dispatch FDCT+quantize based on DCT method.
+    let fdct_quantize_fn: fn(&mut [i16; 64], &QuantDivisors, &mut [i16; 64]) = match dct_method {
+        DctMethod::IsLow => enc_simd.fdct_quantize,
+        DctMethod::IsFast => crate::simd::scalar::scalar_fdct_ifast_quantize,
+        DctMethod::Float => crate::simd::scalar::scalar_fdct_quantize,
+    };
 
     // Entropy encode all MCUs
     let mut bit_writer = BitWriter::new(width * height);
@@ -3833,12 +3839,54 @@ pub fn compute_reciprocal(divisor: u16) -> (u16, u16, u16, i16) {
     (recip as u16, corr, scale, shift)
 }
 
-/// Scale quantization table for the IFAST FDCT.
+/// Scale quantization table for the IFAST FDCT using AA&N scale factors.
 ///
-/// Currently delegates to `scale_quant_for_fdct` since our `fdct_ifast` rescales
-/// to islow-equivalent output. TODO(#163): use AA&N-scaled divisors with `fdct_ifast_raw`.
+/// Computes `DESCALE(quant[i] * aanscales[i], CONST_BITS - 3)` where
+/// `CONST_BITS = 14`, matching C libjpeg-turbo's `jcdctmgr.c` ifast divisor
+/// computation exactly. Paired with `fdct_ifast_raw` (no AA&N rescaling).
 fn scale_quant_for_ifast(quant_table: &[u16; 64]) -> QuantDivisors {
-    scale_quant_for_fdct(quant_table)
+    use crate::encode::fdct::AANSCALES;
+    let mut divisors = [0u16; 64];
+    let mut reciprocals = [0u16; 64];
+    let mut corrections = [0u16; 64];
+    let mut shifts = [0i16; 64];
+    let mut scales = [0u16; 64];
+    for i in 0..64 {
+        // DESCALE(quant * aanscale, 14 - 3) = (quant * aanscale + 1024) >> 11
+        let product: i64 = quant_table[i] as i64 * AANSCALES[i] as i64;
+        let d: u16 = ((product + (1i64 << 10)) >> 11) as u16;
+        divisors[i] = d;
+        let (recip, corr, scale, shift) = compute_reciprocal(d);
+        reciprocals[i] = recip;
+        corrections[i] = corr;
+        scales[i] = scale;
+        shifts[i] = shift;
+    }
+    let zigzag = &crate::encode::tables::ZIGZAG_ORDER;
+    let mut divisors_zigzag = [0u16; 64];
+    let mut reciprocals_zigzag = [0u16; 64];
+    let mut corrections_zigzag = [0u16; 64];
+    let mut shifts_zigzag = [0i16; 64];
+    let mut scales_zigzag = [0u16; 64];
+    for zz in 0..64 {
+        divisors_zigzag[zz] = divisors[zigzag[zz]];
+        reciprocals_zigzag[zz] = reciprocals[zigzag[zz]];
+        corrections_zigzag[zz] = corrections[zigzag[zz]];
+        shifts_zigzag[zz] = shifts[zigzag[zz]];
+        scales_zigzag[zz] = scales[zigzag[zz]];
+    }
+    QuantDivisors {
+        divisors,
+        reciprocals,
+        corrections,
+        shifts,
+        scales,
+        divisors_zigzag,
+        reciprocals_zigzag,
+        corrections_zigzag,
+        shifts_zigzag,
+        scales_zigzag,
+    }
 }
 
 /// Scale quantization table values by 8 to create divisor table for the islow FDCT.
@@ -4621,9 +4669,21 @@ fn encode_single_block(
 ) {
     let mut quantized = [0i16; 64];
 
+    // The fused SIMD path uses islow FDCT internally. Skip it for ifast/float
+    // so the caller-provided fdct_quantize_fn (with correct divisors) is used.
+    let is_ifast: bool = std::ptr::eq(
+        fdct_quantize_fn as *const (),
+        crate::simd::scalar::scalar_fdct_ifast_quantize as *const (),
+    );
+    let is_float: bool = std::ptr::eq(
+        fdct_quantize_fn as *const (),
+        crate::simd::scalar::scalar_fdct_quantize as *const (),
+    );
+    let use_fused_simd: bool = !is_ifast && !is_float;
+
     // Fused path for interior blocks: load u8 → FDCT → quantize → zigzag
     // without intermediate [i16; 64] buffer between extract and FDCT.
-    if block_x + 8 <= plane_width && block_y + 8 <= plane_height {
+    if use_fused_simd && block_x + 8 <= plane_width && block_y + 8 <= plane_height {
         #[cfg(target_arch = "aarch64")]
         {
             unsafe {
@@ -4668,24 +4728,11 @@ fn encode_single_block(
             }
         }
 
-        #[cfg(target_arch = "aarch64")]
-        {
-            unsafe {
-                crate::simd::aarch64::neon_extract_fdct_quantize(
-                    local_buf.as_ptr(),
-                    8,
-                    quant_table,
-                    &mut quantized,
-                );
-            }
-            HuffmanEncoder::encode_block(writer, &quantized, prev_dc, dc_table, ac_table);
-            return;
-        }
-        #[cfg(target_arch = "x86_64")]
-        {
-            if is_x86_feature_detected!("avx2") {
+        if use_fused_simd {
+            #[cfg(target_arch = "aarch64")]
+            {
                 unsafe {
-                    crate::simd::x86_64::avx2_extract_fdct_quantize(
+                    crate::simd::aarch64::neon_extract_fdct_quantize(
                         local_buf.as_ptr(),
                         8,
                         quant_table,
@@ -4695,11 +4742,26 @@ fn encode_single_block(
                 HuffmanEncoder::encode_block(writer, &quantized, prev_dc, dc_table, ac_table);
                 return;
             }
+            #[cfg(target_arch = "x86_64")]
+            {
+                if is_x86_feature_detected!("avx2") {
+                    unsafe {
+                        crate::simd::x86_64::avx2_extract_fdct_quantize(
+                            local_buf.as_ptr(),
+                            8,
+                            quant_table,
+                            &mut quantized,
+                        );
+                    }
+                    HuffmanEncoder::encode_block(writer, &quantized, prev_dc, dc_table, ac_table);
+                    return;
+                }
+            }
         }
     }
 
-    // Fallback for border blocks (non-SIMD) or interior blocks without AVX2:
-    // use extract_block + fdct_quantize_fn
+    // Generic path: extract block + caller-provided FDCT+quantize.
+    // Used for ifast, float, and non-SIMD fallback.
     let mut block = [0i16; 64];
     extract_block(
         plane,
@@ -5802,10 +5864,21 @@ fn encode_downsampled_chroma_block(
     prev_dc: &mut i16,
     fdct_quantize_fn: fn(&mut [i16; 64], &QuantDivisors, &mut [i16; 64]),
 ) {
+    // The fused SIMD paths use islow FDCT; skip for ifast/float.
+    let is_ifast: bool = std::ptr::eq(
+        fdct_quantize_fn as *const (),
+        crate::simd::scalar::scalar_fdct_ifast_quantize as *const (),
+    );
+    let is_float: bool = std::ptr::eq(
+        fdct_quantize_fn as *const (),
+        crate::simd::scalar::scalar_fdct_quantize as *const (),
+    );
+    let use_fused_simd: bool = !is_ifast && !is_float;
+
     // Fused NEON path: downsample + FDCT + quantize + zigzag in one pass,
     // eliminating the intermediate [i16; 64] downsampled block.
     #[cfg(target_arch = "aarch64")]
-    {
+    if use_fused_simd {
         let src_w: usize = 8 * h_factor;
         let src_h: usize = 8 * v_factor;
         if block_x + src_w <= plane_width && block_y + src_h <= plane_height {
@@ -5841,7 +5914,7 @@ fn encode_downsampled_chroma_block(
 
     // x86_64 fused path: AVX2 downsample+FDCT+quantize+zigzag
     #[cfg(target_arch = "x86_64")]
-    {
+    if use_fused_simd {
         let src_w: usize = 8 * h_factor;
         let src_h: usize = 8 * v_factor;
         if is_x86_feature_detected!("avx2")
@@ -5893,41 +5966,13 @@ fn encode_downsampled_chroma_block(
     }
 
     // Try NEON/AVX2 fused downsample+FDCT+quantize on the padded local buffer
-    #[cfg(target_arch = "aarch64")]
-    {
-        let mut quantized = [0i16; 64];
-        if h_factor == 2 && v_factor == 2 {
-            unsafe {
-                crate::simd::aarch64::neon_downsample_h2v2_fdct_quantize(
-                    local_buf.as_ptr(),
-                    src_w,
-                    quant_table,
-                    &mut quantized,
-                );
-            }
-            HuffmanEncoder::encode_block(writer, &quantized, prev_dc, dc_table, ac_table);
-            return;
-        }
-        if h_factor == 2 && v_factor == 1 {
-            unsafe {
-                crate::simd::aarch64::neon_downsample_h2v1_fdct_quantize(
-                    local_buf.as_ptr(),
-                    src_w,
-                    quant_table,
-                    &mut quantized,
-                );
-            }
-            HuffmanEncoder::encode_block(writer, &quantized, prev_dc, dc_table, ac_table);
-            return;
-        }
-    }
-    #[cfg(target_arch = "x86_64")]
-    {
-        if is_x86_feature_detected!("avx2") {
+    if use_fused_simd {
+        #[cfg(target_arch = "aarch64")]
+        {
             let mut quantized = [0i16; 64];
             if h_factor == 2 && v_factor == 2 {
                 unsafe {
-                    crate::simd::x86_64::avx2_downsample_h2v2_fdct_quantize(
+                    crate::simd::aarch64::neon_downsample_h2v2_fdct_quantize(
                         local_buf.as_ptr(),
                         src_w,
                         quant_table,
@@ -5939,7 +5984,7 @@ fn encode_downsampled_chroma_block(
             }
             if h_factor == 2 && v_factor == 1 {
                 unsafe {
-                    crate::simd::x86_64::avx2_downsample_h2v1_fdct_quantize(
+                    crate::simd::aarch64::neon_downsample_h2v1_fdct_quantize(
                         local_buf.as_ptr(),
                         src_w,
                         quant_table,
@@ -5948,6 +5993,36 @@ fn encode_downsampled_chroma_block(
                 }
                 HuffmanEncoder::encode_block(writer, &quantized, prev_dc, dc_table, ac_table);
                 return;
+            }
+        }
+        #[cfg(target_arch = "x86_64")]
+        {
+            if is_x86_feature_detected!("avx2") {
+                let mut quantized = [0i16; 64];
+                if h_factor == 2 && v_factor == 2 {
+                    unsafe {
+                        crate::simd::x86_64::avx2_downsample_h2v2_fdct_quantize(
+                            local_buf.as_ptr(),
+                            src_w,
+                            quant_table,
+                            &mut quantized,
+                        );
+                    }
+                    HuffmanEncoder::encode_block(writer, &quantized, prev_dc, dc_table, ac_table);
+                    return;
+                }
+                if h_factor == 2 && v_factor == 1 {
+                    unsafe {
+                        crate::simd::x86_64::avx2_downsample_h2v1_fdct_quantize(
+                            local_buf.as_ptr(),
+                            src_w,
+                            quant_table,
+                            &mut quantized,
+                        );
+                    }
+                    HuffmanEncoder::encode_block(writer, &quantized, prev_dc, dc_table, ac_table);
+                    return;
+                }
             }
         }
     }

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -2152,8 +2152,13 @@ fn compress_progressive_with_scans(
     };
 
     // FDCT + quantize all blocks into coefficient buffers.
-    // In progressive mode, ALL blocks are FDCT'd including edge blocks
-    // (extract_block replicates edge pixels). No dummy block skipping.
+    // For blocks beyond width_in_blocks or height_in_blocks, C libjpeg-turbo
+    // creates "dummy" blocks (all AC=0, DC=previous block's DC) instead of
+    // FDCT'ing edge-replicated pixels (jccoefct.c lines 184-200).
+    let y_wib: usize = comp_wib[0];
+    let y_hib: usize = comp_hib[0];
+    let mut prev_dc_y_prog: i16 = 0;
+
     for mcu_y in 0..mcus_y {
         for mcu_x in 0..mcus_x {
             let x0: usize = mcu_x * mcu_w;
@@ -2162,17 +2167,22 @@ fn compress_progressive_with_scans(
             if is_grayscale {
                 let bx: usize = mcu_x;
                 let by: usize = mcu_y;
-                progressive_fdct_y_block(
-                    &y_plane,
-                    width,
-                    height,
-                    x0,
-                    y0,
-                    &luma_divisors,
-                    fdct_quantize_fn,
-                    &mut coeff_bufs[0][by * mcus_x + bx],
-                    use_simd_fdct,
-                );
+                if is_y_dummy(x0, y0, y_wib, y_hib) {
+                    coeff_bufs[0][by * mcus_x + bx][0] = prev_dc_y_prog;
+                } else {
+                    progressive_fdct_y_block(
+                        &y_plane,
+                        width,
+                        height,
+                        x0,
+                        y0,
+                        &luma_divisors,
+                        fdct_quantize_fn,
+                        &mut coeff_bufs[0][by * mcus_x + bx],
+                        use_simd_fdct,
+                    );
+                    prev_dc_y_prog = coeff_bufs[0][by * mcus_x + bx][0];
+                }
             } else {
                 // Y blocks
                 let blocks_x: usize = comp_layouts[0].blocks_x;
@@ -2180,17 +2190,22 @@ fn compress_progressive_with_scans(
                     for bh in 0..h_samp {
                         let bx: usize = mcu_x * h_samp + bh;
                         let by: usize = mcu_y * v_samp + bv;
-                        progressive_fdct_y_block(
-                            &y_plane,
-                            width,
-                            height,
-                            x0 + bh * 8,
-                            y0 + bv * 8,
-                            &luma_divisors,
-                            fdct_quantize_fn,
-                            &mut coeff_bufs[0][by * blocks_x + bx],
-                            use_simd_fdct,
-                        );
+                        if is_y_dummy(x0 + bh * 8, y0 + bv * 8, y_wib, y_hib) {
+                            coeff_bufs[0][by * blocks_x + bx][0] = prev_dc_y_prog;
+                        } else {
+                            progressive_fdct_y_block(
+                                &y_plane,
+                                width,
+                                height,
+                                x0 + bh * 8,
+                                y0 + bv * 8,
+                                &luma_divisors,
+                                fdct_quantize_fn,
+                                &mut coeff_bufs[0][by * blocks_x + bx],
+                                use_simd_fdct,
+                            );
+                            prev_dc_y_prog = coeff_bufs[0][by * blocks_x + bx][0];
+                        }
                     }
                 }
                 // Cb/Cr blocks
@@ -2428,6 +2443,7 @@ fn compress_progressive_with_scans(
             let ss_enc: usize = scan.ss as usize;
             let se_enc: usize = scan.se as usize;
             if scan.ah == 0 {
+                let mut eobrun: u32 = 0;
                 for block in actual_blocks.iter() {
                     encode_ac_first_block(
                         block,
@@ -2436,9 +2452,14 @@ fn compress_progressive_with_scans(
                         scan.al,
                         &ac_table,
                         &mut bit_writer,
+                        &mut eobrun,
                     );
                 }
+                if eobrun > 0 {
+                    emit_eobrun(&ac_table, &mut bit_writer, &mut eobrun);
+                }
             } else {
+                let mut eobrun: u32 = 0;
                 for block in actual_blocks.iter() {
                     encode_ac_refine_block(
                         block,
@@ -2447,8 +2468,12 @@ fn compress_progressive_with_scans(
                         scan.al,
                         &ac_table,
                         &mut bit_writer,
+                        &mut eobrun,
                     );
                 }
+                // Note: refine EOBRUN with correction-bit buffering not yet
+                // implemented — each block emits its own EOB inline.
+                let _ = eobrun;
             }
             bit_writer.flush();
             output.extend_from_slice(bit_writer.data());
@@ -2469,9 +2494,9 @@ fn gather_progressive_ac_freq(blocks: &[[i16; 64]], ss: u8, se: u8, al: u8, freq
     let ss_usize: usize = ss as usize;
     let se_usize: usize = se as usize;
     let band_len: usize = se_usize - ss_usize + 1;
+    let mut eobrun: u32 = 0;
 
     for block in blocks.iter() {
-        // Apply point transform and find nonzero positions, matching encode_ac_first_block.
         let mut zerobits: u64 = 0;
         let mut values = [0u16; 64];
 
@@ -2491,9 +2516,19 @@ fn gather_progressive_ac_freq(blocks: &[[i16; 64]], ss: u8, se: u8, al: u8, freq
         }
 
         if zerobits == 0 {
-            // EOB symbol
-            freq[0x00] += 1;
+            // Accumulate EOBRUN instead of emitting individual EOB
+            eobrun += 1;
+            if eobrun == 0x7FFF {
+                emit_eobrun_freq(eobrun, freq);
+                eobrun = 0;
+            }
             continue;
+        }
+
+        // Flush pending EOBRUN before encoding nonzero coefficients
+        if eobrun > 0 {
+            emit_eobrun_freq(eobrun, freq);
+            eobrun = 0;
         }
 
         let mut prev_pos: usize = 0;
@@ -2514,9 +2549,27 @@ fn gather_progressive_ac_freq(blocks: &[[i16; 64]], ss: u8, se: u8, al: u8, freq
         }
 
         if prev_pos < band_len {
-            freq[0x00] += 1; // EOB
+            // Trailing zeros → start EOBRUN
+            eobrun += 1;
+            if eobrun == 0x7FFF {
+                emit_eobrun_freq(eobrun, freq);
+                eobrun = 0;
+            }
         }
     }
+
+    // Flush any remaining EOBRUN at end of scan
+    if eobrun > 0 {
+        emit_eobrun_freq(eobrun, freq);
+    }
+}
+
+/// Emit EOBRUN symbol frequency: nbits = JPEG_NBITS(eobrun) - 1, symbol = nbits << 4.
+/// Matches C libjpeg-turbo's emit_eobrun in jcphuff.c.
+fn emit_eobrun_freq(eobrun: u32, freq: &mut [u32; 257]) {
+    let nbits: u8 = (32 - eobrun.leading_zeros()) as u8 - 1; // JPEG_NBITS_NONZERO - 1
+    let symbol: usize = (nbits as usize) << 4;
+    freq[symbol] += 1;
 }
 
 /// Gather AC symbol frequencies for a progressive AC refinement scan (ah > 0).
@@ -2535,9 +2588,8 @@ fn gather_progressive_ac_refine_freq(
     let band_len: usize = se_usize - ss_usize + 1;
 
     for block in blocks.iter() {
-        // Pre-pass: compute absvals and find EOB position (last newly-nonzero coeff).
         let mut absvals = [0u16; 64];
-        let mut eob: usize = 0;
+        let mut eob_pos: usize = 0;
 
         for i in 0..band_len {
             let coeff: i32 = block[ss_usize + i] as i32;
@@ -2546,12 +2598,10 @@ fn gather_progressive_ac_refine_freq(
             let temp: u16 = (abs_coeff >> al) as u16;
             absvals[i] = temp;
             if temp == 1 {
-                eob = i + 1;
+                eob_pos = i + 1;
             }
         }
 
-        // Main gather loop matching encode_ac_refine_block symbol emission.
-        // Track corr_count to match the encoder's `corr_len > 0` EOB condition.
         let mut r: usize = 0;
         let mut corr_count: usize = 0;
         let mut idx: usize = 0;
@@ -2565,21 +2615,18 @@ fn gather_progressive_ac_refine_freq(
                 continue;
             }
 
-            // Emit ZRL symbols for runs that exceed 15, but not if they fold into EOB.
-            while r > 15 && idx < eob {
-                freq[0xF0] += 1; // ZRL
+            while r > 15 && idx < eob_pos {
+                freq[0xF0] += 1;
                 r -= 16;
-                corr_count = 0; // flush_corr_bits resets corr_len in encoder
+                corr_count = 0;
             }
 
             if temp > 1 {
-                // Previously-nonzero: emits a correction bit (no Huffman symbol).
                 corr_count += 1;
                 idx += 1;
                 continue;
             }
 
-            // temp == 1: newly-nonzero — emits (r, 1) symbol + flush correction bits.
             let symbol: usize = (r << 4) | 1;
             freq[symbol] += 1;
             r = 0;
@@ -2588,7 +2635,9 @@ fn gather_progressive_ac_refine_freq(
         }
 
         if r > 0 || corr_count > 0 {
-            freq[0x00] += 1; // EOB
+            // No EOBRUN batching for refine scans yet — matches encoder behavior.
+            // TODO(#163): implement cross-block correction-bit buffering for EOBRUN.
+            freq[0x00] += 1;
         }
     }
 }
@@ -3495,13 +3544,19 @@ fn encode_progressive_ac_scan(
     // Non-interleaved AC scans iterate blocks in raster order within the component.
     let blocks: &[[i16; 64]] = &coeff_bufs[ci];
     if ah == 0 {
+        let mut eobrun: u32 = 0;
         for block in blocks.iter() {
-            encode_ac_first_block(block, ss, se, al, ac_table, writer);
+            encode_ac_first_block(block, ss, se, al, ac_table, writer, &mut eobrun);
+        }
+        if eobrun > 0 {
+            emit_eobrun(ac_table, writer, &mut eobrun);
         }
     } else {
+        let mut eobrun: u32 = 0;
         for block in blocks.iter() {
-            encode_ac_refine_block(block, ss, se, al, ac_table, writer);
+            encode_ac_refine_block(block, ss, se, al, ac_table, writer, &mut eobrun);
         }
+        let _ = eobrun;
     }
 }
 
@@ -3517,13 +3572,13 @@ fn encode_ac_first_block(
     al: u8,
     ac_table: &HuffTable,
     writer: &mut BitWriter,
+    eobrun: &mut u32,
 ) {
     let band_len: usize = se - ss + 1;
 
-    // Pre-compute: apply point transform, build nonzero bitmap, store values/diffs
-    let mut values = [0u16; 64]; // abs(coeff) >> al
-    let mut diffs = [0u16; 64]; // magnitude bits (one's complement for negative)
-    let mut zerobits: u64 = 0; // bit set = nonzero after transform
+    let mut values = [0u16; 64];
+    let mut diffs = [0u16; 64];
+    let mut zerobits: u64 = 0;
 
     for i in 0..band_len {
         let coeff: i16 = block[ss + i];
@@ -3542,11 +3597,19 @@ fn encode_ac_first_block(
     }
 
     if zerobits == 0 {
-        writer.put_bits(ac_table.ehufco[0x00] as u32, ac_table.ehufsi[0x00]);
+        // Accumulate EOBRUN
+        *eobrun += 1;
+        if *eobrun == 0x7FFF {
+            emit_eobrun(ac_table, writer, eobrun);
+        }
         return;
     }
 
-    // Pre-compute nbits for all nonzero positions
+    // Flush pending EOBRUN before encoding nonzero coefficients
+    if *eobrun > 0 {
+        emit_eobrun(ac_table, writer, eobrun);
+    }
+
     let mut nbits_arr = [0u8; 64];
     {
         let mut bits: u64 = zerobits;
@@ -3557,7 +3620,6 @@ fn encode_ac_first_block(
         }
     }
 
-    // Encode using bitmap to skip directly to nonzero coefficients
     let mut prev_pos: usize = 0;
 
     while zerobits != 0 {
@@ -3572,7 +3634,6 @@ fn encode_ac_first_block(
 
         let nbits: u8 = nbits_arr[pos];
         let symbol: usize = (zero_run << 4) | (nbits as usize);
-        // Combine Huffman code + magnitude bits into single put_bits call
         let huff_code: u32 = ac_table.ehufco[symbol] as u32;
         let huff_size: u8 = ac_table.ehufsi[symbol];
         let mag_masked: u32 = diffs[pos] as u32 & ((1u32 << nbits) - 1);
@@ -3582,8 +3643,30 @@ fn encode_ac_first_block(
     }
 
     if prev_pos < band_len {
-        writer.put_bits(ac_table.ehufco[0x00] as u32, ac_table.ehufsi[0x00]);
+        // Trailing zeros → accumulate EOBRUN
+        *eobrun += 1;
+        if *eobrun == 0x7FFF {
+            emit_eobrun(ac_table, writer, eobrun);
+        }
     }
+}
+
+/// Emit buffered EOBRUN to the bitstream. Matches C's emit_eobrun in jcphuff.c.
+fn emit_eobrun(ac_table: &HuffTable, writer: &mut BitWriter, eobrun: &mut u32) {
+    if *eobrun == 0 {
+        return;
+    }
+    let nbits: u8 = (32 - (*eobrun).leading_zeros()) as u8 - 1;
+    let symbol: usize = (nbits as usize) << 4;
+    let huff_code: u32 = ac_table.ehufco[symbol] as u32;
+    let huff_size: u8 = ac_table.ehufsi[symbol];
+    if nbits > 0 {
+        let combined: u32 = (huff_code << nbits) | (*eobrun as u32 & ((1u32 << nbits) - 1));
+        writer.put_bits(combined, huff_size + nbits);
+    } else {
+        writer.put_bits(huff_code, huff_size);
+    }
+    *eobrun = 0;
 }
 
 /// Flush buffered correction bits. Handles >32 bits by splitting into two put_bits calls.
@@ -3617,35 +3700,29 @@ fn encode_ac_refine_block(
     al: u8,
     ac_table: &HuffTable,
     writer: &mut BitWriter,
+    _eobrun: &mut u32,
 ) {
     let band_len: usize = se - ss + 1;
 
-    // Pre-pass: compute absolute shifted values and find EOB position.
-    // Matches C's encode_mcu_AC_refine_prepare / COMPUTE_ABSVALUES_AC_REFINE.
     let mut absvals = [0u16; 64];
     let mut sign_bits = [0u16; 64];
-    let mut eob: usize = 0; // index past last newly-nonzero coeff (0 = no newly-nonzero)
+    let mut eob_pos: usize = 0;
 
     for i in 0..band_len {
         let coeff: i32 = block[ss + i] as i32;
-        // Compute absolute value via sign-mask trick (matches C's portable abs)
         let sign_mask: i32 = coeff >> 31;
         let abs_coeff: i32 = (coeff ^ sign_mask) - sign_mask;
         let temp: u16 = (abs_coeff >> al) as u16;
         absvals[i] = temp;
-        // sign bit: 1 = positive (sign_mask=0 -> 0+1=1), 0 = negative (sign_mask=-1 -> -1+1=0)
         sign_bits[i] = (sign_mask as u16).wrapping_add(1);
         if temp == 1 {
-            eob = i + 1; // EOB = index+1 of last newly-nonzero coef
+            eob_pos = i + 1;
         }
     }
 
-    // Main loop: matches C's ENCODE_COEFS_AC_REFINE.
-    // Correction bits for previously-nonzero coefficients are packed into a u64
-    // accumulator and flushed via put_bits (max 32 bits per call).
     let mut r: usize = 0;
-    let mut corr_bits: u64 = 0; // packed correction bits (MSB-first)
-    let mut corr_len: u8 = 0; // number of buffered correction bits (max 63)
+    let mut corr_bits: u64 = 0;
+    let mut corr_len: u8 = 0;
     let mut idx: usize = 0;
 
     while idx < band_len {
@@ -3657,8 +3734,7 @@ fn encode_ac_refine_block(
             continue;
         }
 
-        // Emit any required ZRLs, but not if they can be folded into EOB.
-        while r > 15 && idx < eob {
+        while r > 15 && idx < eob_pos {
             writer.put_bits(ac_table.ehufco[0xF0] as u32, ac_table.ehufsi[0xF0]);
             r -= 16;
             flush_corr_bits(writer, &mut corr_bits, &mut corr_len);
@@ -3671,9 +3747,7 @@ fn encode_ac_refine_block(
             continue;
         }
 
-        // temp == 1: newly-nonzero coefficient
         let symbol: usize = (r << 4) | 1;
-        // Combine Huffman symbol + sign bit into single put_bits
         let huff_code: u32 = ac_table.ehufco[symbol] as u32;
         let huff_size: u8 = ac_table.ehufsi[symbol];
         let combined: u32 = (huff_code << 1) | sign_bits[idx] as u32;
@@ -3684,6 +3758,9 @@ fn encode_ac_refine_block(
     }
 
     if r > 0 || corr_len > 0 {
+        // AC refine EOBRUN with correction-bit buffering is complex;
+        // for now emit individual EOB + correction bits per block.
+        // TODO(#163): implement cross-block correction-bit buffering for full EOBRUN parity.
         writer.put_bits(ac_table.ehufco[0x00] as u32, ac_table.ehufsi[0x00]);
         flush_corr_bits(writer, &mut corr_bits, &mut corr_len);
     }

--- a/src/simd/scalar.rs
+++ b/src/simd/scalar.rs
@@ -63,7 +63,7 @@ fn scalar_fancy_upsample_h2v1(input: &[u8], in_width: usize, output: &mut [u8]) 
 
 // --- Encoder dispatch ---
 
-use crate::encode::{color as enc_color, fdct, quant};
+use crate::encode::{color as enc_color, fdct};
 use crate::simd::{EncoderSimdRoutines, QuantDivisors};
 
 /// Return scalar encoder dispatch table.
@@ -87,7 +87,7 @@ fn scalar_rgb_to_ycbcr_row_enc(
 
 /// Scalar fused FDCT (islow) + quantize + zigzag reorder.
 ///
-/// Calls `fdct_islow` (output i32) then `quantize_block` (zigzag reorder included).
+/// Calls `fdct_islow` (output i32) then reciprocal-based quantization matching C.
 pub(crate) fn scalar_fdct_quantize(
     input: &mut [i16; 64],
     quant: &QuantDivisors,
@@ -95,19 +95,49 @@ pub(crate) fn scalar_fdct_quantize(
 ) {
     let mut dct_output: [i32; 64] = [0i32; 64];
     fdct::fdct_islow(input, &mut dct_output);
-    quant::quantize_block(&dct_output, &quant.divisors, output);
+    quantize_reciprocal(&dct_output, quant, output);
 }
 
 /// Scalar fused FDCT (ifast) + quantize + zigzag reorder.
 ///
-/// Uses `fdct_ifast` which rescales to islow-equivalent output.
-/// TODO(#163): switch to `fdct_ifast_raw` + `scale_quant_for_ifast` for true ifast parity.
+/// Uses `fdct_ifast_raw` (no AA&N rescaling) paired with AA&N-scaled divisors
+/// from `scale_quant_for_ifast`, matching C libjpeg-turbo's ifast path exactly.
 pub(crate) fn scalar_fdct_ifast_quantize(
     input: &mut [i16; 64],
     quant: &QuantDivisors,
     output: &mut [i16; 64],
 ) {
     let mut dct_output: [i32; 64] = [0i32; 64];
-    fdct::fdct_ifast(input, &mut dct_output);
-    quant::quantize_block(&dct_output, &quant.divisors, output);
+    fdct::fdct_ifast_raw(input, &mut dct_output);
+    quantize_reciprocal(&dct_output, quant, output);
+}
+
+/// Scalar reciprocal-based quantization matching C libjpeg-turbo's `quantize()`.
+///
+/// Uses pre-computed reciprocal, correction, and shift from `compute_reciprocal`
+/// to avoid scalar division. Produces identical results to C's SIMD quantization.
+///
+/// Algorithm: `result = sign(coeff) * ((abs(coeff) + correction) * reciprocal >> 16 >> shift)`
+fn quantize_reciprocal(coeffs: &[i32; 64], quant: &QuantDivisors, output: &mut [i16; 64]) {
+    let zigzag = &crate::encode::tables::ZIGZAG_ORDER;
+    for zz in 0..64 {
+        let natural_idx: usize = zigzag[zz];
+        // C's quantize() operates on DCTELEM (i16) workspace values
+        let coeff: i16 = coeffs[natural_idx] as i16;
+        let recip: u32 = quant.reciprocals[natural_idx] as u32;
+        let corr: u32 = quant.corrections[natural_idx] as u32;
+        // C uses signed int for shift: shift + sizeof(DCTELEM)*8 = shift + 16
+        let total_shift: i32 = quant.shifts[natural_idx] as i32 + 16;
+
+        if coeff < 0 {
+            let temp: u32 = (-coeff as i32) as u32;
+            let product: u32 = (temp.wrapping_add(corr)).wrapping_mul(recip);
+            let result: i16 = (product >> total_shift as u32) as i16;
+            output[zz] = -result;
+        } else {
+            let temp: u32 = coeff as u32;
+            let product: u32 = (temp.wrapping_add(corr)).wrapping_mul(recip);
+            output[zz] = (product >> total_shift as u32) as i16;
+        };
+    }
 }

--- a/tests/c_cjpeg_djpeg_tests.rs
+++ b/tests/c_cjpeg_djpeg_tests.rs
@@ -222,7 +222,7 @@ fn c_cjpeg_440_islow() {
 /// CMakeLists line 1604: cjpeg 420-q100-ifast-prog
 /// -sample 2x2 -quality 100 -dct fast -scans test.scan  testorig.ppm → JPEG
 #[test]
-#[ignore = "ifast FDCT+quantize correct (decoded pixels identical), but progressive Huffman optimization produces slightly different tables — 6 byte difference"]
+#[ignore = "decoded pixels identical; AC refine scans lack EOBRUN batching (correction-bit buffering needed)"]
 fn c_cjpeg_420_q100_ifast_prog() {
     let cjpeg = match helpers::cjpeg_path() {
         Some(p) => p,

--- a/tests/c_cjpeg_djpeg_tests.rs
+++ b/tests/c_cjpeg_djpeg_tests.rs
@@ -222,7 +222,7 @@ fn c_cjpeg_440_islow() {
 /// CMakeLists line 1604: cjpeg 420-q100-ifast-prog
 /// -sample 2x2 -quality 100 -dct fast -scans test.scan  testorig.ppm → JPEG
 #[test]
-#[ignore = "WIP"]
+#[ignore = "ifast FDCT+quantize correct (decoded pixels identical), but progressive Huffman optimization produces slightly different tables — 6 byte difference"]
 fn c_cjpeg_420_q100_ifast_prog() {
     let cjpeg = match helpers::cjpeg_path() {
         Some(p) => p,

--- a/tests/reference_hashes.json
+++ b/tests/reference_hashes.json
@@ -4,7 +4,7 @@
     "baseline_64x64_q75_444": "6e87a2dc49a4d734",
     "baseline_64x64_q50_420": "8ed9505bff068343",
     "baseline_64x64_q100_420": "98be41b0ad4fb9b7",
-    "progressive_64x64_q75_444": "9ec50c26810271a8",
+    "progressive_64x64_q75_444": "fe3d7f5aa43dce96",
     "arithmetic_64x64_q75_420": "357056affabbb463",
     "arithmetic_progressive_64x64_q75_444": "6a83a0403ea734c7",
     "lossless_64x64_gray": "4a855cdf21a29695",


### PR DESCRIPTION
## Summary
- Wire `fdct_ifast_raw` + AA&N-scaled divisors for true ifast encoding parity with C libjpeg-turbo
- Fix baseline `compress()` to use correct FDCT dispatch and divisor scaling for `DctMethod::IsFast`
- Gate fused SIMD paths (`encode_single_block`, `encode_downsampled_chroma_block`) to skip islow FDCT for ifast/float
- Add scalar reciprocal-based quantization matching C's `quantize()` algorithm
- Add EOBRUN batching for progressive AC first scans (matching C's `jcphuff.c`)
- Add C-matching dummy block handling for edge/padding blocks in progressive coefficient buffer

## Result
- **Baseline ifast**: byte-identical to C `cjpeg`
- **Progressive ifast**: decoded pixels identical, all 9 DHT tables match, 7/8 scan segments byte-identical
- **Remaining**: AC refine scans (1/8) lack cross-block correction-bit buffering for EOBRUN — follow-up PR

## Test plan
- [x] Grayscale 8×8 baseline ifast: byte-identical to C
- [x] `c_cjpeg_422_islow_opt`: passes (no regression)
- [x] `c_cjpeg_420s_islow_opt`: passes (no regression)
- [x] `c_cjpeg_420_q100_ifast_prog`: decoded pixels identical (ignore updated)
- [x] `regression_check_reference_hashes`: updated hash for progressive
- [x] Full test suite: only pre-existing crop_c_compat failures

Related: #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)