### PR TITLE
docs: tighten parity documentation

### DIFF
--- a/docs/C_API_REFERENCE.md
+++ b/docs/C_API_REFERENCE.md
@@ -1,7 +1,8 @@
 # libjpeg-turbo C API → Rust Mapping Reference
 
 > Every public C function from `turbojpeg.h` and `jpeglib.h` with description and Rust equivalent.
-> ✅ = implemented, ❌ = not yet, 🔶 = partial, N/A = not applicable in Rust
+> ✅ = end-to-end public equivalent, ❌ = not yet, 🔶 = partial or different surface, N/A = not applicable in Rust
+> If support only exists through a different Rust API surface, an internal helper, or a storage-only `TjHandle` field, use `🔶` rather than `✅`.
 
 ---
 
@@ -21,43 +22,45 @@
 | `tj3Set(handle, param, value)` | Set integer parameter | `TjHandle::set()` | ✅ |
 | `tj3Get(handle, param)` | Get integer parameter | `TjHandle::get()` | ✅ |
 
+`TjHandle` get/set exists, but several parameters below are only partially wired through `compress()` / `decompress()`.
+
 **All 26 TJPARAM values:**
 
 | TJPARAM | Description | Rust | Status |
 |---|---|---|---|
 | `STOPONWARNING` | Treat warnings as fatal | `Decoder::set_stop_on_warning()` | ✅ |
 | `BOTTOMUP` | Bottom-up row order | `Encoder::bottom_up()` / `ScanlineDecoder::set_bottom_up()` | ✅ |
-| `NOREALLOC` | Disable output buffer realloc | `compress_into()` | ✅ |
+| `NOREALLOC` | Disable output buffer realloc | `compress_into()` (separate API, not `TjHandle`) | 🔶 |
 | `QUALITY` | Lossy quality 1-100 | `quality: u8` param | ✅ |
 | `SUBSAMP` | Chroma subsampling | `subsampling: Subsampling` param | ✅ |
 | `JPEGWIDTH` | JPEG image width (read-only) | `Image.width` | ✅ |
 | `JPEGHEIGHT` | JPEG image height (read-only) | `Image.height` | ✅ |
-| `PRECISION` | Sample precision 2-16 bits | `compress_lossless_arbitrary()` / `decompress_lossless_arbitrary()` | ✅ |
-| `COLORSPACE` | JPEG colorspace | `Encoder::colorspace()` / `Decoder::set_output_colorspace()` | ✅ |
+| `PRECISION` | Sample precision 2-16 bits | `compress_12bit()`, `compress_16bit()`, `decompress_12bit()`, `decompress_16bit()`, `compress_lossless_arbitrary()` / `decompress_lossless_arbitrary()` | 🔶 |
+| `COLORSPACE` | JPEG colorspace | `Encoder::colorspace()` / `Decoder::set_output_colorspace()` | 🔶 |
 | `FASTUPSAMPLE` | Nearest-neighbor upsampling | `Decoder::set_fast_upsample()` | ✅ |
 | `FASTDCT` | Fast DCT/IDCT algorithm | `Decoder::set_fast_dct()` | ✅ |
 | `OPTIMIZE` | Optimized Huffman tables | `compress_optimized()` | ✅ |
 | `PROGRESSIVE` | Progressive JPEG mode | `compress_progressive()` | ✅ |
 | `SCANLIMIT` | Max progressive scans | `Decoder::set_scan_limit()` | ✅ |
-| `ARITHMETIC` | Arithmetic entropy coding | `compress_arithmetic()` | ✅ |
+| `ARITHMETIC` | Arithmetic entropy coding | `compress_arithmetic()`, `TransformOptions::arithmetic` | ✅ |
 | `LOSSLESS` | Lossless JPEG mode | `compress_lossless()` | ✅ |
 | `LOSSLESSPSV` | Lossless predictor 1-7 | `Encoder::lossless_predictor()` | ✅ |
 | `LOSSLESSPT` | Lossless point transform 0-15 | `Encoder::lossless_point_transform()` | ✅ |
 | `RESTARTBLOCKS` | Restart interval (MCU blocks) | `Encoder::restart_blocks()` | ✅ |
 | `RESTARTROWS` | Restart interval (MCU rows) | `Encoder::restart_rows()` | ✅ |
-| `XDENSITY` | Horizontal pixel density | `DensityInfo` | ✅ |
-| `YDENSITY` | Vertical pixel density | `DensityInfo` | ✅ |
-| `DENSITYUNITS` | 0=unknown, 1=ppi, 2=ppcm | `DensityUnit` enum | ✅ |
+| `XDENSITY` | Horizontal pixel density | `Image.density` read + `JpegCoefficients.x_density` low-level rewrite | 🔶 |
+| `YDENSITY` | Vertical pixel density | `Image.density` read + `JpegCoefficients.y_density` low-level rewrite | 🔶 |
+| `DENSITYUNITS` | 0=unknown, 1=ppi, 2=ppcm | `Image.density` read + `JpegCoefficients.density_unit` low-level rewrite | 🔶 |
 | `MAXMEMORY` | Memory limit | `Decoder::set_max_memory()` | ✅ |
 | `MAXPIXELS` | Image size limit | `Decoder::set_max_pixels()` | ✅ |
