### PR TITLE
fix: correct reference image test pairs and remove silent encoder skip

### DIFF
--- a/tests/cross_product_decompress.rs
+++ b/tests/cross_product_decompress.rs
@@ -1324,28 +1324,20 @@ fn tjdecomptest_arithmetic_progressive_sources() {
 
     for &subsamp in &color_subsampling_modes {
         // Create arithmetic-encoded source
-        let arith_jpeg: Vec<u8> = {
-            let enc = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
-                .quality(90)
-                .subsampling(subsamp)
-                .arithmetic(true);
-            match enc.encode() {
-                Ok(j) => j,
-                Err(_) => continue,
-            }
-        };
+        let arith_jpeg: Vec<u8> = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+            .quality(90)
+            .subsampling(subsamp)
+            .arithmetic(true)
+            .encode()
+            .unwrap_or_else(|e| panic!("arithmetic encode failed for {:?}: {}", subsamp, e));
 
         // Create progressive-encoded source
-        let prog_jpeg: Vec<u8> = {
-            let enc = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
-                .quality(90)
-                .subsampling(subsamp)
-                .progressive(true);
-            match enc.encode() {
-                Ok(j) => j,
-                Err(_) => continue,
-            }
-        };
+        let prog_jpeg: Vec<u8> = Encoder::new(&pixels, 32, 32, PixelFormat::Rgb)
+            .quality(90)
+            .subsampling(subsamp)
+            .progressive(true)
+            .encode()
+            .unwrap_or_else(|e| panic!("progressive encode failed for {:?}: {}", subsamp, e));
 
         let sources: Vec<(&str, &Vec<u8>)> =
             vec![("arithmetic", &arith_jpeg), ("progressive", &prog_jpeg)];

--- a/tests/reference_image_compat.rs
+++ b/tests/reference_image_compat.rs
@@ -182,10 +182,17 @@ fn reference_all_images_decodable() {
     }
 }
 
+/// Verify that baseline and arithmetic decoders produce identical pixels
+/// for lossless transcodes.
+///
+/// testimgint.jpg (baseline, integer DCT from testorig.ppm) and
+/// testimgari.jpg (arithmetic, lossless transcode of testimgint.jpg via
+/// jpegtran -arithmetic) contain identical DCT coefficients.
+/// Decoded pixels must match exactly.
 #[test]
 fn reference_baseline_vs_arithmetic_pixel_similarity() {
     let b = decompress_to(
-        include_bytes!("../references/libjpeg-turbo/testimages/testorig.jpg"),
+        include_bytes!("../references/libjpeg-turbo/testimages/testimgint.jpg"),
         PixelFormat::Rgb,
     )
     .unwrap();
@@ -201,22 +208,41 @@ fn reference_baseline_vs_arithmetic_pixel_similarity() {
         .zip(a.data.iter())
         .map(|(&x, &y)| (x as i32 - y as i32).unsigned_abs() as u64)
         .sum();
-    let mean: f64 = total as f64 / b.data.len() as f64;
-    assert!(mean < 100.0, "baseline vs arith mean diff {:.2}", mean);
+    assert_eq!(
+        total, 0,
+        "baseline vs arith must be pixel-identical for lossless transcodes"
+    );
 }
 
+/// Verify that baseline and progressive decoders produce identical pixels
+/// for lossless transcodes.
+///
+/// Generates a progressive JPEG from testimgint.jpg via lossless transform
+/// (jpegtran -progressive equivalent), then verifies decoded pixels match
+/// the baseline decode exactly.
 #[test]
 fn reference_baseline_vs_progressive_pixel_similarity() {
-    let b = decompress_to(
-        include_bytes!("../references/libjpeg-turbo/testimages/testorig.jpg"),
-        PixelFormat::Rgb,
+    use libjpeg_turbo_rs::{
+        transform_jpeg_with_options, MarkerCopyMode, TransformOp, TransformOptions,
+    };
+
+    let baseline_jpeg: &[u8] =
+        include_bytes!("../references/libjpeg-turbo/testimages/testimgint.jpg");
+
+    // Lossless transcode to progressive (equivalent to jpegtran -progressive)
+    let progressive_jpeg: Vec<u8> = transform_jpeg_with_options(
+        baseline_jpeg,
+        &TransformOptions {
+            op: TransformOp::None,
+            progressive: true,
+            copy_markers: MarkerCopyMode::None,
+            ..Default::default()
+        },
     )
     .unwrap();
-    let p = decompress_to(
-        include_bytes!("../references/libjpeg-turbo/testimages/testimgint.jpg"),
-        PixelFormat::Rgb,
-    )
-    .unwrap();
+
+    let b = decompress_to(baseline_jpeg, PixelFormat::Rgb).unwrap();
+    let p = decompress_to(&progressive_jpeg, PixelFormat::Rgb).unwrap();
     assert_eq!((b.width, b.height), (p.width, p.height));
     let total: u64 = b
         .data
@@ -224,8 +250,10 @@ fn reference_baseline_vs_progressive_pixel_similarity() {
         .zip(p.data.iter())
         .map(|(&x, &y)| (x as i32 - y as i32).unsigned_abs() as u64)
         .sum();
-    let mean: f64 = total as f64 / b.data.len() as f64;
-    assert!(mean < 5.0, "baseline vs prog mean diff {:.2}", mean);
+    assert_eq!(
+        total, 0,
+        "baseline vs progressive must be pixel-identical for lossless transcodes"
+    );
 }
 
 // --- C djpeg cross-validation helpers ---


### PR DESCRIPTION
## Summary

- **Fix wrong test file pairs**: `testorig.jpg` and `testimgari.jpg`/`testimgint.jpg` have genuinely different DCT coefficients (294 coeffs differ across 3 components) because they were generated by different `cjpeg` runs. The real lossless transcode pair is `testimgint.jpg` ↔ `testimgari.jpg` (0 coeff diff). Tests now compare the correct pair and assert `total_diff == 0`.
- **Fix misidentified progressive test**: `testimgint.jpg` is SOF0 (baseline), not progressive. The test now generates a progressive JPEG at runtime via lossless `jpegtran -progressive` equivalent and asserts pixel-identical output.
- **Remove silent encoder skip**: Replace `match enc.encode() { Err(_) => continue }` with `.unwrap_or_else(|e| panic!(...))` so encoder failures surface immediately instead of being silently skipped.

## Test plan

- [x] `cargo test --test reference_image_compat` — both tests pass with strict `assert_eq!(total, 0)`
- [x] `cargo test --test cross_product_decompress` — all 12 tests pass
- [x] `cargo test` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)