### PR TITLE
fix: update tj3_handle scaling factor tests to match all 16 IDCT scales

### DIFF
--- a/src/api/tj3.rs
+++ b/src/api/tj3.rs
@@ -302,7 +302,7 @@ impl TjHandle {
 
     /// Set scaling factor for decompression.
     ///
-    /// Only the standard JPEG scaling factors are supported: 1/1, 1/2, 1/4, 1/8.
+    /// Supports all 16 JPEG IDCT scaling factors from 1/8 to 2/1.
     pub fn set_scaling_factor(&mut self, num: u32, denom: u32) -> Result<()> {
         let valid = Self::scaling_factors();
         if !valid.contains(&(num, denom)) {

--- a/tests/tj3_handle.rs
+++ b/tests/tj3_handle.rs
@@ -187,15 +187,19 @@ fn handle_icc_profile() {
 #[test]
 fn handle_scaling_factor() {
     let mut handle = TjHandle::new();
-    // Valid scaling factors
+    // Valid scaling factors (standard JPEG IDCT scales)
     handle.set_scaling_factor(1, 1).unwrap();
     handle.set_scaling_factor(1, 2).unwrap();
     handle.set_scaling_factor(1, 4).unwrap();
     handle.set_scaling_factor(1, 8).unwrap();
+    handle.set_scaling_factor(2, 1).unwrap();
+    handle.set_scaling_factor(3, 2).unwrap();
+    handle.set_scaling_factor(3, 4).unwrap();
+    handle.set_scaling_factor(3, 8).unwrap();
     // Invalid scaling factor
     assert!(handle.set_scaling_factor(1, 3).is_err());
     assert!(handle.set_scaling_factor(0, 1).is_err());
-    assert!(handle.set_scaling_factor(2, 1).is_err());
+    assert!(handle.set_scaling_factor(4, 1).is_err());
 }
 
 #[test]
@@ -218,7 +222,7 @@ fn handle_scaling_factors_list() {
     assert!(factors.contains(&(1, 2)));
     assert!(factors.contains(&(1, 4)));
     assert!(factors.contains(&(1, 8)));
-    assert_eq!(factors.len(), 4);
+    assert_eq!(factors.len(), 16);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- TjHandle API supports all 16 JPEG IDCT scaling factors (1/8 to 2/1), matching C libjpeg-turbo
- Tests incorrectly expected only 4 factors and rejected valid upscale factors like 2/1
- Update tests to expect 16 factors and accept all valid IDCT scales
- Fix docstring on `set_scaling_factor` to reflect full range

## Test plan
- [x] All 30 `tj3_handle` tests pass
- [x] `cargo clippy` and `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)