-| `SAVEMARKERS` | Marker preservation level 0-4 | `MarkerSaveConfig` enum | ✅ |
+| `SAVEMARKERS` | Marker preservation level 0-4 | `Decoder::save_markers()` / `MarkerSaveConfig` | 🔶 |
 
 ### Memory
 
 | C Function | Description | Rust | Status |
 |---|---|---|---|
-| `tj3Alloc(bytes)` | Allocate buffer | `Vec::with_capacity()` | ✅ |
-| `tj3Free(buffer)` | Free buffer | `drop()` / RAII | ✅ |
+| `tj3Alloc(bytes)` | Allocate buffer | `Vec::with_capacity()` / owned buffers | 🔶 |
+| `tj3Free(buffer)` | Free buffer | `drop()` / RAII | 🔶 |
 
 ### Buffer Size Calculation
 
@@ -73,16 +76,16 @@
 
 | C Function | Description | Rust | Status |
 |---|---|---|---|
-| `tj3SetICCProfile(handle, buf, size)` | Set ICC for encoding | `compress_with_metadata(icc_profile: Some(&data))` | ✅ |
-| `tj3GetICCProfile(handle, &buf, &size)` | Get ICC after decode | `Image.icc_profile()` | ✅ |
+| `tj3SetICCProfile(handle, buf, size)` | Set ICC for encoding | `TjHandle::set_icc_profile()` / `Encoder::icc_profile()` | ✅ |
+| `tj3GetICCProfile(handle, &buf, &size)` | Get ICC after decode | `Image.icc_profile()` | 🔶 |
 
 ### Compression (8-bit)
 
 | C Function | Description | Rust | Status |
 |---|---|---|---|
 | `tj3Compress8(handle, src, w, pitch, h, pf, &dst, &size)` | Compress 8-bit pixels to JPEG | `compress()`, `compress_optimized()`, etc. | ✅ |
-| `tj3Compress12(handle, src, w, pitch, h, pf, &dst, &size)` | Compress 12-bit pixels | `write_scanlines_12()` + TjHandle | ✅ |
-| `tj3Compress16(handle, src, w, pitch, h, pf, &dst, &size)` | Compress 16-bit pixels (lossless only) | `write_scanlines_16()` + TjHandle | ✅ |
+| `tj3Compress12(handle, src, w, pitch, h, pf, &dst, &size)` | Compress 12-bit pixels | `compress_12bit()` / `write_scanlines_12()` | 🔶 |
+| `tj3Compress16(handle, src, w, pitch, h, pf, &dst, &size)` | Compress 16-bit pixels (lossless only) | `compress_16bit()` / `write_scanlines_16()` | 🔶 |
 
 ### Compression from YUV
 
@@ -117,8 +120,8 @@
 | C Function | Description | Rust | Status |
 |---|---|---|---|
 | `tj3Decompress8(handle, jpeg, size, dst, pitch, pf)` | Decompress JPEG to 8-bit pixels | `decompress()`, `decompress_to()` | ✅ |
-| `tj3Decompress12(handle, jpeg, size, dst, pitch, pf)` | Decompress to 12-bit | `read_scanlines_12()` + TjHandle | ✅ |
-| `tj3Decompress16(handle, jpeg, size, dst, pitch, pf)` | Decompress to 16-bit | `read_scanlines_16()` + TjHandle | ✅ |
+| `tj3Decompress12(handle, jpeg, size, dst, pitch, pf)` | Decompress to 12-bit | `decompress_12bit()` / `read_scanlines_12()` | 🔶 |
+| `tj3Decompress16(handle, jpeg, size, dst, pitch, pf)` | Decompress to 16-bit | `decompress_16bit()` / `read_scanlines_16()` | 🔶 |
 
 ### Decompression to YUV
 
@@ -138,22 +141,22 @@
 
 | C Function | Description | Rust | Status |
 |---|---|---|---|
-| `tj3Transform(handle, jpeg, size, n, &dstBufs, &dstSizes, transforms)` | Lossless transform with options | `transform_jpeg()` (all ops + all TJXOPT flags + custom filter) | ✅ |
+| `tj3Transform(handle, jpeg, size, n, &dstBufs, &dstSizes, transforms)` | Lossless transform with options | `transform_jpeg()` / `transform_jpeg_with_options()` (all ops + all TJXOPT flags, including arithmetic/progressive output, + custom filter) | ✅ |
 | `tj3TransformBufSize(handle, transform)` | Estimate output buffer size | `transform_buf_size()` | ✅ |
 
 ### Error Handling
 
 | C Function | Description | Rust | Status |
 |---|---|---|---|
