### PR TITLE
fix: correct x86_64 chroma downsample bias in fused AVX2 encode

### DIFF
--- a/src/simd/x86_64/mod.rs
+++ b/src/simd/x86_64/mod.rs
@@ -139,7 +139,7 @@ pub(crate) unsafe fn avx2_downsample_h2v2_fdct_quantize(
     use core::arch::x86_64::*;
 
     let ones: __m128i = _mm_set1_epi8(1);
-    let bias: __m128i = _mm_set1_epi16(2); // rounding for divide-by-4
+    let bias: __m128i = _mm_set_epi16(2, 1, 2, 1, 2, 1, 2, 1); // alternating rounding bias for divide-by-4
     let level_shift: __m128i = _mm_set1_epi16(128);
 
     // Downsample 8 pairs of rows → 8 output rows (each 8 i16)
@@ -200,7 +200,7 @@ pub(crate) unsafe fn avx2_downsample_h2v1_fdct_quantize(
     use core::arch::x86_64::*;
 
     let ones: __m128i = _mm_set1_epi8(1);
-    let bias: __m128i = _mm_set1_epi16(1); // rounding for divide-by-2
+    let bias: __m128i = _mm_set_epi16(1, 0, 1, 0, 1, 0, 1, 0); // alternating rounding bias for divide-by-2
     let level_shift: __m128i = _mm_set1_epi16(128);
 
     macro_rules! downsample_row {

--- a/tests/reference_hashes_x86_64.json
+++ b/tests/reference_hashes_x86_64.json
@@ -1,14 +1,14 @@
 {
     "_comment": "Known-good hashes for x86_64. See reference_hashes.json for aarch64.",
-    "baseline_64x64_q75_420": "9ad1fa12e8052aa8",
+    "baseline_64x64_q75_420": "c7ad67294b46618c",
     "baseline_64x64_q75_444": "6e87a2dc49a4d734",
-    "baseline_64x64_q50_420": "54ed8a926c00c379",
-    "baseline_64x64_q100_420": "3c30f1c126da281e",
+    "baseline_64x64_q50_420": "8ed9505bff068343",
+    "baseline_64x64_q100_420": "98be41b0ad4fb9b7",
     "progressive_64x64_q75_444": "1f816d68100180a1",
-    "arithmetic_64x64_q75_420": "a37c9bf9488869fc",
+    "arithmetic_64x64_q75_420": "357056affabbb463",
     "arithmetic_progressive_64x64_q75_444": "fc63399fce0b73e1",
     "lossless_64x64_gray": "4a855cdf21a29695",
-    "optimized_64x64_q75_420": "c711bdb62f2dacbb",
+    "optimized_64x64_q75_420": "35de3c0008354b10",
     "grayscale_64x64_q75": "d323d028765d182a",
     "metadata_icc_exif_64x64_q75_444": "b08c66cf278bd5a2"
 }


### PR DESCRIPTION
## Summary
- Fused AVX2 downsample+FDCT+quantize used constant rounding bias instead of the alternating pattern C libjpeg-turbo uses
- H2V1: `_mm_set1_epi16(1)` → `_mm_set_epi16(1,0,1,0,1,0,1,0)` (alternating `[0,1,0,1,...]`)
- H2V2: `_mm_set1_epi16(2)` → `_mm_set_epi16(2,1,2,1,2,1,2,1)` (alternating `[1,2,1,2,...]`)
- Updated x86_64 bitstream regression hashes for the corrected output
- Reference: `libjpeg-turbo/simd/x86_64/jcsample-avx2.asm` lines 92-95, 253-257

## Test plan
- [x] `cargo test --lib` — 152 passed
- [x] `cargo test --test c_tjcomptest` — S422/S420 now byte-identical with C cjpeg
- [x] `cargo test --test cross_encode_decode` — 24 passed
- [x] `cargo test` full suite — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)