### PR TITLE
feat: AVX2/SSE2 SIMD optimization — decode 0.91x C, encode 1.02x C

### DIFF
--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -356,6 +356,8 @@
 - [x] AVX2 color conversion for RGBA/BGR/BGRA formats (`avx2_ycbcr_to_rgba_row`, `avx2_ycbcr_to_bgr_row`, `avx2_ycbcr_to_bgra_row`)
 - [x] SSE2 IDCT DC-only fast path + strided output
 - [x] x86_64 encoder SIMD (AVX2 FDCT, RGB→YCbCr, quantization + zigzag)
+- [x] AVX2 encode color conversion for RGBA/BGR/BGRA formats
+- [x] Fused MCU-row encode pipeline for all pixel formats (RGB/RGBA/BGR/BGRA)
 
 ### General
 - [x] Scalar fallback for all operations

--- a/docs/plans/avx2-sse2-optimization.md
+++ b/docs/plans/avx2-sse2-optimization.md
@@ -1,0 +1,212 @@
+# AVX2/SSE2 SIMD Optimization Plan
+
+## Goal
+Optimize x86_64 AVX2/SSE2 decode/encode pipeline to match or beat C libjpeg-turbo across all resolutions (64x64 ~ 3840x2160) and subsampling modes (4:2:0/4:2:2/4:4:4).
+
+## Current State
+
+### Implemented (AVX2)
+| Component | Function | Status |
+|-----------|----------|--------|
+| IDCT islow | `avx2_idct_islow` | Wired in dispatch |
+| YCbCr→RGB (10 formats) | `avx2_ycbcr_to_rgb_row` | Wired in dispatch |
+| Fancy H2V1 | `avx2_fancy_upsample_h2v1` | Wired in dispatch |
+| Merged H2V1 upsample+color | `avx2_merged_h2v1_ycbcr_to_rgb` | Wired in decode pipeline |
+| Merged H2V2 upsample+color | `avx2_merged_h2v2_ycbcr_to_rgb` | Wired in decode pipeline |
+| FDCT islow | `avx2_fdct_islow` | Wired in dispatch |
+| FDCT+Quantize+Zigzag | `avx2_fdct_quantize` | Wired in dispatch |
+| Extract+FDCT+Quant | `avx2_extract_fdct_quantize` | Wired in dispatch |
+| Downsample H2V2+FDCT+Quant | `avx2_downsample_h2v2_fdct_quantize` | Wired in dispatch |
+| Downsample H2V1+FDCT+Quant | `avx2_downsample_h2v1_fdct_quantize` | Wired in dispatch |
+| RGB→YCbCr | `avx2_rgb_to_ycbcr_row` | Wired in dispatch |
+
+### Implemented (SSE2)
+| Component | Function | Status |
+|-----------|----------|--------|
+| IDCT islow | `sse2_idct_islow` | Wired in dispatch (fallback) |
+| YCbCr→RGB | `sse2_ycbcr_to_rgb_row` | Wired in dispatch (fallback) |
+| Fancy H2V1 | `sse2_fancy_upsample_h2v1` | Wired in dispatch (fallback) |
+
+### Scalar Fallback (NOT SIMD)
+| Component | Gap vs NEON/WASM | Impact |
+|-----------|------------------|--------|
+| Fancy H2V2 upsample | NEON+WASM have SIMD | **High** (4:2:0 is most common) |
+| IDCT ifast | NEON has SIMD | Low (islow is default) |
+| IDCT float | NEON has SIMD | Low (rarely used) |
+| Multi-format encode color | NEON has partial SIMD | Medium (only RGB→YCbCr) |
+| SSE2 merged upsample+color | AVX2 has it, SSE2 doesn't | Medium (SSE2-only CPUs) |
+| SSE2 FDCT+quantize | AVX2 has it, SSE2 doesn't | Medium (SSE2-only CPUs) |
+| SSE2 RGB→YCbCr | AVX2 has it, SSE2 doesn't | Medium (SSE2-only CPUs) |
+| Huffman encode SIMD | C has `jchuff-sse2.asm` | **High** (15-25% of encode time) |
+
+### Baseline Performance (x86_64, i5-10400)
+| Benchmark | Rust | C libjpeg-turbo | Ratio |
+|-----------|------|-----------------|-------|
+| graphic_640x480_420 | 884 us | ~884 us | ~1.00x |
+| photo_640x480_420 | 616 us | TBD | TBD |
+| photo_1920x1080_420 | 19.86 ms | TBD | TBD |
+
+## Rules
+- **Output must be bit-identical to C libjpeg-turbo.** Every SIMD function MUST produce diff=0 vs C djpeg/cjpeg output. Cross-validate using `cargo test`.
+- Every change MUST pass `cargo test` before moving to the next task.
+- Benchmark using `cargo bench` full matrix + `./bench_c_decode_linux` / `./bench_c_encode_matrix` for C comparison.
+- One change at a time. Commit each completed task separately.
+- If a change regresses correctness, revert and investigate.
+- Profile before optimizing: `samply record` or `perf record` to identify actual hotspots.
+- Stable CPU frequency: `echo performance > scaling_governor`, disable turbo boost before benchmarks.
+- Reference existing aarch64 NEON and wasm32 SIMD128 implementations for algorithm design.
+- Reference C ASM in `references/libjpeg-turbo/simd/x86_64/` for correctness verification.
+
+## Correctness Notes (from @jpeg-expert review)
+
+- **H2V2 rounding**: AVX2 has no rounding-shift instruction. Use WASM/C pattern (explicit bias +8 for even, +7 for odd, then `vpsrlw 4`). Do NOT port NEON's `vrshrn` pattern directly.
+- **Lane-crossing**: AVX2 H2V2 horizontal neighbor access crosses 128-bit lane boundary. Use `_mm256_permute2x128_si256` or `_mm256_alignr_epi8` for the shift. 3-cycle latency, not a blocker but must be correct.
+- **Boundary safety**: C ASM writes dummy samples past buffer end — Rust cannot do this. Use `col + 16 <= in_width` (SSE2) / `col + 32 <= in_width` (AVX2) loop condition with scalar tail, matching NEON/WASM approach.
+- **Edge pixels**: Last-column odd position must use edge replication (`cs_last*4 + 7) >> 4`). Verify scalar tail covers this.
+- **Progressive JPEG**: No impact — upsample/color stages are post-IDCT, agnostic to scan structure.
+
+## Boundary Test Matrix (mandatory for all upsample implementations)
+
+| Test Case | Why |
+|-----------|-----|
+| width=1, 2, 3 | Below SIMD threshold, scalar fallback |
+| width=15, 16, 17 | SSE2 boundary (exactly one chunk ± 1) |
+| width=31, 32, 33 | AVX2 boundary (exactly one chunk ± 1) |
+| height=1 | Edge replication (above=below=current row) |
+| Odd output dimensions | chroma width rounding edge cases |
+| All-zero / all-255 chroma | Verify no u16 overflow (max colsum horizontal = 4088, fits u16) |
+| Restart marker boundary | Upsample state must not leak across restart intervals |
+| Merged vs separate path | Cross-validate identical output on non-aligned widths |
+
+---
+
+## Phase 1: Baseline Measurement & Gap Analysis
+
+### Task 1-1: Full decode/encode benchmark baseline
+- Set stable CPU frequency (performance governor, no turbo boost)
+- Run `cargo bench` full decode matrix (all resolutions, subsampling modes)
+- Run `cargo bench` full encode matrix
+- Run `./bench_c_decode_linux` and `./bench_c_encode_matrix` for C comparison
+- Record: Rust vs C times and ratio for each benchmark
+- Save as `experiments/x86_64_avx2_baseline.md`
+
+### Task 1-2: Profile decode hotspots
+- `samply record` or `perf record` on `cargo bench -- decode_1920x1080_420`
+- Identify top-5 hotspots by time percentage
+- Document which functions are SIMD vs scalar fallback
+- Prioritize optimization targets by measured impact
+
+---
+
+## Phase 2: Decode Optimization (High Impact)
+
+### Task 2-1: AVX2 Fancy H2V2 Upsample
+- **Reference**: `src/simd/wasm32/upsample.rs` (`wasm_fancy_upsample_h2v2`) as primary algorithm reference, `references/libjpeg-turbo/simd/x86_64/jdsample-avx2.asm`, `src/simd/aarch64/upsample.rs` (`neon_fancy_upsample_h2v2`)
+- **What**: Implement `avx2_fancy_upsample_h2v2` — fused vertical+horizontal triangle filter for 4:2:0
+- **Algorithm**: Single-pass approach (follow WASM/C pattern, NOT NEON vrshrn):
+  - Vertical: `colsum = cur*3 + neighbor` in u16
+  - Horizontal even: `(thiscs*3 + lastcs + 8) >> 4`
+  - Horizontal odd: `(thiscs*3 + nextcs + 7) >> 4`
+  - Explicit bias +8/+7 before `vpsrlw 4` (no rounding-shift instruction on x86)
+- **Lane-crossing**: Horizontal neighbor at 128-bit boundary requires `_mm256_permute2x128_si256` + `_mm256_alignr_epi8` or `_mm256_permutevar8x32_epi32`
+- **Loop condition**: `col + 16 <= in_width` for AVX2 (16 u16 samples per iteration), scalar tail for remainder
+- **Why**: 4:2:0 is ~90% of real-world JPEGs; this is the #1 scalar fallback gap
+- **Wire up**: Call from decode pipeline where `fancy_h2v2` is invoked
+- **Verify**: `cargo test`, diff=0 vs scalar `fancy_h2v2`, run boundary test matrix above
+
+### Task 2-2: SSE2 Fancy H2V2 Upsample
+- **Reference**: Same as 2-1 but using 128-bit SSE2 intrinsics
+- **What**: Implement `sse2_fancy_upsample_h2v2` for SSE2-only CPU fallback
+- **Algorithm**: Same single-pass approach, 8 samples per iteration, `col + 8 <= in_width`
+- **Verify**: `cargo test`, diff=0 vs scalar, boundary test matrix
+
+### Task 2-3: Optimize merged upsample+color hot path
+- **What**: Profile `avx2_merged_h2v2_ycbcr_to_rgb` and `avx2_merged_h2v1_ycbcr_to_rgb` for bottlenecks
+- **Reference**: `references/libjpeg-turbo/simd/x86_64/jdmrgext-avx2.asm`
+- **Note**: Merged path uses box-filter (nearest-neighbor chroma duplication), NOT triangle filter. This is correct and matches C libjpeg-turbo design.
+- **Actions**:
+  - Compare register usage vs C ASM
+  - Check for unnecessary loads/stores in the inner loop
+  - Verify interleave/store patterns match C's optimized approach
+- **Verify**: `cargo test`, benchmark before/after
+- **Audit findings (2026-04-12)**:
+  - Rust processes 16 chroma samples/iter vs C's 32 (2-pass Y loop). ~25% extra chroma math.
+  - Rust drops to 128-bit SSSE3 for RGB interleave/store; C stays 256-bit. ~5-8% loss.
+  - Chroma math is identical (same coefficients, same approach).
+  - **Deferred to Phase 4 (Task 4-3)**: widen to 32-chroma inner loop + 256-bit RGB store.
+
+---
+
+## Phase 3: Encode Optimization
+
+### Task 3-1: Multi-format encode color conversion (AVX2)
+- **Reference**: `src/simd/aarch64/color_encode.rs` (NEON multi-format)
+- **What**: Extend `avx2_rgb_to_ycbcr_row` to handle RGBA/BGR/BGRA input formats
+- **Approach**: Macro-based generation with different channel deinterleave shuffles (SSSE3 pshufb)
+- **Wire up**: Register format-specific variants in encoder dispatch
+- **Verify**: `cargo test`, diff=0 vs scalar for all formats
+
+### Task 3-2: Huffman encode SIMD (SSE2)
+- **Reference**: `references/libjpeg-turbo/simd/x86_64/jchuff-sse2.asm`, `jcphuff-sse2.asm`
+- **What**: SIMD-accelerated Huffman encoding — counting leading zeros and bitstream packing
+- **Why**: Huffman encoding is 15-25% of encode time. C has SSE2 SIMD for this, Rust port is scalar-only
+- **Verify**: `cargo test`, diff=0 vs scalar, encode benchmark before/after
+
+---
+
+## Phase 4: Performance Tuning (profile-gated)
+
+> **Gate**: Only proceed with Tasks 4-1/4-2 if profiling shows the target function occupies >5% of total time. Otherwise skip directly to Task 4-3.
+
+### Task 4-1: IDCT register pressure and memory access
+- **What**: Profile AVX2 IDCT for cache misses, register spills, unnecessary moves
+- **Reference**: Compare against `references/libjpeg-turbo/simd/x86_64/jidctint-avx2.asm`
+- **Key**: Check if the DC-only fast path triggers frequently enough; optimize transpose operations
+- **Verify**: `cargo test`, benchmark before/after
+
+### Task 4-2: Color conversion throughput
+- **What**: Profile AVX2 YCbCr→RGB for throughput bottlenecks
+- **Reference**: `references/libjpeg-turbo/simd/x86_64/jdcolext-avx2.asm`
+- **Key**: Check if interleave/store pattern (3-byte RGB via pshufb) can be improved
+- **Verify**: `cargo test`, benchmark before/after
+
+### Task 4-3: Whole-pipeline optimization
+- **What**: Profile end-to-end decode/encode for inter-function overhead
+- **Key areas**:
+  - Memory allocation between pipeline stages
+  - Cache locality of coefficient buffers
+  - Unnecessary copies between SIMD and scalar boundaries
+- **Verify**: `cargo test`, full benchmark matrix before/after
+
+---
+
+## Phase 5: Final Verification & Benchmark
+
+### Task 5-1: Full test suite validation
+- Run `cargo test` full suite
+- Cross-validate all decode outputs against C `djpeg` (diff=0)
+- Cross-validate all encode outputs against C `cjpeg` (diff=0)
+- Verify all subsampling modes: 4:2:0, 4:2:2, 4:4:4
+- Verify all output formats: RGB, RGBA, BGR, BGRA, RGBX, BGRX
+- Run full boundary test matrix from Correctness Notes section
+
+### Task 5-2: Final performance benchmark
+- Run `cargo bench` full decode+encode matrix
+- Run C comparison benchmarks
+- Produce Rust/C ratio table: resolution x subsampling x operation
+- Compare against Phase 1 baseline
+- Save as `experiments/x86_64_avx2_final_report.md`
+
+### Task 5-3: Documentation update
+- Update `docs/FEATURE_PARITY.md` checkboxes for newly implemented features
+- Update `docs/C_API_REFERENCE.md` status for new SIMD paths
+- Update `README.md` if architecture/performance claims changed
+
+---
+
+## Deferred (low priority)
+
+### SSE2 encode pipeline (FDCT+quantize, RGB→YCbCr)
+- **Why deferred**: AVX2-less CPUs are pre-2013 hardware, diminishing returns
+- **SSE2 lacks `pmulld`** — FDCT butterfly needs `pmadd`/shift emulation, substantial effort
+- **Revisit**: if user demand or CI coverage requires SSE2 encode support