-| `tj3GetErrorStr(handle)` | Get error message string | `JpegError` Display impl | ✅ |
-| `tj3GetErrorCode(handle)` | Get TJERR_WARNING or TJERR_FATAL | `Result<T, JpegError>` | ✅ |
+| `tj3GetErrorStr(handle)` | Get error message string | `JpegError` Display impl (no per-handle getter) | 🔶 |
+| `tj3GetErrorCode(handle)` | Get TJERR_WARNING or TJERR_FATAL | `Result<T, JpegError>` / no C-style getter | 🔶 |
 
 ### Image File I/O
 
 | C Function | Description | Rust | Status |
 |---|---|---|---|
-| `tj3LoadImage8(handle, filename, &w, align, &h, &pf)` | Load BMP/PPM to 8-bit buffer | `load_image()` / `load_image_from_bytes()` | ✅ |
-| `tj3SaveImage8(handle, filename, buf, w, pitch, h, pf)` | Save 8-bit buffer to BMP/PPM | `save_bmp()` / `save_ppm()` | ✅ |
+| `tj3LoadImage8(handle, filename, &w, align, &h, &pf)` | Load 8-bit BMP/PPM/PGM subset | `load_image()` / `load_image_from_bytes()` | 🔶 |
+| `tj3SaveImage8(handle, filename, buf, w, pitch, h, pf)` | Save 8-bit BMP/PPM/PGM subset | `save_bmp()` / `save_ppm()` | 🔶 |
 | `tj3LoadImage12(...)` / `tj3SaveImage12(...)` | 12-bit file I/O | — | ❌ |
 | `tj3LoadImage16(...)` / `tj3SaveImage16(...)` | 16-bit file I/O | — | ❌ |
 
@@ -223,7 +226,7 @@
 | `jpeg_write_m_header(cinfo, marker, len)` | Begin streaming marker write | `MarkerStreamWriter` | ✅ |
 | `jpeg_write_m_byte(cinfo, val)` | Write one byte of marker data | `MarkerStreamWriter` | ✅ |
 | `jpeg_write_tables(cinfo)` | Write tables-only datastream | — | ❌ |
-| `jpeg_write_icc_profile(cinfo, data, len)` | Write ICC profile | `marker_writer::write_app2_icc()` | ✅ |
+| `jpeg_write_icc_profile(cinfo, data, len)` | Write ICC profile | `marker_writer::write_app2_icc()` | 🔶 |
 
 ### Decompression
 
@@ -279,7 +282,7 @@
 
 | C Function | Description | Rust | Status |
 |---|---|---|---|
-| `jpeg_resync_to_restart(cinfo, desired)` | Resync to restart marker after error | Internal in decoder | ✅ |
+| `jpeg_resync_to_restart(cinfo, desired)` | Resync to restart marker after error | Internal in decoder | 🔶 |
 
 ### ICC Profile
 
@@ -500,18 +503,25 @@
 
 ---
 
-## Remaining Gaps
+## Remaining Gaps / Partial Mappings
 
-Only these items from the C API remain unimplemented:
+These are the highest-signal C API surfaces that still lack end-to-end public parity, even when adjacent Rust APIs exist:
 
-| C Function | Category | Notes |
+| C Function / Surface | Status | Notes |
 |---|---|---|
-| `jpeg_default_colorspace()` | Compression setup | Reset to default colorspace |
-| `jpeg_default_qtables()` | Compression setup | Reset quant tables to defaults |
-| `jpeg_suppress_tables()` | Compression setup | Table suppression for multi-image streams |
-| `jpeg_write_tables()` | Marker writing | Tables-only datastream (abbreviated JPEG) |
-| `jpeg12_write_raw_data()` | Compression | 12-bit raw data write |
-| `jpeg12_read_raw_data()` | Decompression | 12-bit raw data read |
-| `tj3LoadImage12/16()` | Image I/O | 12/16-bit BMP/PPM file I/O |
-| `tj3SaveImage12/16()` | Image I/O | 12/16-bit BMP/PPM file I/O |
-| `JPEG_HEADER_TABLES_ONLY` | Return code | Tables-only datastream detection |
+| `TJPARAM_NOREALLOC`, `PRECISION`, `COLORSPACE`, `XDENSITY`, `YDENSITY`, `DENSITYUNITS`, `SAVEMARKERS` on `TjHandle` | 🔶 | Stored on `TjHandle`, but not all are applied end-to-end by `compress()` / `decompress()` |
+| `tj3GetICCProfile(handle)` | 🔶 | ICC can be read from `Image`, but decode does not populate the handle-level ICC buffer |
+| `tj3Compress12/16()` / `tj3Decompress12/16()` | 🔶 | Implemented through precision-specific Rust APIs, not through the `TjHandle` surface |
+| `tj3LoadImage8()` / `tj3SaveImage8()` full parity | 🔶 | Rust only covers BMP/PPM/PGM 8-bit helpers, not PNG or the full handle-driven semantics from C |
+| `tj3LoadImage12/16()` / `tj3SaveImage12/16()` | ❌ | Missing |
+| `tj3GetErrorStr()` / `tj3GetErrorCode()` | 🔶 | Rust uses `Result` / `JpegError`, not C-style per-handle getters |
+| `tj3Alloc()` / `tj3Free()` dedicated allocator API | 🔶 | Idiomatic Rust ownership exists, but not a TurboJPEG allocator entry point |
+| `jpeg_write_icc_profile()` | 🔶 | Low-level helper exists, but no libjpeg-style public wrapper around a compression state object |
+| `jpeg_resync_to_restart()` | 🔶 | Internal behavior only, no public hook |
+| `jpeg_default_colorspace()` | ❌ | Missing |
+| `jpeg_default_qtables()` | ❌ | Missing |
+| `jpeg_suppress_tables()` | ❌ | Missing |
+| `jpeg_write_tables()` | ❌ | Missing |
+| `jpeg12_write_raw_data()` | ❌ | Missing |
+| `jpeg12_read_raw_data()` | ❌ | Missing |
+| `JPEG_HEADER_TABLES_ONLY` | ❌ | Tables-only datastream detection missing |

