### PR TITLE
fix: route to optimized encoder when smoothing_factor > 0

### DIFF
--- a/src/api/encoder.rs
+++ b/src/api/encoder.rs
@@ -795,6 +795,18 @@ impl<'a> Encoder<'a> {
                 self.subsampling,
                 restart_interval,
             )?
+        } else if self.smoothing_factor > 0 {
+            // Smoothing requires full-plane buffering, only available in the
+            // optimized path. Route there when smoothing is requested.
+            encoder::compress_optimized(
+                effective_pixels,
+                self.width,
+                self.height,
+                effective_format,
+                quality,
+                self.subsampling,
+                self.smoothing_factor,
+            )?
         } else {
             encoder::compress(
                 effective_pixels,


### PR DESCRIPTION
## Summary
- Fix `smoothing_factor` being silently ignored in the default encoder path
- The default `compress` uses single-pass streaming with no smoothing support
- When `smoothing_factor > 0`, route to `compress_optimized` which buffers full planes and applies the smoothing filter

## Test plan
- [x] `smoothing_factor_changes_output` — previously failed, now passes
- [x] All 16 `niche_options` tests pass
- [x] Full test suite passes (conformance flakes are pre-existing)
- [x] `cargo clippy` and `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)