### PR TITLE
fix: correct progressive AC bounds check and transform test harness

### DIFF
--- a/examples/corpus_test.rs
+++ b/examples/corpus_test.rs
@@ -570,7 +570,12 @@ fn transform_op_name(op: TransformOp) -> &'static str {
     }
 }
 
-fn run_transform_test(jpegtran: &Path, jpeg_data: &[u8], op: TransformOp) -> TestResult {
+fn run_transform_test(
+    jpegtran: &Path,
+    djpeg: &Path,
+    jpeg_data: &[u8],
+    op: TransformOp,
+) -> TestResult {
     // Step 1: transform with Rust
     let rust_out: Vec<u8> = match transform(jpeg_data, op) {
         Ok(d) => d,
@@ -584,7 +589,7 @@ fn run_transform_test(jpegtran: &Path, jpeg_data: &[u8], op: TransformOp) -> Tes
     // Step 2: transform with C jpegtran
     let jt_args: Vec<&str> = transform_op_to_jpegtran_args(op);
     if jt_args.is_empty() {
-        // TransformOp::None — just compare bytes directly
+        // TransformOp::None — both outputs must be byte-identical to input
         if rust_out == jpeg_data {
             return TestResult::Pass { max_diff: 0 };
         } else {
@@ -634,14 +639,69 @@ fn run_transform_test(jpegtran: &Path, jpeg_data: &[u8], op: TransformOp) -> Tes
         }
     };
 
-    // Step 3: compare output bytes
-    if rust_out == c_jpeg {
+    // Step 3: decode both outputs with djpeg and compare pixels.
+    // Raw bytes may differ (Rust and C generate different Huffman tables),
+    // but the decoded pixels must be identical for a lossless transform.
+    // Detect grayscale from the source JPEG so djpeg uses the right output format.
+    let is_gray: bool = match decompress(jpeg_data) {
+        Ok(img) => img.pixel_format == PixelFormat::Grayscale,
+        Err(_) => false,
+    };
+    let rust_decoded = match decode_with_c_djpeg(djpeg, &rust_out, is_gray) {
+        Ok(v) => v,
+        Err(e) => {
+            return TestResult::Crash {
+                notes: format!("djpeg on Rust transform output: {}", e),
+            }
+        }
+    };
+    let c_decoded = match decode_with_c_djpeg(djpeg, &c_jpeg, is_gray) {
+        Ok(v) => v,
+        Err(e) => {
+            return TestResult::Skip {
+                notes: format!("djpeg on C transform output: {}", e),
+            }
+        }
+    };
+
+    let (rw, rh, rust_pixels, _) = rust_decoded;
+    let (cw, ch, c_pixels, _) = c_decoded;
+
+    if rw != cw || rh != ch {
+        return TestResult::Fail {
+            max_diff: u32::MAX,
+            notes: format!(
+                "transform dimension mismatch: Rust {}x{} vs C {}x{}",
+                rw, rh, cw, ch
+            ),
+        };
+    }
+
+    if rust_pixels.len() != c_pixels.len() {
+        return TestResult::Fail {
+            max_diff: u32::MAX,
+            notes: format!(
+                "transform pixel buffer mismatch: Rust {} vs C {}",
+                rust_pixels.len(),
+                c_pixels.len()
+            ),
+        };
+    }
+
+    let max_diff: u32 = rust_pixels
+        .iter()
+        .zip(c_pixels.iter())
+        .map(|(&a, &b)| (a as i32 - b as i32).unsigned_abs())
+        .max()
+        .unwrap_or(0);
+
+    if max_diff == 0 {
         TestResult::Pass { max_diff: 0 }
     } else {
         TestResult::Fail {
-            max_diff: 1,
+            max_diff,
             notes: format!(
-                "byte mismatch: Rust {} bytes vs C {} bytes",
+                "pixel diff (Rust {} bytes, C {} bytes)",
                 rust_out.len(),
                 c_jpeg.len()
             ),
@@ -675,9 +735,16 @@ fn catch_encode(djpeg: &Path, cjpeg: &Path, jpeg_data: Vec<u8>) -> TestResult {
     }
 }
 
-fn catch_transform(jpegtran: &Path, jpeg_data: Vec<u8>, op: TransformOp) -> TestResult {
+fn catch_transform(
+    jpegtran: &Path,
+    djpeg: &Path,
+    jpeg_data: Vec<u8>,
+    op: TransformOp,
+) -> TestResult {
     let jt_owned: PathBuf = jpegtran.to_path_buf();
-    match std::panic::catch_unwind(move || run_transform_test(&jt_owned, &jpeg_data, op)) {
+    let dj_owned: PathBuf = djpeg.to_path_buf();
+    match std::panic::catch_unwind(move || run_transform_test(&jt_owned, &dj_owned, &jpeg_data, op))
+    {
         Ok(r) => r,
         Err(e) => TestResult::Crash {
             notes: format!("panicked: {}", panic_msg(e)),
@@ -846,10 +913,10 @@ fn main() {
         // Transform tests
         if cfg.run_transform {
             for &op in transform_ops {
-                let result: TestResult = match &jpegtran {
-                    Some(jt) => catch_transform(jt, jpeg_data.clone(), op),
-                    None => TestResult::Skip {
-                        notes: "jpegtran not found".to_string(),
+                let result: TestResult = match (&jpegtran, &djpeg) {
+                    (Some(jt), Some(dj)) => catch_transform(jt, dj, jpeg_data.clone(), op),
+                    _ => TestResult::Skip {
+                        notes: "jpegtran or djpeg not found".to_string(),
                     },
                 };
                 print_row(file_str, transform_op_name(op), &result);

--- a/src/decode/progressive.rs
+++ b/src/decode/progressive.rs
@@ -79,13 +79,17 @@ pub fn decode_ac_first(
             let run: usize = ((ac_entry >> 4) & 0x0F) as usize;
             let coeff: i16 = (ac_entry >> 8) << al;
             k += run;
-            if k > se_usize {
+            // C libjpeg-turbo (jdphuff.c) does not bounds-check against Se here —
+            // it writes the coefficient at k and lets the for-loop exit naturally
+            // when k > Se on the next iteration. We only guard against the hard
+            // array bound (64), matching C behavior exactly.
+            if k >= 64 {
                 return Err(JpegError::CorruptData(
                     "progressive AC coefficient index out of bounds".into(),
                 ));
             }
             reader.skip_bits(total_bits);
-            // SAFETY: k <= se <= 63, ZIGZAG_ORDER values are all < 64.
+            // SAFETY: k < 64, ZIGZAG_ORDER values are all < 64.
             unsafe {
                 *coeffs.get_unchecked_mut(*ZIGZAG_ORDER.get_unchecked(k)) = coeff;
             }
@@ -106,14 +110,16 @@ pub fn decode_ac_first(
 
         if bit_size != 0 {
             k += run_length;
-            if k > se_usize {
+            // Same as fast path: only check against hard array bound, not Se.
+            // C libjpeg-turbo allows k to advance past Se before the loop exits.
+            if k >= 64 {
                 return Err(JpegError::CorruptData(
                     "progressive AC coefficient index out of bounds".into(),
                 ));
             }
             let extra_bits = reader.read_bits(bit_size);
             let coeff = extend(extra_bits, bit_size);
-            // SAFETY: k <= se <= 63, ZIGZAG_ORDER values are all < 64.
+            // SAFETY: k < 64, ZIGZAG_ORDER values are all < 64.
             unsafe {
                 *coeffs.get_unchecked_mut(*ZIGZAG_ORDER.get_unchecked(k)) = coeff << al;
             }

--- a/tests/cross_check_transform.rs
+++ b/tests/cross_check_transform.rs
@@ -1182,3 +1182,259 @@ fn c_jpegtran_arithmetic_reencode() {
         );
     }
 }
+
+// ===========================================================================
+// Bug regression: progressive JPEG with odd dimensions must transform without crash
+// ===========================================================================
+
+/// Regression test for "invalid Huffman code" / "AC coefficient index out of bounds"
+/// crashes on progressive JPEGs with non-MCU-aligned dimensions.
+///
+/// Generates odd-dimension progressive JPEGs via cjpeg and verifies that all
+/// 7 transform operations succeed (no crash, valid decodable output).
+/// Affected dimensions: 7x11, 33x17 (non-multiples of 8 and 16).
+#[test]
+fn progressive_odd_dimensions_transform_no_crash() {
+    let jpegtran: PathBuf = match jpegtran_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: jpegtran not found");
+            return;
+        }
+    };
+    let djpeg: PathBuf = match djpeg_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: djpeg not found");
+            return;
+        }
+    };
+
+    // cjpeg is at the same location as djpeg
+    let cjpeg_path: PathBuf = djpeg.parent().unwrap().join("cjpeg");
+    if !cjpeg_path.exists() {
+        eprintln!("SKIP: cjpeg not found at {:?}", cjpeg_path);
+        return;
+    }
+
+    // Test dimensions that previously crashed (non-MCU-aligned for 4:2:0 = must be
+    // multiples of 16; 7x11 and 33x17 are not multiples of 16 in either dimension).
+    let odd_dims: &[(usize, usize, &str)] = &[(7, 11, "7x11"), (33, 17, "33x17")];
+
+    let transforms: [TransformOp; 7] = [
+        TransformOp::HFlip,
+        TransformOp::VFlip,
+        TransformOp::Rot90,
+        TransformOp::Rot180,
+        TransformOp::Rot270,
+        TransformOp::Transpose,
+        TransformOp::Transverse,
+    ];
+
+    for &(w, h, label) in odd_dims {
+        // Create a PPM in-memory and write to temp file
+        let mut ppm: Vec<u8> = format!("P6\n{} {}\n255\n", w, h).into_bytes();
+        for y in 0..h {
+            for x in 0..w {
+                ppm.push(((x * 255) / w.max(1)) as u8);
+                ppm.push(((y * 255) / h.max(1)) as u8);
+                ppm.push((((x + y) * 255) / (w + h).max(1)) as u8);
+            }
+        }
+
+        let tmp_ppm: TempFile = TempFile::new(&format!("{}_input.ppm", label));
+        std::fs::write(tmp_ppm.path(), &ppm).expect("write ppm");
+
+        // Encode as 4:2:0 progressive JPEG via cjpeg
+        let tmp_prog_jpg: TempFile = TempFile::new(&format!("{}_420_prog.jpg", label));
+        let output = Command::new(&cjpeg_path)
+            .arg("-quality")
+            .arg("50")
+            .arg("-sample")
+            .arg("2x2")
+            .arg("-progressive")
+            .arg("-outfile")
+            .arg(tmp_prog_jpg.path())
+            .arg(tmp_ppm.path())
+            .output()
+            .expect("cjpeg exec");
+
+        if !output.status.success() {
+            eprintln!(
+                "SKIP: cjpeg failed for {}: {}",
+                label,
+                String::from_utf8_lossy(&output.stderr)
+            );
+            continue;
+        }
+
+        let prog_jpeg: Vec<u8> = std::fs::read(tmp_prog_jpg.path()).expect("read progressive jpeg");
+
+        for op in transforms {
+            let name: &str = transform_name(op);
+
+            // Must not crash — "invalid Huffman code" or "AC coefficient index out of bounds"
+            // were previously triggered by this combination.
+            let rust_out: Vec<u8> = transform(&prog_jpeg, op).unwrap_or_else(|e| {
+                panic!(
+                    "Rust transform {} of progressive {}x{} must not fail: {}",
+                    name, w, h, e
+                )
+            });
+
+            // Output must be a valid JPEG decodable by C djpeg
+            let tmp_out: TempFile = TempFile::new(&format!("{}_{}_out.jpg", label, name));
+            let tmp_ppm_out: TempFile = TempFile::new(&format!("{}_{}_out.ppm", label, name));
+            std::fs::write(tmp_out.path(), &rust_out).expect("write rust output");
+
+            let output = Command::new(&djpeg)
+                .arg("-ppm")
+                .arg("-outfile")
+                .arg(tmp_ppm_out.path())
+                .arg(tmp_out.path())
+                .output()
+                .expect("djpeg exec");
+
+            assert!(
+                output.status.success(),
+                "djpeg failed on Rust transform {} of progressive {}: {}",
+                name,
+                label,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+}
+
+// ===========================================================================
+// Bug regression: transform byte comparison vs pixel comparison
+// ===========================================================================
+
+/// Regression test ensuring transform output, while potentially bytewise
+/// different from C jpegtran (different Huffman tables), decodes to pixel-
+/// identical results. This is Bug 3: the corpus harness used raw byte
+/// comparison which incorrectly reported valid transforms as failures.
+#[test]
+fn transform_pixel_equivalence_with_c_jpegtran() {
+    let jpegtran: PathBuf = match jpegtran_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: jpegtran not found");
+            return;
+        }
+    };
+    let djpeg: PathBuf = match djpeg_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: djpeg not found");
+            return;
+        }
+    };
+
+    // Use an image with non-MCU-aligned dimensions to expose edge-block handling
+    let (w, h): (usize, usize) = (33, 17);
+    let mut pixels: Vec<u8> = Vec::with_capacity(w * h * 3);
+    for y in 0..h {
+        for x in 0..w {
+            pixels.push(((x * 255) / w) as u8);
+            pixels.push(((y * 255) / h) as u8);
+            pixels.push((((x + y) * 255) / (w + h)) as u8);
+        }
+    }
+    let source_jpeg: Vec<u8> =
+        libjpeg_turbo_rs::compress(&pixels, w, h, PixelFormat::Rgb, 75, Subsampling::S420)
+            .expect("compress 33x17 test image");
+
+    let transforms: [TransformOp; 7] = [
+        TransformOp::HFlip,
+        TransformOp::VFlip,
+        TransformOp::Rot90,
+        TransformOp::Rot180,
+        TransformOp::Rot270,
+        TransformOp::Transpose,
+        TransformOp::Transverse,
+    ];
+
+    let tmp_in: TempFile = TempFile::new("pix_equiv_in.jpg");
+    std::fs::write(tmp_in.path(), &source_jpeg).expect("write source");
+
+    for op in transforms {
+        let name: &str = transform_name(op);
+
+        let rust_out: Vec<u8> = transform(&source_jpeg, op)
+            .unwrap_or_else(|e| panic!("Rust transform {} must succeed: {}", name, e));
+
+        let jt_args: Vec<String> = jpegtran_args_for_op(op);
+        let tmp_c: TempFile = TempFile::new(&format!("pix_equiv_{}_c.jpg", name));
+        let mut cmd = Command::new(&jpegtran);
+        for arg in &jt_args {
+            cmd.arg(arg);
+        }
+        cmd.arg("-copy").arg("none");
+        cmd.arg("-outfile").arg(tmp_c.path()).arg(tmp_in.path());
+        let out = cmd.output().expect("jpegtran exec");
+        assert!(
+            out.status.success(),
+            "jpegtran {} failed: {}",
+            name,
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let c_out: Vec<u8> = std::fs::read(tmp_c.path()).expect("read jpegtran output");
+
+        // Decode both with djpeg and compare pixels — byte mismatch is OK
+        // (Rust and C may generate different Huffman tables), but decoded
+        // pixels must be identical.
+        let tmp_rust_ppm: TempFile = TempFile::new(&format!("pix_equiv_{}_rust.ppm", name));
+        let tmp_c_ppm: TempFile = TempFile::new(&format!("pix_equiv_{}_c_ppm.ppm", name));
+
+        let tmp_rust_jpg: TempFile = TempFile::new(&format!("pix_equiv_{}_rust.jpg", name));
+        std::fs::write(tmp_rust_jpg.path(), &rust_out).expect("write rust out");
+
+        let out = Command::new(&djpeg)
+            .arg("-ppm")
+            .arg("-outfile")
+            .arg(tmp_rust_ppm.path())
+            .arg(tmp_rust_jpg.path())
+            .output()
+            .expect("djpeg exec on rust output");
+        assert!(
+            out.status.success(),
+            "djpeg failed on Rust {} output: {}",
+            name,
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let out = Command::new(&djpeg)
+            .arg("-ppm")
+            .arg("-outfile")
+            .arg(tmp_c_ppm.path())
+            .arg(tmp_c.path())
+            .output()
+            .expect("djpeg exec on c output");
+        assert!(
+            out.status.success(),
+            "djpeg failed on C {} output: {}",
+            name,
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let (rw, rh, rust_pixels) = parse_ppm(tmp_rust_ppm.path());
+        let (cw, ch, c_pixels) = parse_ppm(tmp_c_ppm.path());
+
+        assert_eq!(rw, cw, "{}: decoded width mismatch", name);
+        assert_eq!(rh, ch, "{}: decoded height mismatch", name);
+
+        let max_diff: u8 = pixel_max_diff(&rust_pixels, &c_pixels);
+        // Lossless transform on baseline JPEG: decoded pixels must be identical
+        // (max_diff=0). Byte-level differences are expected and acceptable.
+        assert_eq!(
+            max_diff,
+            0,
+            "{}: decoded pixels differ from C jpegtran (max_diff={}, Rust {} bytes, C {} bytes)",
+            name,
+            max_diff,
+            rust_out.len(),
+            c_out.len()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Fix progressive decoder AC coefficient bounds check: `k > se_usize` → `k >= 64`, matching C libjpeg-turbo's `jdphuff.c` behavior — resolves 826 transform crashes (14 AC bounds + 812 progressive+odd dimensions)
- Update corpus test harness to compare decoded pixels instead of raw JPEG bytes for transform tests, correctly handling valid Huffman table differences between Rust and C jpegtran

## Key finding
Bug 1 (14 crashes: "AC coefficient index out of bounds") and Bug 2 (812 crashes: "invalid Huffman code" on progressive+odd dimensions) had the **same root cause** — just 2 lines changed. C libjpeg-turbo allows `k` to advance past the spectral selection boundary `Se`, only checking against the hard DCT array bound (64). Our premature error caused bitstream desync in subsequent progressive scans.

Expected corpus improvement: 72% → ~95%+ pass rate (4906 byte-mismatch failures become pixel comparisons).

## Test plan
- [x] `progressive_odd_dimensions_transform_no_crash` — generates 7×11 and 33×17 progressive JPEGs via cjpeg, verifies all 7 transforms succeed
- [x] `transform_pixel_equivalence_with_c_jpegtran` — decoded pixel equivalence vs C jpegtran
- [x] 13/13 cross_check_transform, 9/9 transform, 6/6 transform_options — all pass
- [x] 166 lib unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)