--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -2,6 +2,8 @@
 
 > Track implementation progress. Update checkboxes when features are completed.
 > Source of truth: `turbojpeg.h` (TJ3 API), `jpeglib.h` (libjpeg API), `jmorecfg.h`
+> Reliability rule: `[x]` means the documented public Rust surface is wired end-to-end for the claimed capability.
+> Merely storing a `TjHandle` parameter, exposing an internal helper, or supporting a nearby API surface does not count as full parity.
 
 ---
 
@@ -28,8 +30,8 @@
 ## 2. Sample Precision
 
 - [x] 8-bit (`JSAMPLE` / `u8`)
-- [x] 12-bit (`J12SAMPLE` / `i16`) — `tj3Compress12`, `tj3Decompress12`, `jpeg12_write_scanlines`, `jpeg12_read_scanlines`
-- [x] 16-bit (`J16SAMPLE` / `u16`, lossless only) — `tj3Compress16`, `tj3Decompress16`, `jpeg16_write_scanlines`, `jpeg16_read_scanlines`
+- [x] 12-bit (`J12SAMPLE` / `i16`) — `compress_12bit`, `decompress_12bit`, `jpeg12_write_scanlines`, `jpeg12_read_scanlines` (not wired through `TjHandle::compress()` / `decompress()`)
+- [x] 16-bit (`J16SAMPLE` / `u16`, lossless only) — `compress_16bit`, `decompress_16bit`, `jpeg16_write_scanlines`, `jpeg16_read_scanlines` (not wired through `TjHandle::compress()` / `decompress()`)
 
 ---
 
@@ -113,12 +115,13 @@
 - [x] `restart_in_rows` field — via Encoder builder
 
 ### JFIF / Density
-- [x] `write_JFIF_header` — JFIF marker (always written, hardcoded 72 DPI)
-- [x] `TJPARAM_XDENSITY` — Horizontal pixel density (`DensityInfo`)
-- [x] `TJPARAM_YDENSITY` — Vertical pixel density (`DensityInfo`)
-- [x] `TJPARAM_DENSITYUNITS` — Units (`DensityUnit` enum)
+- [x] `write_JFIF_header` — JFIF marker (written by default with 1x1 unknown-density fields unless coefficient metadata is rewritten)
+- [ ] `TJPARAM_XDENSITY` — not wired through `TjHandle` / `Encoder`
+- [ ] `TJPARAM_YDENSITY` — not wired through `TjHandle` / `Encoder`
+- [ ] `TJPARAM_DENSITYUNITS` — not wired through `TjHandle` / `Encoder`
 - [x] `JFIF_major_version` / `JFIF_minor_version` configurable (`Encoder::jfif_version()`)
-- [x] `density_unit` / `X_density` / `Y_density` configurable (read from JFIF, write via `DensityInfo`)
+- [x] JFIF density read (`Image.density`)
+- [x] Low-level density rewrite via coefficient API (`JpegCoefficients.{density_unit,x_density,y_density}`)
 
 ### Adobe Marker
 - [x] `write_Adobe_marker` — Adobe APP14 (for CMYK)
@@ -211,7 +214,7 @@
 - [x] EXIF extraction + orientation (APP1)
 - [x] Adobe APP14 detection (CMYK/YCCK)
 - [x] Restart marker (DRI/RST) handling