--- a/experiments/x86_64_avx2_baseline.md
+++ b/experiments/x86_64_avx2_baseline.md
@@ -1,0 +1,81 @@
+# x86_64 AVX2/SSE2 Baseline Benchmark Report
+
+**Date**: 2026-04-12
+**CPU**: Intel i5-10400 (x86_64, AVX2)
+**Related**: #193
+
+## Decode Benchmarks (Rust vs C libjpeg-turbo)
+
+| Benchmark | Rust (us) | C (us) | Ratio | Notes |
+|-----------|-----------|--------|-------|-------|
+| photo_64x64_420 | 43.1 | 37.8 | 1.14x | |
+| photo_320x240_420 | 598.7 | 567.8 | 1.05x | |
+| decode_640x480 (gradient) | 829.0 | 681.0 | 1.22x | |
+| graphic_640x480_420 | 685.0 | 645.6 | 1.06x | |
+| checker_640x480_420 | 1340.8 | 1267.5 | 1.06x | |
+| photo_640x480_422 | 2481.2 | 2711.9 | 0.91x | Rust faster |
+| photo_640x480_444 | 3630.9 | 4238.7 | 0.86x | Rust faster |
+| photo_1280x720_420 | 7120.9 | 7817.6 | 0.91x | Rust faster |
+| photo_1920x1080_420 | 16126.5 | 15762.4 | 1.02x | |
+| photo_1920x1080_422 | 19431.0 | 19669.7 | 0.99x | ~parity |
+| photo_1920x1080_444 | 32958.4 | 29498.6 | 1.12x | |
+| photo_2560x1440_420 | 28554.1 | 27056.2 | 1.06x | |
+| photo_3840x2160_420 | 63706.9 | 59636.1 | 1.07x | |
+| graphic_1920x1080_420 | 3745.1 | 3399.6 | 1.10x | |
+| photo_640x480_420_rst | 596.3 | 604.5 | 0.99x | ~parity |
+
+### Progressive Decode
+
+| Benchmark | Rust (us) | C (us) | Ratio | Notes |
+|-----------|-----------|--------|-------|-------|
+| prog_640x480_422 | 6305.8 | 7228.6 | 0.87x | Rust faster |
+| prog_640x480_444 | 9353.1 | 10152.8 | 0.92x | Rust faster |
+| prog_1920x1080_420 | 41292.7 | 41757.7 | 0.99x | ~parity |
+| prog_1920x1080_444 | 72639.1 | 80087.4 | 0.91x | Rust faster |
+| prog_3840x2160_420 | 167581.0 | 169174.1 | 0.99x | ~parity |
+
+### Decode vs zune-jpeg
+
+| Benchmark | Rust (us) | zune (us) | Ratio |
+|-----------|-----------|-----------|-------|
+| 640x480 | 805.8 | 831.5 | 0.97x |
+| graphic_640x480 | 735.6 | 708.4 | 1.04x |
+| 1280x720 | 6860.2 | 8297.1 | 0.83x |
+| 1920x1080 | 15916.9 | 18952.4 | 0.84x |
+| 2560x1440 | 28929.8 | 33022.6 | 0.88x |
+| 3840x2160 | 64369.2 | 74652.3 | 0.86x |
+
+## Encode Benchmarks (Rust vs C libjpeg-turbo)
+
+| Benchmark | Rust (us) | C (us) | Ratio | Notes |
+|-----------|-----------|--------|-------|-------|
+| encode_320x240_420 | 370.8 | 306.0 | 1.21x | |
+| encode_320x240_422 | 449.8 | 404.6 | 1.11x | |
+| encode_320x240_444 | 681.6 | 630.4 | 1.08x | |
+| encode_640x480_422 | 1505.7 | 1293.9 | 1.16x | |
+| encode_640x480_444 | 2409.2 | 2270.2 | 1.06x | |
+| encode_1920x1080_420 | 11575.6 | 8502.9 | 1.36x | Biggest gap |
+| encode_1920x1080_422 | 12188.3 | 11243.2 | 1.08x | |
+| encode_1920x1080_444 | 18033.8 | 15505.1 | 1.16x | |
+
+## Analysis
+
+### Decode Performance
+- **4:2:0 baseline decode**: ~1.02-1.07x C at high resolutions, near parity
+- **4:2:2 and 4:4:4**: Rust is often faster than C (0.86-0.99x)
+- **Progressive**: Rust matches or beats C across all cases
+- **vs zune-jpeg**: Rust is 12-17% faster at large resolutions
+
+### Decode Hotspot: H2V2 Upsample (Scalar Fallback)
+The primary remaining scalar fallback in the decode path is **Fancy H2V2 upsample**, used for all 4:2:0 images (~90% of real-world JPEGs). This explains the ~5-7% gap on large 4:2:0 images (1920x1080, 2560x1440, 3840x2160).
+
+### Encode Performance
+- **1920x1080_420 encode**: 1.36x C — the biggest gap. Likely due to missing Huffman SIMD.
+- **Small images**: 1.08-1.21x C
+- **Large 4:4:4**: 1.16x C
+
+### Priority Optimization Targets
+1. **AVX2 Fancy H2V2 Upsample** — biggest decode scalar fallback gap
+2. **SSE2 Fancy H2V2 Upsample** — SSE2-only CPU fallback
+3. **Encode Huffman SIMD** — explains 1.36x gap on large encode
+4. **Multi-format encode color conversion** — extend AVX2 RGB→YCbCr to other formats

--- a/experiments/x86_64_avx2_final_report.md
+++ b/experiments/x86_64_avx2_final_report.md
@@ -1,0 +1,84 @@
+# x86_64 AVX2/SSE2 Final Benchmark Report
+
+**Date**: 2026-04-12
+**CPU**: Intel i5-10400 (x86_64, AVX2)
+**Related**: #193
+**Changes**: AVX2/SSE2 Fancy H2V2 Upsample, Multi-format encode color conversion, Fused encode pipeline
+
+## Decode: Rust Final vs C libjpeg-turbo
+
+| Benchmark | Baseline (us) | Final (us) | C (us) | Improvement | Rust/C |
+|-----------|--------------|------------|--------|-------------|--------|
+| photo_64x64_420 | 43.1 | 46.4 | 37.8 | — | 1.23x |
+| photo_320x240_420 | 598.7 | 566.6 | 567.8 | +5.4% | **1.00x** |
+| decode_640x480 | 829.0 | 691.8 | 681.0 | +16.6% | 1.02x |
+| graphic_640x480_420 | 685.0 | 617.1 | 645.6 | +9.9% | **0.96x** |
+| checker_640x480_420 | 1340.8 | 1185.7 | 1267.5 | +11.6% | **0.94x** |
+| photo_640x480_422 | 2481.2 | 2380.0 | 2711.9 | +4.1% | **0.88x** |
+| photo_640x480_444 | 3630.9 | 3497.1 | 4238.7 | +3.7% | **0.83x** |
+| photo_1280x720_420 | 7120.9 | 6463.9 | 7817.6 | +9.2% | **0.83x** |
+| photo_1920x1080_420 | 16126.5 | 14304.8 | 15762.4 | +11.3% | **0.91x** |
+| photo_1920x1080_422 | 19431.0 | 18173.1 | 19669.7 | +6.5% | **0.92x** |
+| photo_1920x1080_444 | 32958.4 | 27576.8 | 29498.6 | +16.3% | **0.93x** |
+| photo_2560x1440_420 | 28554.1 | 25429.6 | 27056.2 | +10.9% | **0.94x** |
+| photo_3840x2160_420 | 63706.9 | 58322.9 | 59636.1 | +8.5% | **0.98x** |
+| graphic_1920x1080_420 | 3745.1 | 2631.2 | 3399.6 | +29.7% | **0.77x** |
+| photo_640x480_420_rst | 596.3 | 539.2 | 604.5 | +9.6% | **0.89x** |
+
+### Progressive Decode
+
+| Benchmark | Baseline (us) | Final (us) | C (us) | Improvement | Rust/C |
+|-----------|--------------|------------|--------|-------------|--------|
+| prog_640x480_422 | 6305.8 | 5980.3 | 7228.6 | +5.2% | **0.83x** |
+| prog_640x480_444 | 9353.1 | 8571.0 | 10152.8 | +8.4% | **0.84x** |
+| prog_1920x1080_420 | 41292.7 | 38185.8 | 41757.7 | +7.5% | **0.91x** |
+| prog_1920x1080_444 | 72639.1 | 67800.1 | 80087.4 | +6.7% | **0.85x** |
+| prog_3840x2160_420 | 167581.0 | 154249.3 | 169174.1 | +7.9% | **0.91x** |
+
+### Decode vs zune-jpeg
+
+| Benchmark | Rust (us) | zune (us) | Rust/zune |
+|-----------|-----------|-----------|-----------|
+| 640x480 | 675.2 | 754.3 | **0.90x** |
+| graphic_640x480 | 560.2 | 656.9 | **0.85x** |
+| 1280x720 | 6398.9 | 7853.5 | **0.81x** |
+| 1920x1080 | 14156.4 | 17539.0 | **0.81x** |
+| 2560x1440 | 25532.9 | 31385.8 | **0.81x** |
+| 3840x2160 | 57154.1 | 72237.2 | **0.79x** |
+
+## Encode: Rust vs C libjpeg-turbo
+
+| Benchmark | Rust (us) | C (us) | Rust/C |
+|-----------|-----------|--------|--------|
+| encode_320x240_420 | 370.8 | 306.0 | 1.21x |
+| encode_320x240_422 | 449.8 | 404.6 | 1.11x |
+| encode_320x240_444 | 681.6 | 630.4 | 1.08x |
+| encode_640x480_422 | 1505.7 | 1293.9 | 1.16x |
+| encode_640x480_444 | 2409.2 | 2270.2 | 1.06x |
+| encode_1920x1080_420 | 11575.6 | 8502.9 | 1.36x |
+| encode_1920x1080_422 | 12188.3 | 11243.2 | 1.08x |
+| encode_1920x1080_444 | 18033.8 | 15505.1 | 1.16x |
+
+## Summary
+
+### Decode
+- **4:2:0 baseline**: Rust is now **0.83-0.98x C** across all resolutions (faster than C!)
+- **4:2:2 / 4:4:4**: Rust is **0.83-0.93x C** (significantly faster than C)
+- **Progressive**: Rust is **0.83-0.91x C** (faster than C across the board)
+- **vs zune-jpeg**: Rust is **19-21% faster** at large resolutions
+- **Average improvement from baseline**: ~10% on 4:2:0, up to 30% on graphic content
+
+### Encode
+- Encode remains ~1.08-1.36x C. The primary gap is **Huffman SIMD** (C has `jchuff-sse2.asm`).
+- Multi-format color conversion (RGBA/BGR/BGRA) now uses AVX2 with fused pipeline.
+
+### What was optimized
+1. **AVX2 Fancy H2V2 Upsample** — fused vertical+horizontal triangle filter, 16 samples/iter
+2. **SSE2 Fancy H2V2 Upsample** — 128-bit fallback, 8 samples/iter
+3. **AVX2 Multi-format encode color** — RGBA/BGR/BGRA via SSSE3 pshufb deinterleave
+4. **Fused encode pipeline** — extended MCU-row-at-a-time path to all pixel formats
+
+### Remaining optimization opportunities
+1. **Huffman encode SIMD** (SSE2) — 15-25% of encode time, would close the 1.36x gap
+2. **Wider merged upsample+color** — process 32 chroma samples/iter (currently 16)
+3. **256-bit RGB store** in merged path — avoid drop to 128-bit SSSE3

--- a/src/decode/pipeline.rs
+++ b/src/decode/pipeline.rs
@@ -48,13 +48,18 @@ pub(crate) fn upsample_generic_nearest(
     }
 }
 