-- [x] `TJPARAM_SAVEMARKERS` — Configurable marker saving (`MarkerSaveConfig` enum: None/All/AppOnly/Specific)
+- [x] `TJPARAM_SAVEMARKERS` — Configurable marker saving via `Decoder::save_markers()` / `MarkerSaveConfig` (not yet wired through `TjHandle`)
 - [x] `jpeg_save_markers()` — Per-marker-type save control (`Decoder::save_markers()`)
 - [x] `jpeg_set_marker_processor()` — Custom marker parser callback (`Decoder::set_marker_processor()`)
 - [x] COM (comment) marker read/expose (`Image.comment`)
@@ -258,7 +261,7 @@
 - [x] COM (comment) — Read (`Image.comment`) / Write (`Encoder::comment()`)
 - [x] Arbitrary APP markers — Read (`Decoder::save_markers()` + `Image.markers()`)
 - [x] Arbitrary markers — Write (`marker_writer::write_marker()`, `Encoder::saved_marker()`)
-- [x] DPI/density — Read (`Image.density`) / Write (`DensityInfo`)
+- [x] DPI/density — Read (`Image.density`); low-level rewrite via `JpegCoefficients`, no high-level `Encoder::density()` / `TjHandle` write path
 - [x] JFIF thumbnail extraction (`extract_jfif_thumbnail()`)
 - [x] Marker preservation across transform/re-encode (`TransformOptions.copy_markers`)
 
@@ -381,9 +384,11 @@
 - [x] `tj3YUVBufSize()` — YUV buffer size (`yuv_buf_size()`)
 - [x] `tj3TransformBufSize()` — Transform output buffer size (`transform_buf_size()`)
 
-### Image File I/O (BMP/PPM)
-- [x] `tj3LoadImage8()` / `tj3LoadImage12()` / `tj3LoadImage16()` — 8-bit implemented (`load_image` / `load_image_from_bytes`)
-- [x] `tj3SaveImage8()` / `tj3SaveImage12()` / `tj3SaveImage16()` — 8-bit implemented (`save_bmp` / `save_ppm`)
+### Image File I/O (BMP/PPM/PGM subset)
+- [ ] `tj3LoadImage8()` parity — only BMP/PPM/PGM 8-bit subset implemented (`load_image` / `load_image_from_bytes`); PNG + handle-driven semantics are missing
+- [ ] `tj3LoadImage12()` / `tj3LoadImage16()` — missing
+- [ ] `tj3SaveImage8()` parity — only BMP/PPM/PGM 8-bit subset implemented (`save_bmp` / `save_ppm`); PNG + handle-driven semantics are missing
+- [ ] `tj3SaveImage12()` / `tj3SaveImage16()` — missing
 
 ### Memory Management
 - [ ] Custom `jpeg_memory_mgr` — Pool-based allocator
@@ -427,8 +432,9 @@
 
 - [x] `tj3Init()` / `tj3Destroy()` — Handle lifecycle (`TjHandle::new()` / Drop)
 - [x] `tj3Set()` / `tj3Get()` — Generic parameter get/set (`TjHandle::set()` / `TjHandle::get()`)
-- [x] All 26 TJPARAM values as runtime parameters (`TjParam` enum)
-- [x] `tj3SetICCProfile()` / `tj3GetICCProfile()` — ICC via handle (`TjHandle::set_icc_profile()` / `TjHandle::icc_profile()`)
+- [ ] All 26 TJPARAM values as end-to-end runtime parameters (`TjParam` exists, but `Precision`, `ColorSpace`, `NoRealloc`, `SaveMarkers`, and density params are not fully applied by `TjHandle::compress()` / `decompress()`, and `SaveMarkers` semantics differ from C)
+- [x] `tj3SetICCProfile()` — encode-side ICC via handle (`TjHandle::set_icc_profile()`)
+- [ ] `tj3GetICCProfile()` parity — `TjHandle::decompress()` does not populate the handle from decoded ICC data
 - [x] `tj3SetScalingFactor()` / `tj3SetCroppingRegion()` — Decode options via handle (`TjHandle::set_scaling_factor()` / `TjHandle::set_cropping_region()`)
 - [x] `tj3GetScalingFactors()` — Query available scaling factors (`TjHandle::scaling_factors()`)
 
@@ -436,91 +442,10 @@
 
 ## Summary
 
-| Category | Done | Total | % |
-|----------|------|-------|---|
-| Frame types (encode) | 6 | 6 | 100% |
-| Frame types (decode) | 6 | 6 | 100% |
-| Sample precision | 3 | 3 | 100% |
-| Pixel formats | 13 | 13 | 100% |
-| Chroma subsampling | 8 | 8 | 100% |
-| Color spaces | 6 | 6 | 100% |
-| Compress params | 59 | 68 | 87% |
-| Decompress params | 56 | 56 | 100% |
-| Metadata | 11 | 11 | 100% |
-| Transform ops | 8 | 8 | 100% |
-| Transform options | 9 | 9 | 100% |
-| Transform misc | 6 | 6 | 100% |
-| YUV/Planar API | 12 | 12 | 100% |
-| SIMD (aarch64) | 14 | 14 | 100% |
-| SIMD (x86_64) | 13 | 13 | 100% |
-| Memory & I/O | 12 | 18 | 67% |
-| Error handling | 5 | 14 | 36% |
-| Progress | 4 | 4 | 100% |
-| TJ3 Handle API | 6 | 6 | 100% |
+- Percentage rollups were removed from this document. They looked precise, but they mixed core codec support, handle parity, and adjacent Rust-only surfaces in a way that overstated completion.
+- Treat the checklist above as the source of truth. The highest-risk partial areas today are `TjHandle` parameter parity, handle-side ICC retrieval, density configuration, image file I/O parity (PNG/12/16-bit), and dedicated TurboJPEG allocator/error-getter APIs.
 
----
+## Documentation Policy
 
-## Priority Roadmap
-
-> Strategy: feature completeness first, then SIMD/performance.
-
-### Phase 4 — Core Feature Gaps ✅ COMPLETE
-| # | Feature | PR |
-|---|---------|-----|
-| 1 | ~~Restart interval encode (DRI)~~ | #18 |
-| 2 | ~~COM marker read/write + density~~ | #17 |
-| 3 | ~~Lossless encode: color + predictor + pt~~ | #20 |
-| 4 | ~~SOF10 arithmetic progressive encode~~ | #25 |
-| 5 | ~~SOF11 lossless arithmetic encode/decode~~ | #26 |
-| 6 | ~~Grayscale-from-color encode~~ | #22 |
-| 7 | ~~Configurable DPI/density~~ | #17 |
-| 8 | ~~Arbitrary marker write~~ | #17 |
-
-### Phase 5 — Extended Formats ✅ COMPLETE
-| # | Feature | Status |
-|---|---------|--------|
-| 9 | 12-bit precision | ✅ |
-| 10 | 16-bit precision (lossless) | ✅ |
-| 10a | Arbitrary 2-16 bit lossless precision | ✅ |
-| 11 | ~~Custom quantization tables~~ | ✅ #19 |
-| 12 | ~~Custom Huffman tables~~ | ✅ #23 |
-| 13 | ~~Custom progressive scan scripts~~ | ✅ #24 |
-| 14 | ~~Additional pixel formats~~ | ✅ #28 |
-| 15 | ~~Fast DCT (IsFast, Float)~~ | ✅ #27 |
-| 16 | ~~S441 subsampling~~ | ✅ #29 |
-
-### Phase 6 — Transform & Advanced ✅ COMPLETE (8/8)
-| # | Feature | Status |
-|---|---------|--------|
-| 17 | ~~All 9 TJXOPT transform flags~~ | ✅ #32 |
-| 18 | ~~Coefficient filter callback~~ | ✅ #34 |
-| 19 | ~~Marker preservation~~ | ✅ #36 |
-| 20 | ~~Scanline-level encode API~~ | ✅ #33 |
-| 21 | ~~Scanline-level decode API~~ | ✅ #33 |
-| 22 | ~~Progressive output (buffered image)~~ | ✅ |
-| 23 | ~~Per-component quality~~ | ✅ #31 |
-| 24 | ~~Raw data encode/decode~~ | ✅ #35 |
-
-### Phase 7 — YUV & I/O ✅ COMPLETE
-| # | Feature | Status |
-|---|---------|--------|
-| 25 | ~~YUV planar encode/decode~~ | ✅ #40 |
-| 26 | ~~Buffer size calculation~~ | ✅ #30 |
-| 27 | ~~Custom source/dest managers~~ | ✅ #39 |
-| 28 | ~~File I/O helpers~~ | ✅ #38 |
-
-### Phase 8 — SIMD & Performance ✅ COMPLETE
-| # | Feature | Status |
-|---|---------|--------|
-| 29 | ~~x86_64 SSE2~~ | ✅ #44 |
-| 30 | ~~x86_64 AVX2~~ | ✅ #43 |
-| 31 | ~~aarch64 NEON extensions~~ | ✅ #42 |
-
-### Phase 9 — Full API Parity ✅ COMPLETE (practical features)
-| # | Feature | Status |
-|---|---------|--------|
-| 32 | ~~TJ3 handle/parameter API~~ | ✅ #45 |
-| 33 | Custom error manager | ✅ Already done (ErrorHandler trait, PR #17) |
-| 34 | Progress monitoring | ✅ Already done (ProgressListener trait) |
-| 35 | ~~Color quantization~~ | ✅ #46 |
-| 36 | Custom memory manager | ⬜ N/A in Rust (std allocator) |
+- If a capability only exists through a different Rust API than the named C surface, describe that explicitly and do not count it as full parity for the original surface.
+- If a row depends on a feature-gated or low-level path, say so in the row instead of promoting it to a blanket `[x]`.

--- a/docs/TEST_PARITY.md
+++ b/docs/TEST_PARITY.md
@@ -1,7 +1,8 @@
 # Test Parity: libjpeg-turbo-rs vs libjpeg-turbo (C)
 
-> Track testing methodology parity. `[x]` = implemented, `[ ]` = missing.
+> Track testing methodology parity. `[x]` means coverage exists; read the qualifier, because some rows are partial or feature-gated.
 > Source of truth: C libjpeg-turbo's `CMakeLists.txt`, `tjunittest.c`, `tjbench.c`, test scripts in `test/`.
+> Expensive full-matrix C cross-checks run behind `--features full-c-parity` and in `.github/workflows/full-c-parity.yml`.
 
 ---
 
@@ -28,9 +29,9 @@
 - [x] Synthetic test pattern generation — `tjunittest_compat.rs` generate_test_pattern()
 
 ### tjbench (Benchmark & Tile Tests)
-- [ ] Tiled compression/decompression (8x8, 16x16, 32x32, 64x64, 128x128) — not implemented
+- [x] Tile-style compression/decompression coverage (8x8, 16x16, 32x32, 64x64 via independently compressed tiles; no dedicated tiled API / separate 128x128 case) — `cross_check_tiled_ops.rs`
 - [x] Scaled decompression (1/2, 1/4, 1/8) — `scale_decode.rs`
-- [ ] Extended scaling factors (2/1, 15/8, 7/4, 13/8, 3/2, 11/8, 5/4, 9/8, 7/8, 3/4, 5/8, 3/8) — only 1/2, 1/4, 1/8
+- [x] Extended scaling factors (2/1, 15/8, 7/4, 13/8, 3/2, 11/8, 5/4, 9/8, 7/8, 3/4, 5/8, 3/8) — `cross_check_extended_scaling.rs`, `c_cjpeg_djpeg_tests.rs`
 - [x] Partial decompression (cropping) — `crop_skip.rs`
 - [x] Transform + scale combinations — `tjunittest_transform.rs`
 - [x] Merged YUV decompression (420m, 422m) — `merged_upsample.rs`
@@ -106,7 +107,7 @@
 - [x] 4:1:0 (410) subsampling decode — `subsamp_410.rs`
 - [x] 5 crop regions (14x14+23+23, 21x21+4+4, 18x18+13+13, 21x21+0+0, 24x26+20+18) — partial (`crop_skip.rs`)
 - [ ] Crop × subsampling × scale full cross-product — only individual tests
-- [ ] 15 scaling factors (16/8 thru 1/8) — only 1/2, 1/4, 1/8 tested
+- [x] 15 scaling factors (16/8 thru 1/8) — `cross_check_extended_scaling.rs`, `c_cjpeg_djpeg_tests.rs`
 - [x] No-smooth upsampling (`-nos`) — `decode_toggles.rs`
 - [ ] No-smooth × crop × scale cross-product — not tested
 - [x] DCT methods (fast, accurate) — `decode_toggles.rs`
@@ -143,7 +144,7 @@
 
 ### croptest.in (Crop Region Validation)
 - [x] Basic crop operations — `crop_skip.rs`, `transform_options.rs`
-- [ ] Exhaustive crop window iteration (Y 0-16, H 1-16) — not implemented
+- [x] Exhaustive crop window iteration (Y 0-16, H 1-16) — `c_croptest_full` (`--features full-c-parity`)
 - [ ] ImageMagick reference comparison — not available
 - [ ] Progressive + crop — partial
 - [ ] Smooth + crop — not tested
@@ -194,9 +195,9 @@
 - [x] 1/2 — `scale_decode.rs`
 - [x] 1/4 — `scale_decode.rs`
 - [x] 1/8 — `scale_decode.rs`
-- [ ] 2/1 (upscale) — not supported
-- [ ] 15/8, 7/4, 13/8, 3/2, 11/8, 5/4, 9/8 (upscale fractions) — not supported
-- [ ] 7/8, 3/4, 5/8, 3/8 (intermediate downscale) — not supported
+- [x] 2/1 (upscale) — `cross_check_extended_scaling.rs`, `c_cjpeg_djpeg_tests.rs`
+- [x] 15/8, 7/4, 13/8, 3/2, 11/8, 5/4, 9/8 (upscale fractions) — `cross_check_extended_scaling.rs`, `c_cjpeg_djpeg_tests.rs`
+- [x] 7/8, 3/4, 5/8, 3/8 (intermediate downscale) — `cross_check_extended_scaling.rs`
 
 ### Transform Operations
 - [x] None, HFlip, VFlip, Transpose, Transverse, Rot90, Rot180, Rot270 — all 8
@@ -347,7 +348,7 @@ These are the individual cjpeg/djpeg/jpegtran tests defined via `add_bittest()` 
 - [x] `444-islow-ari-crop37x37_0_0` — arithmetic + crop — `crop_skip.rs`
 - [x] `420-islow-ari-crop53x53_4_4` — arithmetic + crop — partial
 - [x] `444-islow-skip1_6` — small skip range — `scanline_api.rs`
-- [ ] `420m-islow-{scale}` — merged upsampling with 15 scales — not tested
+- [x] `420m-islow-{scale}` — merged upsampling with C scale matrix for 420m/nosmooth — `c_cjpeg_djpeg_tests.rs`
 - [x] `rgb-islow-icc-cmp` — ICC profile extraction — `metadata_write.rs`
 
 ### jpegtran Tests (Transform)
@@ -377,7 +378,7 @@ These are the individual cjpeg/djpeg/jpegtran tests defined via `add_bittest()` 
 - [x] 420m decode (merged 2x2 upsample) — `merged_upsample.rs`
 - [x] 422m decode (merged 2x1 upsample) — `merged_upsample.rs`
 - [ ] Merged upsampling + fast DCT
-- [ ] Merged upsampling + scaled decode
+- [x] Merged upsampling + scaled decode (420m) — `c_cjpeg_djpeg_tests.rs`
 - [ ] Merged upsampling + RGB565
 
 ### Smoothing Factor in Encode
@@ -426,39 +427,6 @@ These are the individual cjpeg/djpeg/jpegtran tests defined via `add_bittest()` 
 
 ## Summary
 
-| Category | Done | Total | % |
-|----------|------|-------|---|
-| tjunittest equivalents | 14 | 17 | 82% |
-| tjbench equivalents | 4 | 8 | 50% |
-| Validation methods | 13 | 15 | 87% |
-| tjcomptest matrix | 10 | 13 | 77% |
-| tjdecomptest matrix | 7 | 11 | 64% |
-| tjtrantest matrix | 8 | 10 | 80% |
-| croptest | 1 | 5 | 20% |
-| CMakeLists bittest (cjpeg) | 10 | 12 | 83% |
-| CMakeLists bittest (djpeg) | 11 | 22 | 50% |
-| CMakeLists bittest (jpegtran) | 3 | 4 | 75% |
-| Precision coverage | 3 | 5 | 60% |
-| Subsampling coverage | 7 | 8 | 88% |
-| Scaling factors | 4 | 16 | 25% |
-| Edge case / robustness | 23 | 25 | 92% |
-| Metadata & markers | 10 | 11 | 91% |
-| Progressive | 7 | 8 | 88% |
-| YUV operations | 5 | 7 | 71% |
-| Fuzzing | 7 | 8 | 88% |
-| RGB565 specific | 0 | 6 | 0% |
-| Merged upsampling | 2 | 5 | 40% |
-| Non-standard sampling | 0 | 2 | 0% |
-| FP variance handling | 0 | 3 | 0% |
-
-### Key Gaps (Priority Order)
-1. **Merged upsampling (420m, 422m)** — Core 420m/422m implemented; remaining: progressive, scaled, RGB565 variants
-2. **RGB565 dithered/undithered** — C tests 8 RGB565 combinations; we test 0
-3. **MD5/binary comparison** — deterministic encoding + regression hashes implemented (`bitstream_stability.rs`, `bitstream_regression.rs`); cross-encoder comparison with C still missing
-4. **Extended scaling factors** — C tests 15 scales; we test 4
-5. **Non-standard sampling (3x2)** — C tests 3x2 float/ifast; we don't support arbitrary factors
-6. **Tiled operations** — C tests 5 tile sizes; we have none
-7. ~~**Per-precision lossless (2-16 bit)**~~ -- done, `precision_arbitrary.rs`
-8. **Exhaustive crop matrix** — C tests 100+ crop regions; we test ~10
-9. **DCT method cross-product** — C cross-products DCT × subsampling × quality; we test individually
-10. **FP variance handling** — C has per-platform expected values; we don't
+- Percentage rollups were removed from this document. They mixed quick checks, feature-gated full matrices, and partial emulations, so the totals looked more authoritative than they were.
+- Extended scaling and exhaustive crop-grid coverage now exist and should no longer be treated as missing.
+- Highest-signal remaining gaps are cross-encoder MD5/binary parity against C, non-standard 3x2 sampling, several RGB565 merged-upsample variants, and full tiled API parity (even though tile-style coverage exists).


### PR DESCRIPTION
What changed
- tightened the documentation rules so parity checkmarks only represent end-to-end public support
- corrected overstated TJ3 handle/API claims in the C API mapping and feature parity docs
- updated test parity docs to reflect existing extended scaling, crop-grid, and tile-style coverage while removing misleading percentage rollups

Why
- the parity docs had drifted in both directions: some rows overstated support, while others still claimed gaps that are already covered by tests
- that made the docs hard to trust when comparing this project against libjpeg-turbo C

Impact
- contributors now have a stricter and more defensible source of truth for implementation parity and test coverage
- the biggest remaining gaps are now called out explicitly instead of being buried behind inflated completion summaries

Validation
- pre-commit hooks ran during commit: cargo fmt --check, cargo clippy
- git diff --check