-/// Dispatch fancy_h2v2_row to AVX2 or scalar based on CPU features.
+/// Dispatch fancy_h2v2_row to AVX2, SSE2, or scalar based on CPU features.
 #[inline]
 fn fancy_h2v2_row_dispatch(cur: &[u8], neighbor: &[u8], output: &mut [u8], in_width: usize) {
     #[cfg(all(target_arch = "x86_64", feature = "simd"))]
     {
         if is_x86_feature_detected!("avx2") {
             return crate::simd::x86_64::avx2_upsample::avx2_fancy_h2v2_row(
+                cur, neighbor, output, in_width,
+            );
+        }
+        if is_x86_feature_detected!("sse2") {
+            return crate::simd::x86_64::upsample::sse2_fancy_h2v2_row(
                 cur, neighbor, output, in_width,
             );
         }
@@ -1031,6 +1036,11 @@ impl<'a> Decoder<'a> {
         {
             if is_x86_feature_detected!("avx2") {
                 return crate::simd::x86_64::avx2_upsample::avx2_fancy_upsample_h2v2(
+                    input, in_width, in_height, output, out_width,
+                );
+            }
+            if is_x86_feature_detected!("sse2") {
+                return crate::simd::x86_64::upsample::sse2_fancy_upsample_h2v2(
                     input, in_width, in_height, output, out_width,
                 );
             }

--- a/src/decode/pipeline.rs
+++ b/src/decode/pipeline.rs
@@ -48,6 +48,52 @@ pub(crate) fn upsample_generic_nearest(
     }
 }
 
+/// Dispatch fancy_h2v2_row to AVX2 or scalar based on CPU features.
+#[inline]
+fn fancy_h2v2_row_dispatch(cur: &[u8], neighbor: &[u8], output: &mut [u8], in_width: usize) {
+    #[cfg(all(target_arch = "x86_64", feature = "simd"))]
+    {
+        if is_x86_feature_detected!("avx2") {
+            return crate::simd::x86_64::avx2_upsample::avx2_fancy_h2v2_row(
+                cur, neighbor, output, in_width,
+            );
+        }
+    }
+
+    crate::decode::upsample::fancy_h2v2_row(cur, neighbor, output, in_width);
+}
+
+/// Dispatch fancy_h2v2_strided to AVX2 row function or scalar.
+#[inline]
+fn fancy_h2v2_strided_dispatch(
+    input: &[u8],
+    in_width: usize,
+    in_stride: usize,
+    in_height: usize,
+    output: &mut [u8],
+    out_width: usize,
+) {
+    for y in 0..in_height {
+        let cur_row: &[u8] = &input[y * in_stride..y * in_stride + in_width];
+        let above: &[u8] = if y > 0 {
+            &input[(y - 1) * in_stride..(y - 1) * in_stride + in_width]
+        } else {
+            cur_row
+        };
+        let below: &[u8] = if y + 1 < in_height {
+            &input[(y + 1) * in_stride..(y + 1) * in_stride + in_width]
+        } else {
+            cur_row
+        };
+
+        for (v, neighbor) in [(0, above), (1, below)] {
+            let out_y: usize = y * 2 + v;
+            let out_row: &mut [u8] = &mut output[out_y * out_width..];
+            fancy_h2v2_row_dispatch(cur_row, neighbor, out_row, in_width);
+        }
+    }
+}
+
 /// Per-component layout info for progressive decoding.
 struct CompInfo {
     /// Buffer width in blocks (rounded up to MCU alignment: mcus_x * h_samp).
@@ -979,6 +1025,15 @@ impl<'a> Decoder<'a> {
             return crate::simd::wasm32::upsample::wasm_fancy_upsample_h2v2(
                 input, in_width, in_height, output, out_width,
             );
+        }
+
+        #[cfg(all(target_arch = "x86_64", feature = "simd"))]
+        {
+            if is_x86_feature_detected!("avx2") {
+                return crate::simd::x86_64::avx2_upsample::avx2_fancy_upsample_h2v2(
+                    input, in_width, in_height, output, out_width,
+                );
+            }
         }
 
         // Fused H2V2: vertical + horizontal in one pass using >> 4 arithmetic.
@@ -3301,32 +3356,12 @@ impl<'a> Decoder<'a> {
                         };
 
                         // Fused vertical+horizontal upsample for top output row
-                        crate::decode::upsample::fancy_h2v2_row(
-                            cb_cur,
-                            cb_above,
-                            &mut cb_row_top,
-                            actual_cb_w,
-                        );
-                        crate::decode::upsample::fancy_h2v2_row(
-                            cr_cur,
-                            cr_above,
-                            &mut cr_row_top,
-                            actual_cb_w,
-                        );
+                        fancy_h2v2_row_dispatch(cb_cur, cb_above, &mut cb_row_top, actual_cb_w);
+                        fancy_h2v2_row_dispatch(cr_cur, cr_above, &mut cr_row_top, actual_cb_w);
 
                         // Fused vertical+horizontal upsample for bottom output row
-                        crate::decode::upsample::fancy_h2v2_row(
-                            cb_cur,
-                            cb_below,
-                            &mut cb_row_bot,
-                            actual_cb_w,
-                        );
-                        crate::decode::upsample::fancy_h2v2_row(
-                            cr_cur,
-                            cr_below,
-                            &mut cr_row_bot,
-                            actual_cb_w,
-                        );
+                        fancy_h2v2_row_dispatch(cb_cur, cb_below, &mut cb_row_bot, actual_cb_w);
+                        fancy_h2v2_row_dispatch(cr_cur, cr_below, &mut cr_row_bot, actual_cb_w);
 
                         // Color convert both output rows immediately
                         let out_y_top = cy * 2;
@@ -3459,7 +3494,7 @@ impl<'a> Decoder<'a> {
                         }
                     } else if comp_hf == 2 && comp_vf == 2 {
                         // H2V2: fused 2D triangle filter fancy upsample.
-                        crate::decode::upsample::fancy_h2v2_strided(
+                        fancy_h2v2_strided_dispatch(
                             &comp_plane[comp_off..],
                             actual_w,
                             comp_w,

--- a/src/encode/huffman_encode.rs
+++ b/src/encode/huffman_encode.rs
@@ -657,10 +657,9 @@ unsafe fn encode_ac_sparse_lsb(
             r -= 16;
         }
 
-        // Load coefficient, compute magnitude on demand
+        // Load coefficient, use NBITS table + branchless complement
         let ac: i16 = *coeffs.add(pos as usize);
-        let abs_val: u16 = ac.unsigned_abs();
-        let nbits: u32 = 16 - abs_val.leading_zeros();
+        let nbits: u32 = *JPEG_NBITS.as_ptr().add(ac as u16 as usize) as u32;
         let sign: i16 = ac >> 15;
         let mag: u32 = (ac.wrapping_add(sign) as u16 as u32) & ((1u32 << nbits) - 1);
 
@@ -1048,16 +1047,39 @@ unsafe fn encode_ac_dense_neon_local(
     }
 }
 
+/// JPEG NBITS lookup table: maps coefficient value to bit category.
+///
+/// 65536 entries (i16 range). Indexed by `(value as u16) as usize`.
+/// Matches C libjpeg-turbo's `jpeg_nbits_table` used in `jchuff-sse2.asm`.
+/// For value v: `JPEG_NBITS[v as u16] = ceil(log2(|v| + 1))`.
+static JPEG_NBITS: [u8; 65536] = {
+    let mut table = [0u8; 65536];
+    let mut i: i32 = 0;
+    while i < 65536 {
+        let v: i16 = i as i16;
+        let abs_v: u16 = if v < 0 {
+            (v.wrapping_neg()) as u16
+        } else {
+            v as u16
+        };
+        table[i as usize] = if abs_v == 0 {
+            0
+        } else {
+            (16 - abs_v.leading_zeros()) as u8
+        };
+        i += 1;
+    }
+    table
+};
+
 /// Compute the category and magnitude bits for a DC difference value.
 ///
 /// Returns (magnitude_bits, category) where category is 0..11.
-/// Fully branchless: uses arithmetic shift for sign and leading_zeros for category.
+/// Fully branchless: uses arithmetic shift for sign and NBITS table for category.
 #[inline(always)]
 fn encode_dc_value(diff: i16) -> (u16, u8) {
-    let abs_diff: u16 = diff.unsigned_abs();
-    let category: u8 = (16 - abs_diff.leading_zeros()) as u8;
-    // Branchless magnitude: positive → value, negative → value-1 (one's complement)
-    let sign: i16 = diff >> 15; // 0 for non-negative, -1 for negative
+    let category: u8 = JPEG_NBITS[diff as u16 as usize];
+    let sign: i16 = diff >> 15;
     let magnitude_bits: u16 = (diff.wrapping_add(sign)) as u16;
     (magnitude_bits, category)
 }

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -14,6 +14,69 @@ use crate::encode::progressive::ProgressiveScan;
 use crate::encode::tables;
 use crate::simd::QuantDivisors;
 
+/// Color conversion function: (pixels, y, cb, cr, width).
+type ColorConvertRowFn = fn(&[u8], &mut [u8], &mut [u8], &mut [u8], usize);
+
+/// Select the best available RGBA→YCbCr row conversion function.
+fn select_rgba_to_ycbcr_fn() -> ColorConvertRowFn {
+    #[cfg(all(target_arch = "aarch64", feature = "simd"))]
+    {
+        return crate::simd::aarch64::color_encode::neon_rgba_to_ycbcr_row;
+    }
+    #[cfg(all(target_arch = "wasm32", feature = "simd"))]
+    {
+        return crate::simd::wasm32::color_encode::wasm_rgba_to_ycbcr_row;
+    }
+    #[cfg(all(target_arch = "x86_64", feature = "simd"))]
+    {
+        if is_x86_feature_detected!("avx2") {
+            return crate::simd::x86_64::avx2_color_encode::avx2_rgba_to_ycbcr_row;
+        }
+    }
+    #[allow(unreachable_code)]
+    color::rgba_to_ycbcr_row
+}
+
+/// Select the best available BGR→YCbCr row conversion function.
+fn select_bgr_to_ycbcr_fn() -> ColorConvertRowFn {
+    #[cfg(all(target_arch = "aarch64", feature = "simd"))]
+    {
+        return crate::simd::aarch64::color_encode::neon_bgr_to_ycbcr_row;
+    }
+    #[cfg(all(target_arch = "wasm32", feature = "simd"))]
+    {
+        return crate::simd::wasm32::color_encode::wasm_bgr_to_ycbcr_row;
+    }
+    #[cfg(all(target_arch = "x86_64", feature = "simd"))]
+    {
+        if is_x86_feature_detected!("avx2") {
+            return crate::simd::x86_64::avx2_color_encode::avx2_bgr_to_ycbcr_row;
+        }
+    }
+    #[allow(unreachable_code)]
+    color::bgr_to_ycbcr_row_scalar
+}
+
+/// Select the best available BGRA→YCbCr row conversion function.
+fn select_bgra_to_ycbcr_fn() -> ColorConvertRowFn {
+    #[cfg(all(target_arch = "aarch64", feature = "simd"))]
+    {
+        return crate::simd::aarch64::color_encode::neon_bgra_to_ycbcr_row;
+    }
+    #[cfg(all(target_arch = "wasm32", feature = "simd"))]
+    {
+        return crate::simd::wasm32::color_encode::wasm_bgra_to_ycbcr_row;
+    }
+    #[cfg(all(target_arch = "x86_64", feature = "simd"))]
+    {
+        if is_x86_feature_detected!("avx2") {
+            return crate::simd::x86_64::avx2_color_encode::avx2_bgra_to_ycbcr_row;
+        }
+    }
+    #[allow(unreachable_code)]
+    color::bgra_to_ycbcr_row_scalar
+}
+
 /// Compress raw pixel data into a JPEG byte stream.
 ///
 /// # Arguments
@@ -124,11 +187,22 @@ pub fn compress(
     let mut prev_dc_cb: i16 = 0;
     let mut prev_dc_cr: i16 = 0;
 
-    // Single-pass fused approach for RGB: convert MCU rows on-the-fly instead
+    // Single-pass fused approach: convert MCU rows on-the-fly instead
     // of pre-allocating full-size planes. Keeps data in L1/L2 cache between
     // color conversion and encoding.
-    if pixel_format == PixelFormat::Rgb && !is_grayscale {
-        let rgb_to_ycbcr_fn = enc_simd.rgb_to_ycbcr_row;
+    // Select format-specific color conversion function + BPP for the fast path.
+    let fused_color_fn: Option<(ColorConvertRowFn, usize)> = if is_grayscale {
+        None
+    } else {
+        match pixel_format {
+            PixelFormat::Rgb => Some((enc_simd.rgb_to_ycbcr_row, 3)),
+            PixelFormat::Rgba => Some((select_rgba_to_ycbcr_fn(), 4)),
+            PixelFormat::Bgr => Some((select_bgr_to_ycbcr_fn(), 3)),
+            PixelFormat::Bgra => Some((select_bgra_to_ycbcr_fn(), 4)),
+            _ => None,
+        }
+    };
+    if let Some((color_convert_fn, bpp)) = fused_color_fn {
         // Pad buffer width to MCU-aligned, matching C libjpeg-turbo's behavior.
         // C allocates coefficient buffers padded to MCU boundaries and pads input
         // with expand_right_edge up to width_in_blocks * DCTSIZE per component.
@@ -144,13 +218,13 @@ pub fn compress(
             let y0: usize = mcu_row * mcu_h;
             let rows_available: usize = (height - y0).min(mcu_h);
 
-            // Convert this MCU row's RGB data to YCbCr
+            // Convert this MCU row's pixel data to YCbCr
             for row in 0..rows_available {
                 let src_row: usize = y0 + row;
-                let src_offset: usize = src_row * width * 3;
+                let src_offset: usize = src_row * width * bpp;
                 let dst_offset: usize = row * padded_w;
-                rgb_to_ycbcr_fn(
-                    &pixels[src_offset..src_offset + width * 3],
+                color_convert_fn(
+                    &pixels[src_offset..src_offset + width * bpp],
                     &mut y_buf[dst_offset..dst_offset + width],
                     &mut cb_buf[dst_offset..dst_offset + width],
                     &mut cr_buf[dst_offset..dst_offset + width],

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -352,6 +352,98 @@ pub fn compress(
                 y_mcu_height
             };
 
+            // 420 fast path: row-level hoisted bit buffer + inline FDCT+Huffman.
+            // One begin_block/end_block per MCU row (not per MCU), eliminating
+            // ~120 ensure_capacity checks per row for 1920-wide images.
+            // Only for interior MCU rows (eff_row_height == y_mcu_height).
+            #[cfg(target_arch = "x86_64")]
+            if is_420 && !cb_half.is_empty() && eff_row_height == y_mcu_height {
+                unsafe {
+                    // Reserve capacity for entire MCU row
+                    let (mut pb, mut fb, mut buf) = bit_writer.begin_block(3072 * mcus_x);
+
+                    for mcu_col in 0..mcus_x {
+                        let x0: usize = mcu_col * mcu_w;
+                        let cx0: usize = mcu_col * (mcu_w / 2);
+
+                        // FDCT + quantize 6 blocks (4Y + Cb + Cr)
+                        let mut q: [[i16; 64]; 6] = [[0i16; 64]; 6];
+                        let y_ptr: *const u8 = y_buf.as_ptr().add(x0);
+                        crate::simd::x86_64::avx2_extract_fdct_quantize(
+                            y_ptr,
+                            padded_w,
+                            &luma_divisors,
+                            &mut q[0],
+                        );
+                        crate::simd::x86_64::avx2_extract_fdct_quantize(
+                            y_ptr.add(8),
+                            padded_w,
+                            &luma_divisors,
+                            &mut q[1],
+                        );
+                        crate::simd::x86_64::avx2_extract_fdct_quantize(
+                            y_ptr.add(8 * padded_w),
+                            padded_w,
+                            &luma_divisors,
+                            &mut q[2],
+                        );
+                        crate::simd::x86_64::avx2_extract_fdct_quantize(
+                            y_ptr.add(8 * padded_w + 8),
+                            padded_w,
+                            &luma_divisors,
+                            &mut q[3],
+                        );
+                        crate::simd::x86_64::avx2_extract_fdct_quantize(
+                            cb_half.as_ptr().add(cx0),
+                            half_w,
+                            &chroma_divisors,
+                            &mut q[4],
+                        );
+                        crate::simd::x86_64::avx2_extract_fdct_quantize(
+                            cr_half.as_ptr().add(cx0),
+                            half_w,
+                            &chroma_divisors,
+                            &mut q[5],
+                        );
+
+                        // Huffman encode 6 blocks with row-hoisted state
+                        for block in q.iter().take(4) {
+                            HuffmanEncoder::encode_block_hoisted(
+                                &mut pb,
+                                &mut fb,
+                                &mut buf,
+                                block,
+                                &mut prev_dc_y,
+                                &dc_luma_table,
+                                &ac_luma_table,
+                            );
+                        }
+                        HuffmanEncoder::encode_block_hoisted(
+                            &mut pb,
+                            &mut fb,
+                            &mut buf,
+                            &q[4],
+                            &mut prev_dc_cb,
+                            &dc_chroma_table,
+                            &ac_chroma_table,
+                        );
+                        HuffmanEncoder::encode_block_hoisted(
+                            &mut pb,
+                            &mut fb,
+                            &mut buf,
+                            &q[5],
+                            &mut prev_dc_cr,
+                            &dc_chroma_table,
+                            &ac_chroma_table,
+                        );
+                    }
+
+                    bit_writer.end_block(pb, fb, buf);
+                }
+                continue; // skip generic MCU column loop below
+            }
+
+            // Generic path for non-420, edge MCU rows, or non-x86_64
             for mcu_col in 0..mcus_x {
                 let x0: usize = mcu_col * mcu_w;
                 let is_last_mcu_col: bool = mcu_col == mcus_x - 1;
@@ -388,58 +480,6 @@ pub fn compress(
                         eff_col_width,
                         eff_row_height,
                     );
-                } else if is_420 && !cb_half.is_empty() {
-                    // 420 with pre-downsampled half-res chroma: use compact buffers
-                    #[cfg(target_arch = "x86_64")]
-                    {
-                        let cx0: usize = mcu_col * (mcu_w / 2);
-                        encode_mcu_420_half_chroma(
-                            &y_buf,
-                            padded_w,
-                            &cb_half,
-                            &cr_half,
-                            half_w,
-                            x0,
-                            0,
-                            cx0,
-                            0,
-                            &luma_divisors,
-                            &chroma_divisors,
-                            &dc_luma_table,
-                            &ac_luma_table,
-                            &dc_chroma_table,
-                            &ac_chroma_table,
-                            &mut bit_writer,
-                            &mut prev_dc_y,
-                            &mut prev_dc_cb,
-                            &mut prev_dc_cr,
-                            fdct_quantize_fn,
-                        );
-                    }
-                    #[cfg(not(target_arch = "x86_64"))]
-                    {
-                        encode_color_mcu(
-                            &y_buf,
-                            &cb_buf,
-                            &cr_buf,
-                            padded_w,
-                            padded_h,
-                            x0,
-                            0,
-                            subsampling,
-                            &luma_divisors,
-                            &chroma_divisors,
-                            &dc_luma_table,
-                            &ac_luma_table,
-                            &dc_chroma_table,
-                            &ac_chroma_table,
-                            &mut bit_writer,
-                            &mut prev_dc_y,
-                            &mut prev_dc_cb,
-                            &mut prev_dc_cr,
-                            fdct_quantize_fn,
-                        );
-                    }
                 } else {
                     encode_color_mcu(
                         &y_buf,
@@ -7066,7 +7106,7 @@ fn encode_mcu_420_x86_64(
 /// Since chroma is already downsampled, we use `avx2_extract_fdct_quantize`
 /// instead of the heavier `avx2_downsample_h2v2_fdct_quantize`.
 #[cfg(target_arch = "x86_64")]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, dead_code)]
 fn encode_mcu_420_half_chroma(
     y_plane: &[u8],
     y_stride: usize,

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -5005,6 +5005,19 @@ fn convert_to_ycbcr(
                     );
                     continue;
                 }
+                #[cfg(all(target_arch = "x86_64", feature = "simd"))]
+                {
+                    if is_x86_feature_detected!("avx2") {
+                        crate::simd::x86_64::avx2_color_encode::avx2_rgba_to_ycbcr_row(
+                            &pixels[src_offset..src_offset + width * bpp],
+                            &mut y_plane[dst_offset..dst_offset + width],
+                            &mut cb_plane[dst_offset..dst_offset + width],
+                            &mut cr_plane[dst_offset..dst_offset + width],
+                            width,
+                        );
+                        continue;
+                    }
+                }
                 #[allow(unreachable_code)]
                 color::rgba_to_ycbcr_row(
                     &pixels[src_offset..src_offset + width * bpp],
@@ -5041,6 +5054,19 @@ fn convert_to_ycbcr(
                     );
                     continue;
                 }
+                #[cfg(all(target_arch = "x86_64", feature = "simd"))]
+                {
+                    if is_x86_feature_detected!("avx2") {
+                        crate::simd::x86_64::avx2_color_encode::avx2_bgr_to_ycbcr_row(
+                            &pixels[src_offset..src_offset + width * bpp],
+                            &mut y_plane[dst_offset..dst_offset + width],
+                            &mut cb_plane[dst_offset..dst_offset + width],
+                            &mut cr_plane[dst_offset..dst_offset + width],
+                            width,
+                        );
+                        continue;
+                    }
+                }
                 #[allow(unreachable_code)]
                 color::bgr_to_ycbcr_row_scalar(
                     &pixels[src_offset..src_offset + width * bpp],
@@ -5076,6 +5102,19 @@ fn convert_to_ycbcr(
                         width,
                     );
                     continue;
+                }
+                #[cfg(all(target_arch = "x86_64", feature = "simd"))]
+                {
+                    if is_x86_feature_detected!("avx2") {
+                        crate::simd::x86_64::avx2_color_encode::avx2_bgra_to_ycbcr_row(
+                            &pixels[src_offset..src_offset + width * bpp],
+                            &mut y_plane[dst_offset..dst_offset + width],
+                            &mut cb_plane[dst_offset..dst_offset + width],
+                            &mut cr_plane[dst_offset..dst_offset + width],
+                            width,
+                        );
+                        continue;
+                    }
                 }
                 #[allow(unreachable_code)]
                 color::bgra_to_ycbcr_row_scalar(

--- a/src/encode/pipeline.rs
+++ b/src/encode/pipeline.rs
@@ -214,6 +214,23 @@ pub fn compress(
         let mut cb_buf: Vec<u8> = vec![0u8; row_buf_size];
         let mut cr_buf: Vec<u8> = vec![0u8; row_buf_size];
 
+        // For 420: pre-allocate half-resolution chroma buffers.
+        // After color conversion, we downsample full-res Cb/Cr into these compact
+        // buffers so that FDCT reads from stride=half_w instead of stride=padded_w.
+        let is_420: bool = subsampling == Subsampling::S420;
+        let half_w: usize = padded_w / 2;
+        let half_h: usize = padded_h / 2;
+        let mut cb_half: Vec<u8> = if is_420 {
+            vec![0u8; half_w * half_h]
+        } else {
+            Vec::new()
+        };
+        let mut cr_half: Vec<u8> = if is_420 {
+            vec![0u8; half_w * half_h]
+        } else {
+            Vec::new()
+        };
+
         for mcu_row in 0..mcus_y {
             let y0: usize = mcu_row * mcu_h;
             let rows_available: usize = (height - y0).min(mcu_h);
@@ -277,6 +294,29 @@ pub fn compress(
                     let src_offset: usize = src_row * padded_w;
                     cb_buf.copy_within(src_offset..src_offset + padded_w, dst_offset);
                     cr_buf.copy_within(src_offset..src_offset + padded_w, dst_offset);
+                }
+            }
+
+            // For 420: downsample full-res Cb/Cr to compact half-res buffers.
+            // This allows FDCT to read from stride=half_w instead of fused
+            // downsample+FDCT from stride=padded_w, improving cache locality.
+            #[cfg(target_arch = "x86_64")]
+            if is_420 && is_x86_feature_detected!("avx2") {
+                unsafe {
+                    crate::simd::x86_64::avx2_downsample_h2v2_plane(
+                        &cb_buf,
+                        padded_w,
+                        padded_h,
+                        &mut cb_half,
+                        half_w,
+                    );
+                    crate::simd::x86_64::avx2_downsample_h2v2_plane(
+                        &cr_buf,
+                        padded_w,
+                        padded_h,
+                        &mut cr_half,
+                        half_w,
+                    );
                 }
             }
 
@@ -348,6 +388,58 @@ pub fn compress(
                         eff_col_width,
                         eff_row_height,
                     );
+                } else if is_420 && !cb_half.is_empty() {
+                    // 420 with pre-downsampled half-res chroma: use compact buffers
+                    #[cfg(target_arch = "x86_64")]
+                    {
+                        let cx0: usize = mcu_col * (mcu_w / 2);
+                        encode_mcu_420_half_chroma(
+                            &y_buf,
+                            padded_w,
+                            &cb_half,
+                            &cr_half,
+                            half_w,
+                            x0,
+                            0,
+                            cx0,
+                            0,
+                            &luma_divisors,
+                            &chroma_divisors,
+                            &dc_luma_table,
+                            &ac_luma_table,
+                            &dc_chroma_table,
+                            &ac_chroma_table,
+                            &mut bit_writer,
+                            &mut prev_dc_y,
+                            &mut prev_dc_cb,
+                            &mut prev_dc_cr,
+                            fdct_quantize_fn,
+                        );
+                    }
+                    #[cfg(not(target_arch = "x86_64"))]
+                    {
+                        encode_color_mcu(
+                            &y_buf,
+                            &cb_buf,
+                            &cr_buf,
+                            padded_w,
+                            padded_h,
+                            x0,
+                            0,
+                            subsampling,
+                            &luma_divisors,
+                            &chroma_divisors,
+                            &dc_luma_table,
+                            &ac_luma_table,
+                            &dc_chroma_table,
+                            &ac_chroma_table,
+                            &mut bit_writer,
+                            &mut prev_dc_y,
+                            &mut prev_dc_cb,
+                            &mut prev_dc_cr,
+                            fdct_quantize_fn,
+                        );
+                    }
                 } else {
                     encode_color_mcu(
                         &y_buf,
@@ -6963,6 +7055,165 @@ fn encode_mcu_420_x86_64(
             ac_chroma_table,
         );
 
+        writer.end_block(pb, fb, buf);
+    }
+}
+
+/// Encode one 420 MCU using pre-downsampled half-resolution chroma buffers.
+///
+/// Y blocks are read from full-resolution `y_plane` (stride = `y_stride`).
+/// Cb/Cr blocks are read from half-resolution buffers (stride = `chroma_stride`).
+/// Since chroma is already downsampled, we use `avx2_extract_fdct_quantize`
+/// instead of the heavier `avx2_downsample_h2v2_fdct_quantize`.
+#[cfg(target_arch = "x86_64")]
+#[allow(clippy::too_many_arguments)]
+fn encode_mcu_420_half_chroma(
+    y_plane: &[u8],
+    y_stride: usize,
+    cb_half: &[u8],
+    cr_half: &[u8],
+    chroma_stride: usize,
+    y_x0: usize,
+    y_y0: usize,
+    chroma_x0: usize,
+    chroma_y0: usize,
+    luma_quant: &QuantDivisors,
+    chroma_quant: &QuantDivisors,
+    dc_luma_table: &HuffTable,
+    ac_luma_table: &HuffTable,
+    dc_chroma_table: &HuffTable,
+    ac_chroma_table: &HuffTable,
+    writer: &mut BitWriter,
+    prev_dc_y: &mut i16,
+    prev_dc_cb: &mut i16,
+    prev_dc_cr: &mut i16,
+    fdct_quantize_fn: fn(&mut [i16; 64], &QuantDivisors, &mut [i16; 64]),
+) {
+    let mut q: [[i16; 64]; 6] = [[0i16; 64]; 6];
+    let has_avx2: bool = is_x86_feature_detected!("avx2");
+
+    // Check if all blocks are interior (common case for non-edge MCUs)
+    let y_interior: bool = y_x0 + 16 <= y_stride && y_y0 + 16 <= 16;
+    let c_interior: bool = chroma_x0 + 8 <= chroma_stride && chroma_y0 + 8 <= 8;
+
+    if y_interior && c_interior && has_avx2 {
+        unsafe {
+            // 4 Y blocks from full-res plane
+            let y_ptr: *const u8 = y_plane.as_ptr().add(y_y0 * y_stride + y_x0);
+            crate::simd::x86_64::avx2_extract_fdct_quantize(y_ptr, y_stride, luma_quant, &mut q[0]);
+            crate::simd::x86_64::avx2_extract_fdct_quantize(
+                y_ptr.add(8),
+                y_stride,
+                luma_quant,
+                &mut q[1],
+            );
+            crate::simd::x86_64::avx2_extract_fdct_quantize(
+                y_ptr.add(8 * y_stride),
+                y_stride,
+                luma_quant,
+                &mut q[2],
+            );
+            crate::simd::x86_64::avx2_extract_fdct_quantize(
+                y_ptr.add(8 * y_stride + 8),
+                y_stride,
+                luma_quant,
+                &mut q[3],
+            );
+            // Cb/Cr from half-res plane (already downsampled, just extract 8×8)
+            crate::simd::x86_64::avx2_extract_fdct_quantize(
+                cb_half.as_ptr().add(chroma_y0 * chroma_stride + chroma_x0),
+                chroma_stride,
+                chroma_quant,
+                &mut q[4],
+            );
+            crate::simd::x86_64::avx2_extract_fdct_quantize(
+                cr_half.as_ptr().add(chroma_y0 * chroma_stride + chroma_x0),
+                chroma_stride,
+                chroma_quant,
+                &mut q[5],
+            );
+        }
+    } else {
+        // Fallback: scalar extract for edge MCUs
+        let y_offsets: [(usize, usize); 4] = [
+            (y_x0, y_y0),
+            (y_x0 + 8, y_y0),
+            (y_x0, y_y0 + 8),
+            (y_x0 + 8, y_y0 + 8),
+        ];
+        for (idx, &(bx, by)) in y_offsets.iter().enumerate() {
+            if has_avx2 && bx + 8 <= y_stride && by + 8 <= 16 {
+                unsafe {
+                    crate::simd::x86_64::avx2_extract_fdct_quantize(
+                        y_plane.as_ptr().add(by * y_stride + bx),
+                        y_stride,
+                        luma_quant,
+                        &mut q[idx],
+                    );
+                }
+            } else {
+                let mut block = [0i16; 64];
+                extract_block(y_plane, y_stride, 16, bx, by, &mut block);
+                fdct_quantize_fn(&mut block, luma_quant, &mut q[idx]);
+            }
+        }
+        // Chroma from half-res
+        if has_avx2 && chroma_x0 + 8 <= chroma_stride && chroma_y0 + 8 <= 8 {
+            unsafe {
+                crate::simd::x86_64::avx2_extract_fdct_quantize(
+                    cb_half.as_ptr().add(chroma_y0 * chroma_stride + chroma_x0),
+                    chroma_stride,
+                    chroma_quant,
+                    &mut q[4],
+                );
+                crate::simd::x86_64::avx2_extract_fdct_quantize(
+                    cr_half.as_ptr().add(chroma_y0 * chroma_stride + chroma_x0),
+                    chroma_stride,
+                    chroma_quant,
+                    &mut q[5],
+                );
+            }
+        } else {
+            let mut block = [0i16; 64];
+            extract_block(cb_half, chroma_stride, 8, chroma_x0, chroma_y0, &mut block);
+            fdct_quantize_fn(&mut block, chroma_quant, &mut q[4]);
+            extract_block(cr_half, chroma_stride, 8, chroma_x0, chroma_y0, &mut block);
+            fdct_quantize_fn(&mut block, chroma_quant, &mut q[5]);
+        }
+    }
+
+    // Huffman encode all 6 blocks with MCU-level hoisted state
+    unsafe {
+        let (mut pb, mut fb, mut buf) = writer.begin_block(3072);
+        for block in q.iter().take(4) {
+            HuffmanEncoder::encode_block_hoisted(
+                &mut pb,
+                &mut fb,
+                &mut buf,
+                block,
+                prev_dc_y,
+                dc_luma_table,
+                ac_luma_table,
+            );
+        }
+        HuffmanEncoder::encode_block_hoisted(
+            &mut pb,
+            &mut fb,
+            &mut buf,
+            &q[4],
+            prev_dc_cb,
+            dc_chroma_table,
+            ac_chroma_table,
+        );
+        HuffmanEncoder::encode_block_hoisted(
+            &mut pb,
+            &mut fb,
+            &mut buf,
+            &q[5],
+            prev_dc_cr,
+            dc_chroma_table,
+            ac_chroma_table,
+        );
         writer.end_block(pb, fb, buf);
     }
 }

--- a/src/simd/x86_64/avx2_color_encode.rs
+++ b/src/simd/x86_64/avx2_color_encode.rs
@@ -44,147 +44,351 @@ const ONE_HALF: i32 = 1 << 15; // 32768
 const CBCR_OFFSET_ROUND: i32 = (128 << 16) + (1 << 15) - 1;
 
 /// AVX2-accelerated RGB to YCbCr row conversion for the encoder.
-///
-/// # Safety contract
-/// Caller must ensure AVX2 is available (dispatch in `x86_64/mod.rs` verifies this).
 pub fn avx2_rgb_to_ycbcr_row(rgb: &[u8], y: &mut [u8], cb: &mut [u8], cr: &mut [u8], width: usize) {
     if width == 0 {
         return;
     }
-    // SAFETY: AVX2 availability guaranteed by dispatch in x86_64::encoder_routines().
     unsafe {
         avx2_rgb_to_ycbcr_row_inner(rgb, y, cb, cr, width);
     }
 }
 
-/// # Safety
-/// Requires AVX2 support.
-#[target_feature(enable = "avx2")]
-unsafe fn avx2_rgb_to_ycbcr_row_inner(
-    rgb: &[u8],
+/// AVX2-accelerated RGBA to YCbCr row conversion (alpha ignored).
+pub fn avx2_rgba_to_ycbcr_row(
+    rgba: &[u8],
     y: &mut [u8],
     cb: &mut [u8],
     cr: &mut [u8],
     width: usize,
 ) {
-    // Broadcast paired coefficients for vpmaddwd
-    let pw_f0299_f0337: __m256i =
-        _mm256_set1_epi32(((F_0_337 as u16 as u32) << 16 | F_0_299 as u16 as u32) as i32);
-    let pw_f0114_f0250: __m256i =
-        _mm256_set1_epi32(((F_0_250 as u16 as u32) << 16 | F_0_114 as u16 as u32) as i32);
-    let pw_mf0169_mf0331: __m256i =
-        _mm256_set1_epi32(((MF_0_331 as u16 as u32) << 16 | MF_0_169 as u16 as u32) as i32);
-    let pw_mf0419_mf0081: __m256i =
-        _mm256_set1_epi32(((MF_0_081 as u16 as u32) << 16 | MF_0_419 as u16 as u32) as i32);
-
-    let pd_onehalf: __m256i = _mm256_set1_epi32(ONE_HALF);
-    let pd_cbcr_round: __m256i = _mm256_set1_epi32(CBCR_OFFSET_ROUND);
-    let zeros: __m256i = _mm256_setzero_si256();
-
-    let rgb_ptr: *const u8 = rgb.as_ptr();
-    let y_ptr: *mut u8 = y.as_mut_ptr();
-    let cb_ptr: *mut u8 = cb.as_mut_ptr();
-    let cr_ptr: *mut u8 = cr.as_mut_ptr();
-
-    let mut offset: usize = 0;
-
-    // Main loop: 16 pixels per iteration (48 bytes of RGB input)
-    while offset + 16 <= width {
-        // Load 48 bytes of interleaved RGB as 3 x __m128i
-        let c0: __m128i = _mm_loadu_si128(rgb_ptr.add(offset * 3) as *const __m128i);
-        let c1: __m128i = _mm_loadu_si128(rgb_ptr.add(offset * 3 + 16) as *const __m128i);
-        let c2: __m128i = _mm_loadu_si128(rgb_ptr.add(offset * 3 + 32) as *const __m128i);
-
-        // Deinterleave RGB into separate R, G, B channels (16 u8 each)
-        let (r_u8, g_u8, b_u8) = deinterleave_rgb_ssse3(c0, c1, c2);
-
-        // Zero-extend u8 to i16 in __m256i (16 values each)
-        let r_i16: __m256i = _mm256_cvtepu8_epi16(r_u8);
-        let g_i16: __m256i = _mm256_cvtepu8_epi16(g_u8);
-        let b_i16: __m256i = _mm256_cvtepu8_epi16(b_u8);
-
-        // Interleave pairs for vpmaddwd
-        // unpacklo/hi operate within 128-bit lanes
-        let rg_lo: __m256i = _mm256_unpacklo_epi16(r_i16, g_i16); // [R0,G0,R1,G1,...,R3,G3 | R8,G8,...,R11,G11]
-        let rg_hi: __m256i = _mm256_unpackhi_epi16(r_i16, g_i16); // [R4,G4,...,R7,G7 | R12,G12,...,R15,G15]
-        let bg_lo: __m256i = _mm256_unpacklo_epi16(b_i16, g_i16);
-        let bg_hi: __m256i = _mm256_unpackhi_epi16(b_i16, g_i16);
-        let gb_lo: __m256i = _mm256_unpacklo_epi16(g_i16, b_i16);
-        let gb_hi: __m256i = _mm256_unpackhi_epi16(g_i16, b_i16);
-
-        // --- Y computation ---
-        // Y = R*F_0_299 + G*F_0_337 + B*F_0_114 + G*F_0_250 + ONE_HALF
-        let y_rg_lo: __m256i = _mm256_madd_epi16(rg_lo, pw_f0299_f0337);
-        let y_rg_hi: __m256i = _mm256_madd_epi16(rg_hi, pw_f0299_f0337);
-        let y_bg_lo: __m256i = _mm256_madd_epi16(bg_lo, pw_f0114_f0250);
-        let y_bg_hi: __m256i = _mm256_madd_epi16(bg_hi, pw_f0114_f0250);
-        let y_lo: __m256i = _mm256_srai_epi32::<16>(_mm256_add_epi32(
-            _mm256_add_epi32(y_rg_lo, y_bg_lo),
-            pd_onehalf,
-        ));
-        let y_hi: __m256i = _mm256_srai_epi32::<16>(_mm256_add_epi32(
-            _mm256_add_epi32(y_rg_hi, y_bg_hi),
-            pd_onehalf,
-        ));
-
-        // --- Cb computation ---
-        // Cb = R*(-F_0_169) + G*(-F_0_331) + B*F_0_500 + CBCR_OFFSET_ROUND
-        let cb_rg_lo: __m256i = _mm256_madd_epi16(rg_lo, pw_mf0169_mf0331);
-        let cb_rg_hi: __m256i = _mm256_madd_epi16(rg_hi, pw_mf0169_mf0331);
-        // B*32768 via zero-extend to i32 + shift left by 15
-        let b_lo_i32: __m256i = _mm256_unpacklo_epi16(b_i16, zeros);
-        let b_hi_i32: __m256i = _mm256_unpackhi_epi16(b_i16, zeros);
-        let b_half_lo: __m256i = _mm256_slli_epi32::<15>(b_lo_i32);
-        let b_half_hi: __m256i = _mm256_slli_epi32::<15>(b_hi_i32);
-        let cb_lo: __m256i = _mm256_srai_epi32::<16>(_mm256_add_epi32(
-            _mm256_add_epi32(cb_rg_lo, b_half_lo),
-            pd_cbcr_round,
-        ));
-        let cb_hi: __m256i = _mm256_srai_epi32::<16>(_mm256_add_epi32(
-            _mm256_add_epi32(cb_rg_hi, b_half_hi),
-            pd_cbcr_round,
-        ));
-
-        // --- Cr computation ---
-        // Cr = G*(-F_0_419) + B*(-F_0_081) + R*F_0_500 + CBCR_OFFSET_ROUND
-        let cr_gb_lo: __m256i = _mm256_madd_epi16(gb_lo, pw_mf0419_mf0081);
-        let cr_gb_hi: __m256i = _mm256_madd_epi16(gb_hi, pw_mf0419_mf0081);
-        // R*32768 via zero-extend to i32 + shift left by 15
-        let r_lo_i32: __m256i = _mm256_unpacklo_epi16(r_i16, zeros);
-        let r_hi_i32: __m256i = _mm256_unpackhi_epi16(r_i16, zeros);
-        let r_half_lo: __m256i = _mm256_slli_epi32::<15>(r_lo_i32);
-        let r_half_hi: __m256i = _mm256_slli_epi32::<15>(r_hi_i32);
-        let cr_lo: __m256i = _mm256_srai_epi32::<16>(_mm256_add_epi32(
-            _mm256_add_epi32(cr_gb_lo, r_half_lo),
-            pd_cbcr_round,
-        ));
-        let cr_hi: __m256i = _mm256_srai_epi32::<16>(_mm256_add_epi32(
-            _mm256_add_epi32(cr_gb_hi, r_half_hi),
-            pd_cbcr_round,
-        ));
-
-        // Pack i32 -> i16 -> u8 and store
-        let y_u8: __m128i = pack_i32_to_u8(y_lo, y_hi);
-        let cb_u8: __m128i = pack_i32_to_u8(cb_lo, cb_hi);
-        let cr_u8: __m128i = pack_i32_to_u8(cr_lo, cr_hi);
-
-        _mm_storeu_si128(y_ptr.add(offset) as *mut __m128i, y_u8);
-        _mm_storeu_si128(cb_ptr.add(offset) as *mut __m128i, cb_u8);
-        _mm_storeu_si128(cr_ptr.add(offset) as *mut __m128i, cr_u8);
-
-        offset += 16;
+    if width == 0 {
+        return;
     }
-
-    // Scalar tail for remaining pixels (< 16)
-    if offset < width {
-        crate::encode::color::rgb_to_ycbcr_row(
-            &rgb[offset * 3..],
-            &mut y[offset..],
-            &mut cb[offset..],
-            &mut cr[offset..],
-            width - offset,
-        );
+    unsafe {
+        avx2_rgba_to_ycbcr_row_inner(rgba, y, cb, cr, width);
     }
+}
+
+/// AVX2-accelerated BGR to YCbCr row conversion.
+pub fn avx2_bgr_to_ycbcr_row(bgr: &[u8], y: &mut [u8], cb: &mut [u8], cr: &mut [u8], width: usize) {
+    if width == 0 {
+        return;
+    }
+    unsafe {
+        avx2_bgr_to_ycbcr_row_inner(bgr, y, cb, cr, width);
+    }
+}
+
+/// AVX2-accelerated BGRA to YCbCr row conversion (alpha ignored).
+pub fn avx2_bgra_to_ycbcr_row(
+    bgra: &[u8],
+    y: &mut [u8],
+    cb: &mut [u8],
+    cr: &mut [u8],
+    width: usize,
+) {
+    if width == 0 {
+        return;
+    }
+    unsafe {
+        avx2_bgra_to_ycbcr_row_inner(bgra, y, cb, cr, width);
+    }
+}
+
+/// Shared Y/Cb/Cr core computation from 16 pixels of R, G, B (as __m256i i16).
+///
+/// Returns (y_u8, cb_u8, cr_u8) as __m128i (16 u8 each).
+///
+/// # Safety
+/// Requires AVX2.
+#[target_feature(enable = "avx2")]
+#[inline]
+#[allow(clippy::too_many_arguments)]
+unsafe fn avx2_ycbcr_core(
+    r_i16: __m256i,
+    g_i16: __m256i,
+    b_i16: __m256i,
+    pw_f0299_f0337: __m256i,
+    pw_f0114_f0250: __m256i,
+    pw_mf0169_mf0331: __m256i,
+    pw_mf0419_mf0081: __m256i,
+    pd_onehalf: __m256i,
+    pd_cbcr_round: __m256i,
+    zeros: __m256i,
+) -> (__m128i, __m128i, __m128i) {
+    let rg_lo: __m256i = _mm256_unpacklo_epi16(r_i16, g_i16);
+    let rg_hi: __m256i = _mm256_unpackhi_epi16(r_i16, g_i16);
+    let bg_lo: __m256i = _mm256_unpacklo_epi16(b_i16, g_i16);
+    let bg_hi: __m256i = _mm256_unpackhi_epi16(b_i16, g_i16);
+    let gb_lo: __m256i = _mm256_unpacklo_epi16(g_i16, b_i16);
+    let gb_hi: __m256i = _mm256_unpackhi_epi16(g_i16, b_i16);
+
+    // Y = R*F_0_299 + G*F_0_337 + B*F_0_114 + G*F_0_250 + ONE_HALF
+    let y_lo: __m256i = _mm256_srai_epi32::<16>(_mm256_add_epi32(
+        _mm256_add_epi32(
+            _mm256_madd_epi16(rg_lo, pw_f0299_f0337),
+            _mm256_madd_epi16(bg_lo, pw_f0114_f0250),
+        ),
+        pd_onehalf,
+    ));
+    let y_hi: __m256i = _mm256_srai_epi32::<16>(_mm256_add_epi32(
+        _mm256_add_epi32(
+            _mm256_madd_epi16(rg_hi, pw_f0299_f0337),
+            _mm256_madd_epi16(bg_hi, pw_f0114_f0250),
+        ),
+        pd_onehalf,
+    ));
+
+    // Cb = R*(-F_0_169) + G*(-F_0_331) + B*F_0_500 + CBCR_OFFSET_ROUND
+    let b_lo_i32: __m256i = _mm256_unpacklo_epi16(b_i16, zeros);
+    let b_hi_i32: __m256i = _mm256_unpackhi_epi16(b_i16, zeros);
+    let cb_lo: __m256i = _mm256_srai_epi32::<16>(_mm256_add_epi32(
+        _mm256_add_epi32(
+            _mm256_madd_epi16(rg_lo, pw_mf0169_mf0331),
+            _mm256_slli_epi32::<15>(b_lo_i32),
+        ),
+        pd_cbcr_round,
+    ));
+    let cb_hi: __m256i = _mm256_srai_epi32::<16>(_mm256_add_epi32(
+        _mm256_add_epi32(
+            _mm256_madd_epi16(rg_hi, pw_mf0169_mf0331),
+            _mm256_slli_epi32::<15>(b_hi_i32),
+        ),
+        pd_cbcr_round,
+    ));
+
+    // Cr = G*(-F_0_419) + B*(-F_0_081) + R*F_0_500 + CBCR_OFFSET_ROUND
+    let r_lo_i32: __m256i = _mm256_unpacklo_epi16(r_i16, zeros);
+    let r_hi_i32: __m256i = _mm256_unpackhi_epi16(r_i16, zeros);
+    let cr_lo: __m256i = _mm256_srai_epi32::<16>(_mm256_add_epi32(
+        _mm256_add_epi32(
+            _mm256_madd_epi16(gb_lo, pw_mf0419_mf0081),
+            _mm256_slli_epi32::<15>(r_lo_i32),
+        ),
+        pd_cbcr_round,
+    ));
+    let cr_hi: __m256i = _mm256_srai_epi32::<16>(_mm256_add_epi32(
+        _mm256_add_epi32(
+            _mm256_madd_epi16(gb_hi, pw_mf0419_mf0081),
+            _mm256_slli_epi32::<15>(r_hi_i32),
+        ),
+        pd_cbcr_round,
+    ));
+
+    (
+        pack_i32_to_u8(y_lo, y_hi),
+        pack_i32_to_u8(cb_lo, cb_hi),
+        pack_i32_to_u8(cr_lo, cr_hi),
+    )
+}
+
+/// Macro to generate format-specific AVX2 color conversion inner functions.
+///
+/// Parameterized by BPP, deinterleave expression, and scalar fallback.
+macro_rules! avx2_color_convert_inner {
+    ($fn_name:ident, $bpp:expr, $deinterleave:expr, $scalar_fn:path) => {
+        #[target_feature(enable = "avx2")]
+        unsafe fn $fn_name(
+            pixels: &[u8],
+            y: &mut [u8],
+            cb: &mut [u8],
+            cr: &mut [u8],
+            width: usize,
+        ) {
+            let pw_f0299_f0337: __m256i =
+                _mm256_set1_epi32(((F_0_337 as u16 as u32) << 16 | F_0_299 as u16 as u32) as i32);
+            let pw_f0114_f0250: __m256i =
+                _mm256_set1_epi32(((F_0_250 as u16 as u32) << 16 | F_0_114 as u16 as u32) as i32);
+            let pw_mf0169_mf0331: __m256i =
+                _mm256_set1_epi32(((MF_0_331 as u16 as u32) << 16 | MF_0_169 as u16 as u32) as i32);
+            let pw_mf0419_mf0081: __m256i =
+                _mm256_set1_epi32(((MF_0_081 as u16 as u32) << 16 | MF_0_419 as u16 as u32) as i32);
+            let pd_onehalf: __m256i = _mm256_set1_epi32(ONE_HALF);
+            let pd_cbcr_round: __m256i = _mm256_set1_epi32(CBCR_OFFSET_ROUND);
+            let zeros: __m256i = _mm256_setzero_si256();
+
+            let px_ptr: *const u8 = pixels.as_ptr();
+            let y_ptr: *mut u8 = y.as_mut_ptr();
+            let cb_ptr: *mut u8 = cb.as_mut_ptr();
+            let cr_ptr: *mut u8 = cr.as_mut_ptr();
+
+            let mut offset: usize = 0;
+
+            while offset + 16 <= width {
+                let (r_u8, g_u8, b_u8) = $deinterleave(px_ptr.add(offset * $bpp));
+
+                let r_i16: __m256i = _mm256_cvtepu8_epi16(r_u8);
+                let g_i16: __m256i = _mm256_cvtepu8_epi16(g_u8);
+                let b_i16: __m256i = _mm256_cvtepu8_epi16(b_u8);
+
+                let (y_u8, cb_u8, cr_u8) = avx2_ycbcr_core(
+                    r_i16,
+                    g_i16,
+                    b_i16,
+                    pw_f0299_f0337,
+                    pw_f0114_f0250,
+                    pw_mf0169_mf0331,
+                    pw_mf0419_mf0081,
+                    pd_onehalf,
+                    pd_cbcr_round,
+                    zeros,
+                );
+
+                _mm_storeu_si128(y_ptr.add(offset) as *mut __m128i, y_u8);
+                _mm_storeu_si128(cb_ptr.add(offset) as *mut __m128i, cb_u8);
+                _mm_storeu_si128(cr_ptr.add(offset) as *mut __m128i, cr_u8);
+
+                offset += 16;
+            }
+
+            if offset < width {
+                $scalar_fn(
+                    &pixels[offset * $bpp..],
+                    &mut y[offset..],
+                    &mut cb[offset..],
+                    &mut cr[offset..],
+                    width - offset,
+                );
+            }
+        }
+    };
+}
+
+// Generate format-specific inner functions
+avx2_color_convert_inner!(
+    avx2_rgb_to_ycbcr_row_inner,
+    3,
+    load_deinterleave_rgb,
+    crate::encode::color::rgb_to_ycbcr_row
+);
+avx2_color_convert_inner!(
+    avx2_rgba_to_ycbcr_row_inner,
+    4,
+    load_deinterleave_rgba,
+    crate::encode::color::rgba_to_ycbcr_row
+);
+avx2_color_convert_inner!(
+    avx2_bgr_to_ycbcr_row_inner,
+    3,
+    load_deinterleave_bgr,
+    crate::encode::color::bgr_to_ycbcr_row_scalar
+);
+avx2_color_convert_inner!(
+    avx2_bgra_to_ycbcr_row_inner,
+    4,
+    load_deinterleave_bgra,
+    crate::encode::color::bgra_to_ycbcr_row_scalar
+);
+
+/// Load and deinterleave 48 bytes (16 RGB pixels) into (R, G, B).
+#[target_feature(enable = "avx2")]
+#[inline]
+unsafe fn load_deinterleave_rgb(ptr: *const u8) -> (__m128i, __m128i, __m128i) {
+    let c0: __m128i = _mm_loadu_si128(ptr as *const __m128i);
+    let c1: __m128i = _mm_loadu_si128(ptr.add(16) as *const __m128i);
+    let c2: __m128i = _mm_loadu_si128(ptr.add(32) as *const __m128i);
+    deinterleave_rgb_ssse3(c0, c1, c2)
+}
+
+/// Load and deinterleave 48 bytes (16 BGR pixels) into (R, G, B).
+/// Same as RGB but with R and B swapped.
+#[target_feature(enable = "avx2")]
+#[inline]
+unsafe fn load_deinterleave_bgr(ptr: *const u8) -> (__m128i, __m128i, __m128i) {
+    let c0: __m128i = _mm_loadu_si128(ptr as *const __m128i);
+    let c1: __m128i = _mm_loadu_si128(ptr.add(16) as *const __m128i);
+    let c2: __m128i = _mm_loadu_si128(ptr.add(32) as *const __m128i);
+    let (b, g, r) = deinterleave_rgb_ssse3(c0, c1, c2);
+    (r, g, b)
+}
+
+/// Load and deinterleave 64 bytes (16 RGBA pixels) into (R, G, B).
+#[target_feature(enable = "avx2")]
+#[inline]
+unsafe fn load_deinterleave_rgba(ptr: *const u8) -> (__m128i, __m128i, __m128i) {
+    let c0: __m128i = _mm_loadu_si128(ptr as *const __m128i);
+    let c1: __m128i = _mm_loadu_si128(ptr.add(16) as *const __m128i);
+    let c2: __m128i = _mm_loadu_si128(ptr.add(32) as *const __m128i);
+    let c3: __m128i = _mm_loadu_si128(ptr.add(48) as *const __m128i);
+    deinterleave_rgba_ssse3(c0, c1, c2, c3)
+}
+
+/// Load and deinterleave 64 bytes (16 BGRA pixels) into (R, G, B).
+#[target_feature(enable = "avx2")]
+#[inline]
+unsafe fn load_deinterleave_bgra(ptr: *const u8) -> (__m128i, __m128i, __m128i) {
+    let c0: __m128i = _mm_loadu_si128(ptr as *const __m128i);
+    let c1: __m128i = _mm_loadu_si128(ptr.add(16) as *const __m128i);
+    let c2: __m128i = _mm_loadu_si128(ptr.add(32) as *const __m128i);
+    let c3: __m128i = _mm_loadu_si128(ptr.add(48) as *const __m128i);
+    let (b, g, r) = deinterleave_rgba_ssse3(c0, c1, c2, c3);
+    (r, g, b)
+}
+
+/// Deinterleave 64 bytes of RGBA into separate R, G, B channels (16 u8 each).
+///
+/// Input: 4 x __m128i containing [R0 G0 B0 A0 R1 G1 B1 A1 ... R15 G15 B15 A15]
+/// Each __m128i holds 4 RGBA pixels (16 bytes). Alpha is discarded.
+///
+/// # Safety
+/// Requires SSSE3.
+#[target_feature(enable = "avx2")]
+#[inline]
+unsafe fn deinterleave_rgba_ssse3(
+    c0: __m128i,
+    c1: __m128i,
+    c2: __m128i,
+    c3: __m128i,
+) -> (__m128i, __m128i, __m128i) {
+    // Each chunk has 4 pixels at offsets 0,4,8,12 (R), 1,5,9,13 (G), 2,6,10,14 (B)
+    // Extract 4 values per chunk, place at correct output offset, then OR together.
+
+    // R channel: byte 0, 4, 8, 12 from each chunk
+    let r_shuf0: __m128i =
+        _mm_setr_epi8(0, 4, 8, 12, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    let r_shuf1: __m128i =
+        _mm_setr_epi8(-1, -1, -1, -1, 0, 4, 8, 12, -1, -1, -1, -1, -1, -1, -1, -1);
+    let r_shuf2: __m128i =
+        _mm_setr_epi8(-1, -1, -1, -1, -1, -1, -1, -1, 0, 4, 8, 12, -1, -1, -1, -1);
+    let r_shuf3: __m128i =
+        _mm_setr_epi8(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 4, 8, 12);
+
+    let r: __m128i = _mm_or_si128(
+        _mm_or_si128(_mm_shuffle_epi8(c0, r_shuf0), _mm_shuffle_epi8(c1, r_shuf1)),
+        _mm_or_si128(_mm_shuffle_epi8(c2, r_shuf2), _mm_shuffle_epi8(c3, r_shuf3)),
+    );
+
+    // G channel: byte 1, 5, 9, 13 from each chunk
+    let g_shuf0: __m128i =
+        _mm_setr_epi8(1, 5, 9, 13, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    let g_shuf1: __m128i =
+        _mm_setr_epi8(-1, -1, -1, -1, 1, 5, 9, 13, -1, -1, -1, -1, -1, -1, -1, -1);
+    let g_shuf2: __m128i =
+        _mm_setr_epi8(-1, -1, -1, -1, -1, -1, -1, -1, 1, 5, 9, 13, -1, -1, -1, -1);
+    let g_shuf3: __m128i =
+        _mm_setr_epi8(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1, 5, 9, 13);
+
+    let g: __m128i = _mm_or_si128(
+        _mm_or_si128(_mm_shuffle_epi8(c0, g_shuf0), _mm_shuffle_epi8(c1, g_shuf1)),
+        _mm_or_si128(_mm_shuffle_epi8(c2, g_shuf2), _mm_shuffle_epi8(c3, g_shuf3)),
+    );
+
+    // B channel: byte 2, 6, 10, 14 from each chunk
+    let b_shuf0: __m128i =
+        _mm_setr_epi8(2, 6, 10, 14, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    let b_shuf1: __m128i =
+        _mm_setr_epi8(-1, -1, -1, -1, 2, 6, 10, 14, -1, -1, -1, -1, -1, -1, -1, -1);
+    let b_shuf2: __m128i =
+        _mm_setr_epi8(-1, -1, -1, -1, -1, -1, -1, -1, 2, 6, 10, 14, -1, -1, -1, -1);
+    let b_shuf3: __m128i =
+        _mm_setr_epi8(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 2, 6, 10, 14);
+
+    let b: __m128i = _mm_or_si128(
+        _mm_or_si128(_mm_shuffle_epi8(c0, b_shuf0), _mm_shuffle_epi8(c1, b_shuf1)),
+        _mm_or_si128(_mm_shuffle_epi8(c2, b_shuf2), _mm_shuffle_epi8(c3, b_shuf3)),
+    );
+
+    (r, g, b)
 }
 
 /// Deinterleave 48 bytes of RGB into separate R, G, B channels (16 u8 each).

--- a/src/simd/x86_64/avx2_upsample.rs
+++ b/src/simd/x86_64/avx2_upsample.rs
@@ -124,3 +124,174 @@ unsafe fn narrow_u16_to_u8_128(v: __m256i) -> __m128i {
     let shuffled = _mm256_permute4x64_epi64::<0b_11_01_10_00>(packed);
     _mm256_castsi256_si128(shuffled)
 }
+
+// ---------------------------------------------------------------------------
+// AVX2 Fancy H2V2 Upsample (fused single-pass 2D triangle filter)
+// ---------------------------------------------------------------------------
+//
+// Fused vertical+horizontal triangle filter for 4:2:0 chroma upsampling.
+// Computes colsum = cur*3 + neighbor in u16, then blends horizontally
+// with a single >>4, matching C libjpeg-turbo `h2v2_fancy_upsample` exactly.
+//
+// Reference: src/simd/wasm32/upsample.rs (wasm_fancy_upsample_h2v2)
+
+/// AVX2 fancy 2x2 upsample (fused single-pass).
+///
+/// For each input row, produces two output rows (top blended with above,
+/// bottom blended with below). All arithmetic stays in u16 to avoid
+/// double-rounding.
+pub fn avx2_fancy_upsample_h2v2(
+    input: &[u8],
+    in_width: usize,
+    in_height: usize,
+    output: &mut [u8],
+    out_width: usize,
+) {
+    if in_width == 0 || in_height == 0 {
+        return;
+    }
+
+    for y in 0..in_height {
+        let cur_row: &[u8] = &input[y * in_width..(y + 1) * in_width];
+        let above: &[u8] = if y > 0 {
+            &input[(y - 1) * in_width..y * in_width]
+        } else {
+            cur_row
+        };
+        let below: &[u8] = if y + 1 < in_height {
+            &input[(y + 1) * in_width..(y + 2) * in_width]
+        } else {
+            cur_row
+        };
+
+        let out_top: &mut [u8] = &mut output[y * 2 * out_width..(y * 2 + 1) * out_width];
+        avx2_fancy_h2v2_row(cur_row, above, out_top, in_width);
+
+        let out_bot: &mut [u8] = &mut output[(y * 2 + 1) * out_width..(y * 2 + 2) * out_width];
+        avx2_fancy_h2v2_row(cur_row, below, out_bot, in_width);
+    }
+}
+
+/// Fused AVX2 H2V2 fancy upsample for one output row.
+///
+/// Computes colsum = cur*3 + neighbor in u16, then horizontal 3:1 blend
+/// with biases +8 (even) / +7 (odd) and a single >>4 shift.
+pub fn avx2_fancy_h2v2_row(cur: &[u8], neighbor: &[u8], output: &mut [u8], in_width: usize) {
+    // Small widths: delegate to scalar
+    if in_width < 3 {
+        crate::decode::upsample::fancy_h2v2_row(cur, neighbor, output, in_width);
+        return;
+    }
+
+    // First column (scalar edge): even pixel + odd pixel
+    let cs0: i32 = cur[0] as i32 * 3 + neighbor[0] as i32;
+    output[0] = ((cs0 * 4 + 8) >> 4) as u8;
+    let cs1: i32 = cur[1] as i32 * 3 + neighbor[1] as i32;
+    output[1] = ((cs0 * 3 + cs1 + 7) >> 4) as u8;
+
+    // SAFETY: AVX2 availability guaranteed by dispatch in x86_64::routines().
+    unsafe {
+        avx2_fancy_h2v2_row_inner(cur, neighbor, output, in_width);
+    }
+
+    // Last pixel (scalar edge): odd position
+    let last: usize = in_width - 1;
+    let cs_last: i32 = cur[last] as i32 * 3 + neighbor[last] as i32;
+    output[last * 2 + 1] = ((cs_last * 4 + 7) >> 4) as u8;
+}
+
+/// AVX2 inner loop for fused H2V2 fancy upsample.
+///
+/// Processes 16 input samples → 32 output pixels per iteration using
+/// overlapping loads (s0 at col-1, s1 at col). All arithmetic in u16.
+///
+/// # Safety
+/// Requires AVX2. `in_width` must be >= 3.
+#[target_feature(enable = "avx2")]
+unsafe fn avx2_fancy_h2v2_row_inner(
+    cur: &[u8],
+    neighbor: &[u8],
+    output: &mut [u8],
+    in_width: usize,
+) {
+    let cur_ptr: *const u8 = cur.as_ptr();
+    let nbr_ptr: *const u8 = neighbor.as_ptr();
+    let out_ptr: *mut u8 = output.as_mut_ptr();
+
+    let three_u16: __m256i = _mm256_set1_epi16(3);
+    let seven_u16: __m256i = _mm256_set1_epi16(7);
+    let eight_u16: __m256i = _mm256_set1_epi16(8);
+
+    let mut col: usize = 1;
+
+    // Main SIMD loop: 16 input samples → 32 output pixels per iteration.
+    // s0 loads from col-1 (16 bytes), s1 from col (16 bytes).
+    // Requires col + 16 <= in_width so both loads stay in bounds.
+    while col + 16 <= in_width {
+        // Load 16 bytes from col-1 and col, widen u8→u16
+        let s0_cur: __m256i =
+            _mm256_cvtepu8_epi16(_mm_loadu_si128(cur_ptr.add(col - 1) as *const __m128i));
+        let s0_nbr: __m256i =
+            _mm256_cvtepu8_epi16(_mm_loadu_si128(nbr_ptr.add(col - 1) as *const __m128i));
+        let s1_cur: __m256i =
+            _mm256_cvtepu8_epi16(_mm_loadu_si128(cur_ptr.add(col) as *const __m128i));
+        let s1_nbr: __m256i =
+            _mm256_cvtepu8_epi16(_mm_loadu_si128(nbr_ptr.add(col) as *const __m128i));
+
+        // Vertical column sums: colsum = neighbor + 3 * cur (in u16)
+        let s0_colsum: __m256i = _mm256_add_epi16(s0_nbr, _mm256_mullo_epi16(s0_cur, three_u16));
+        let s1_colsum: __m256i = _mm256_add_epi16(s1_nbr, _mm256_mullo_epi16(s1_cur, three_u16));
+
+        // Horizontal blend:
+        //   c1 = 3*s0_colsum + s1_colsum  → odd output positions
+        //   c2 = 3*s1_colsum + s0_colsum  → even output positions
+        let c1: __m256i = _mm256_add_epi16(s1_colsum, _mm256_mullo_epi16(s0_colsum, three_u16));
+        let c2: __m256i = _mm256_add_epi16(s0_colsum, _mm256_mullo_epi16(s1_colsum, three_u16));
+
+        // Bias and shift: c1+7>>4 (odd), c2+8>>4 (even)
+        let c1_shifted: __m256i = _mm256_srli_epi16::<4>(_mm256_add_epi16(c1, seven_u16));
+        let c2_shifted: __m256i = _mm256_srli_epi16::<4>(_mm256_add_epi16(c2, eight_u16));
+
+        // Narrow from u16 to u8 (16 values each → __m128i)
+        let c1_u8: __m128i = narrow_u16_to_u8_128(c1_shifted);
+        let c2_u8: __m128i = narrow_u16_to_u8_128(c2_shifted);
+
+        // Interleave c1 (odd) and c2 (even): [c1[0] c2[0] c1[1] c2[1] ...]
+        let lo: __m128i = _mm_unpacklo_epi8(c1_u8, c2_u8);
+        let hi: __m128i = _mm_unpackhi_epi8(c1_u8, c2_u8);
+
+        // Store 32 bytes at output position col*2 - 1
+        _mm_storeu_si128(out_ptr.add(col * 2 - 1) as *mut __m128i, lo);
+        _mm_storeu_si128(out_ptr.add(col * 2 - 1 + 16) as *mut __m128i, hi);
+
+        col += 16;
+    }
+
+    // Scalar tail for remaining columns.
+    let colsum = |i: usize| -> i32 { cur[i] as i32 * 3 + neighbor[i] as i32 };
+
+    // Fill gap: odd pixel for last column whose even pixel was produced by SIMD
+    if col > 1 {
+        let boundary: usize = col - 1;
+        if boundary < in_width - 1 {
+            let this_cs: i32 = colsum(boundary);
+            let next_cs: i32 = colsum(boundary + 1);
+            output[boundary * 2 + 1] = ((this_cs * 3 + next_cs + 7) >> 4) as u8;
+        }
+    }
+
+    // Remaining columns: both even and odd pixels
+    while col < in_width {
+        let this_cs: i32 = colsum(col);
+        let last_cs: i32 = colsum(col - 1);
+
+        output[col * 2] = ((this_cs * 3 + last_cs + 8) >> 4) as u8;
+
+        if col + 1 < in_width {
+            let next_cs: i32 = colsum(col + 1);
+            output[col * 2 + 1] = ((this_cs * 3 + next_cs + 7) >> 4) as u8;
+        }
+
+        col += 1;
+    }
+}

--- a/src/simd/x86_64/mod.rs
+++ b/src/simd/x86_64/mod.rs
@@ -240,6 +240,76 @@ pub(crate) unsafe fn avx2_downsample_h2v1_fdct_quantize(
     avx2_quantize_zigzag(&dct_buf, quant, output);
 }
 
+/// AVX2 H2V2 chroma downsample: full-res plane → half-res plane.
+///
+/// Averages 2×2 blocks with rounding bias: `(a + b + c + d + 2) >> 2`.
+/// Matches C libjpeg-turbo's `h2v2_downsample` in jcsample.c.
+///
+/// Processes 16 output pixels (32 input) per AVX2 iteration.
+///
+/// # Safety
+/// Requires AVX2. `src` must have at least `src_stride * src_rows` bytes.
+/// `dst` must have at least `dst_stride * (src_rows / 2)` bytes.
+/// `src_rows` must be even.
+#[target_feature(enable = "avx2")]
+pub(crate) unsafe fn avx2_downsample_h2v2_plane(
+    src: &[u8],
+    src_stride: usize,
+    src_rows: usize,
+    dst: &mut [u8],
+    dst_stride: usize,
+) {
+    use core::arch::x86_64::*;
+
+    let ones: __m256i = _mm256_set1_epi8(1);
+    // Alternating rounding bias (2,1,2,1...) matching the fused
+    // avx2_downsample_h2v2_fdct_quantize dither pattern.
+    let bias: __m256i = _mm256_set_epi16(2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1);
+
+    let src_ptr: *const u8 = src.as_ptr();
+    let dst_ptr: *mut u8 = dst.as_mut_ptr();
+
+    for dy in 0..src_rows / 2 {
+        let sy: usize = dy * 2;
+        let row0: *const u8 = src_ptr.add(sy * src_stride);
+        let row1: *const u8 = src_ptr.add((sy + 1) * src_stride);
+        let out: *mut u8 = dst_ptr.add(dy * dst_stride);
+
+        let mut sx: usize = 0;
+        let mut dx: usize = 0;
+
+        // AVX2 loop: 32 input pixels → 16 output pixels per iteration
+        while sx + 32 <= src_stride {
+            let r0: __m256i = _mm256_loadu_si256(row0.add(sx) as *const __m256i);
+            let r1: __m256i = _mm256_loadu_si256(row1.add(sx) as *const __m256i);
+            // Horizontal pair sums (u8×1 + u8×1 → u16)
+            let h0: __m256i = _mm256_maddubs_epi16(r0, ones);
+            let h1: __m256i = _mm256_maddubs_epi16(r1, ones);
+            // 2×2 block sum + bias + shift
+            let sum: __m256i = _mm256_add_epi16(_mm256_add_epi16(h0, h1), bias);
+            let avg: __m256i = _mm256_srli_epi16::<2>(sum);
+            // Pack u16→u8 and fix lane ordering
+            let packed: __m256i = _mm256_packus_epi16(avg, _mm256_setzero_si256());
+            let ordered: __m256i = _mm256_permute4x64_epi64::<0b_11_01_10_00>(packed);
+            _mm_storeu_si128(out.add(dx) as *mut __m128i, _mm256_castsi256_si128(ordered));
+            sx += 32;
+            dx += 16;
+        }
+
+        // Scalar tail with alternating dither bias (1 for even, 2 for odd dx)
+        while sx + 1 < src_stride {
+            let a: u16 = *row0.add(sx) as u16;
+            let b: u16 = *row0.add(sx + 1) as u16;
+            let c: u16 = *row1.add(sx) as u16;
+            let d: u16 = *row1.add(sx + 1) as u16;
+            let dither: u16 = if dx & 1 == 0 { 1 } else { 2 };
+            *out.add(dx) = ((a + b + c + d + dither) / 4) as u8;
+            sx += 2;
+            dx += 1;
+        }
+    }
+}
+
 /// AVX2 quantization: adaptive-precision reciprocal multiply matching C libjpeg-turbo.
 ///
 /// Uses three pre-computed tables per element (from `compute_reciprocal`):

--- a/src/simd/x86_64/upsample.rs
+++ b/src/simd/x86_64/upsample.rs
@@ -87,3 +87,154 @@ unsafe fn load_u8x8_as_u16(ptr: *const u8) -> __m128i {
     let lo: __m128i = _mm_loadl_epi64(ptr as *const __m128i);
     _mm_unpacklo_epi8(lo, _mm_setzero_si128())
 }
+
+// ---------------------------------------------------------------------------
+// SSE2 Fancy H2V2 Upsample (fused single-pass 2D triangle filter)
+// ---------------------------------------------------------------------------
+
+/// SSE2 fancy 2x2 upsample (fused single-pass).
+///
+/// Same algorithm as AVX2 version but uses 128-bit registers,
+/// processing 8 input samples per iteration.
+pub fn sse2_fancy_upsample_h2v2(
+    input: &[u8],
+    in_width: usize,
+    in_height: usize,
+    output: &mut [u8],
+    out_width: usize,
+) {
+    if in_width == 0 || in_height == 0 {
+        return;
+    }
+
+    for y in 0..in_height {
+        let cur_row: &[u8] = &input[y * in_width..(y + 1) * in_width];
+        let above: &[u8] = if y > 0 {
+            &input[(y - 1) * in_width..y * in_width]
+        } else {
+            cur_row
+        };
+        let below: &[u8] = if y + 1 < in_height {
+            &input[(y + 1) * in_width..(y + 2) * in_width]
+        } else {
+            cur_row
+        };
+
+        let out_top: &mut [u8] = &mut output[y * 2 * out_width..(y * 2 + 1) * out_width];
+        sse2_fancy_h2v2_row(cur_row, above, out_top, in_width);
+
+        let out_bot: &mut [u8] = &mut output[(y * 2 + 1) * out_width..(y * 2 + 2) * out_width];
+        sse2_fancy_h2v2_row(cur_row, below, out_bot, in_width);
+    }
+}
+
+/// Fused SSE2 H2V2 fancy upsample for one output row.
+pub fn sse2_fancy_h2v2_row(cur: &[u8], neighbor: &[u8], output: &mut [u8], in_width: usize) {
+    if in_width < 3 {
+        crate::decode::upsample::fancy_h2v2_row(cur, neighbor, output, in_width);
+        return;
+    }
+
+    // First column (scalar edge)
+    let cs0: i32 = cur[0] as i32 * 3 + neighbor[0] as i32;
+    output[0] = ((cs0 * 4 + 8) >> 4) as u8;
+    let cs1: i32 = cur[1] as i32 * 3 + neighbor[1] as i32;
+    output[1] = ((cs0 * 3 + cs1 + 7) >> 4) as u8;
+
+    // SAFETY: SSE2 availability guaranteed by dispatch in x86_64::routines().
+    unsafe {
+        sse2_fancy_h2v2_row_inner(cur, neighbor, output, in_width);
+    }
+
+    // Last pixel (scalar edge): odd position
+    let last: usize = in_width - 1;
+    let cs_last: i32 = cur[last] as i32 * 3 + neighbor[last] as i32;
+    output[last * 2 + 1] = ((cs_last * 4 + 7) >> 4) as u8;
+}
+
+/// SSE2 inner loop for fused H2V2 fancy upsample.
+///
+/// Processes 8 input samples → 16 output pixels per iteration.
+///
+/// # Safety
+/// Requires SSE2. `in_width` must be >= 3.
+#[target_feature(enable = "sse2")]
+unsafe fn sse2_fancy_h2v2_row_inner(
+    cur: &[u8],
+    neighbor: &[u8],
+    output: &mut [u8],
+    in_width: usize,
+) {
+    let cur_ptr: *const u8 = cur.as_ptr();
+    let nbr_ptr: *const u8 = neighbor.as_ptr();
+    let out_ptr: *mut u8 = output.as_mut_ptr();
+
+    let three_u16: __m128i = _mm_set1_epi16(3);
+    let seven_u16: __m128i = _mm_set1_epi16(7);
+    let eight_u16: __m128i = _mm_set1_epi16(8);
+
+    let mut col: usize = 1;
+
+    // Main SIMD loop: 8 input samples → 16 output pixels per iteration.
+    while col + 8 <= in_width {
+        // Load 8 bytes from col-1 and col, widen u8→u16
+        let s0_cur: __m128i = load_u8x8_as_u16(cur_ptr.add(col - 1));
+        let s0_nbr: __m128i = load_u8x8_as_u16(nbr_ptr.add(col - 1));
+        let s1_cur: __m128i = load_u8x8_as_u16(cur_ptr.add(col));
+        let s1_nbr: __m128i = load_u8x8_as_u16(nbr_ptr.add(col));
+
+        // Vertical column sums: colsum = neighbor + 3 * cur
+        let s0_colsum: __m128i = _mm_add_epi16(s0_nbr, _mm_mullo_epi16(s0_cur, three_u16));
+        let s1_colsum: __m128i = _mm_add_epi16(s1_nbr, _mm_mullo_epi16(s1_cur, three_u16));
+
+        // Horizontal blend:
+        //   c1 = 3*s0_colsum + s1_colsum  → odd output positions
+        //   c2 = 3*s1_colsum + s0_colsum  → even output positions
+        let c1: __m128i = _mm_add_epi16(s1_colsum, _mm_mullo_epi16(s0_colsum, three_u16));
+        let c2: __m128i = _mm_add_epi16(s0_colsum, _mm_mullo_epi16(s1_colsum, three_u16));
+
+        // Bias and shift: c1+7>>4 (odd), c2+8>>4 (even)
+        let c1_shifted: __m128i = _mm_srli_epi16(_mm_add_epi16(c1, seven_u16), 4);
+        let c2_shifted: __m128i = _mm_srli_epi16(_mm_add_epi16(c2, eight_u16), 4);
+
+        // Narrow from u16 to u8 (no lane-crossing issue with SSE2)
+        let c1_u8: __m128i = _mm_packus_epi16(c1_shifted, _mm_setzero_si128());
+        let c2_u8: __m128i = _mm_packus_epi16(c2_shifted, _mm_setzero_si128());
+
+        // Interleave c1 (odd) and c2 (even): [c1[0] c2[0] c1[1] c2[1] ...]
+        let interleaved: __m128i = _mm_unpacklo_epi8(c1_u8, c2_u8);
+
+        // Store 16 bytes at output position col*2 - 1
+        _mm_storeu_si128(out_ptr.add(col * 2 - 1) as *mut __m128i, interleaved);
+
+        col += 8;
+    }
+
+    // Scalar tail
+    let colsum = |i: usize| -> i32 { cur[i] as i32 * 3 + neighbor[i] as i32 };
+
+    // Fill gap: odd pixel for last column whose even pixel was produced by SIMD
+    if col > 1 {
+        let boundary: usize = col - 1;
+        if boundary < in_width - 1 {
+            let this_cs: i32 = colsum(boundary);
+            let next_cs: i32 = colsum(boundary + 1);
+            output[boundary * 2 + 1] = ((this_cs * 3 + next_cs + 7) >> 4) as u8;
+        }
+    }
+
+    // Remaining columns
+    while col < in_width {
+        let this_cs: i32 = colsum(col);
+        let last_cs: i32 = colsum(col - 1);
+
+        output[col * 2] = ((this_cs * 3 + last_cs + 8) >> 4) as u8;
+
+        if col + 1 < in_width {
+            let next_cs: i32 = colsum(col + 1);
+            output[col * 2 + 1] = ((this_cs * 3 + next_cs + 7) >> 4) as u8;
+        }
+
+        col += 1;
+    }
+}

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -375,7 +375,12 @@ fn parse_ppm_p6(data: &[u8]) -> (usize, usize, Vec<u8>) {
 /// Decode a JPEG with C djpeg to PPM and return raw RGB pixels.
 fn decode_with_djpeg(djpeg: &std::path::Path, jpeg_data: &[u8]) -> Vec<u8> {
     let tmp_dir = std::env::temp_dir();
-    let input_path = tmp_dir.join("conformance_djpeg_input.jpg");
+    let unique_id = format!(
+        "conformance_djpeg_{}_{:?}.jpg",
+        std::process::id(),
+        std::thread::current().id()
+    );
+    let input_path = tmp_dir.join(unique_id);
     std::fs::write(&input_path, jpeg_data).expect("failed to write temp JPEG");
 
     let output = Command::new(djpeg)


### PR DESCRIPTION
## Summary

- **AVX2/SSE2 Fancy H2V2 Upsample**: fused vertical+horizontal triangle filter for 4:2:0 decode (+11%)
- **AVX2 multi-format encode color conversion**: RGBA/BGR/BGRA via SSSE3 pshufb deinterleave
- **420 encode pre-downsample**: compact half-res chroma buffers (+16% encode)
- **JPEG_NBITS lookup table**: replaces lzcnt dependency chain in Huffman encoding (+9% encode)
- **Row-level hoisted bit buffer**: single begin/end per MCU row for 420
- **Fused encode pipeline**: extended MCU-row-at-a-time path to all pixel formats
- **Test fix**: unique temp files in conformance tests (parallel race condition)

## Performance Results (Intel i5-10400)

### Decode (Rust vs C libjpeg-turbo)

| Benchmark | Before | After | vs C |
|-----------|--------|-------|------|
| photo_1920x1080_420 | 16,127 us | 14,305 us | **0.91x** (faster than C!) |
| photo_3840x2160_420 | 63,707 us | 58,323 us | **0.98x** |
| vs zune-jpeg (1080p) | — | — | **0.81x** (19% faster) |

### Encode (Rust vs C libjpeg-turbo)

| Benchmark | Before | After | vs C |
|-----------|--------|-------|------|
| encode_1920x1080_420 | 11,576 us | **8,693 us** | **1.02x** (parity!) |
| encode_1920x1080_422 | 12,188 us | **10,683 us** | **0.95x** (faster than C!) |
| encode_1920x1080_444 | 18,034 us | **15,865 us** | **1.02x** (parity!) |

## Test plan

- [x] `cargo test` — 1,762 passed, 0 failed
- [x] C djpeg cross-validation (diff=0)
- [x] Bitstream regression tests
- [x] Conformance tests (parallel-safe)
- [x] `cargo clippy --lib -- -D warnings` clean

Related: #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)