### PR TITLE
fix(capi): populate cinfo.arith_code from SOF marker in jpeg_read_header

### DIFF
--- a/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
+++ b/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
@@ -1499,11 +1499,9 @@ pub extern "C" fn jpeg_read_header(cinfo: *mut c_void, _require_image: CBoolean)
     } else {
         0
     };
-    // `arith_code` is not exposed by `Decoder::header()`; stock baseline
-    // files use Huffman, so the default of 0 matches the common case.
-    // TODO(C2-follow-up): surface `JpegMetadata::is_arithmetic` through
-    // the public API so we can populate this field faithfully.
-    c.arith_code = 0;
+    // Populate `arith_code` from the parsed SOF marker type.
+    // SOF9/SOF10/SOF11 → arithmetic (1); SOF0/SOF1/SOF2/SOF3 → Huffman (0).
+    c.arith_code = if decoder.is_arithmetic() { 1 } else { 0 };
 
     // Heuristic for jpeg_color_space matching libjpeg jdmarker:
     //   1 component     -> JCS_GRAYSCALE
@@ -2145,6 +2143,16 @@ pub extern "C" fn jpeg_capi_test_x_density(cinfo: *mut c_void) -> c_int {
 pub extern "C" fn jpeg_capi_test_y_density(cinfo: *mut c_void) -> c_int {
     match unsafe { cinfo_mut(cinfo) } {
         Some(c) => c.Y_density as c_int,
+        None => -1,
+    }
+}
+
+/// Read `cinfo->arith_code` after `jpeg_read_header`. Returns 1 for
+/// arithmetic-coded streams, 0 for Huffman, -1 if `cinfo` is null.
+#[no_mangle]
+pub extern "C" fn jpeg_capi_test_arith_code(cinfo: *mut c_void) -> c_int {
+    match unsafe { cinfo_mut(cinfo) } {
+        Some(c) => c.arith_code as c_int,
         None => -1,
     }
 }

--- a/crates/libjpeg-turbo-rs-capi/tests/arith_code_flag.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/arith_code_flag.rs
@@ -1,0 +1,169 @@
+//! A1-12: `cinfo.arith_code` is correctly populated by `jpeg_read_header`.
+//!
+//! Classic-API callers that branch on `cinfo.arith_code` (e.g. to pick a
+//! codec path or to print stream metadata) must see `1` for arithmetic-coded
+//! JPEGs (SOF9/SOF10/SOF11) and `0` for Huffman-coded JPEGs (SOF0/SOF1/…).
+//! The shim previously hardcoded `arith_code = 0` regardless of the actual
+//! SOF marker; this test pins the correct behaviour.
+
+use std::ffi::{c_int, c_void};
+use std::mem::MaybeUninit;
+use std::os::raw::c_ulong;
+use std::path::PathBuf;
+
+// libjpeg `jpeg_read_header` return codes.
+const JPEG_HEADER_OK: c_int = 1;
+
+fn dlext() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "dll"
+    } else if cfg!(target_os = "macos") {
+        "dylib"
+    } else {
+        "so"
+    }
+}
+
+fn lib_prefix() -> &'static str {
+    if cfg!(target_os = "windows") {
+        ""
+    } else {
+        "lib"
+    }
+}
+
+fn cdylib_path() -> PathBuf {
+    if let Ok(p) = std::env::var("CARGO_CDYLIB_FILE_LIBJPEG_TURBO_RS_CAPI") {
+        return PathBuf::from(p);
+    }
+    let exe: PathBuf = std::env::current_exe().expect("current_exe");
+    let mut dir: PathBuf = exe.clone();
+    while dir.pop() {
+        let candidate: PathBuf =
+            dir.join(format!("{}libjpeg_turbo_rs_capi.{}", lib_prefix(), dlext()));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    panic!("could not locate cdylib near {}", exe.display());
+}
+
+/// Run `jpeg_create_decompress` → `jpeg_mem_src` → `jpeg_read_header` →
+/// `jpeg_capi_test_arith_code` → `jpeg_destroy_decompress` on `jpeg_bytes`,
+/// and return the `arith_code` value the shim put in `cinfo`.
+fn read_arith_code_flag(lib: &libloading::Library, jpeg_bytes: &[u8]) -> c_int {
+    unsafe {
+        // Allocate opaque buffers for cinfo and the error manager.
+        const CINFO_BYTES: usize = 4096;
+        let mut cinfo: MaybeUninit<[u8; CINFO_BYTES]> = MaybeUninit::zeroed();
+        let cinfo_ptr: *mut c_void = cinfo.as_mut_ptr() as *mut c_void;
+
+        const ERR_BYTES: usize = 512;
+        let mut err: MaybeUninit<[u8; ERR_BYTES]> = MaybeUninit::zeroed();
+        let err_ptr: *mut c_void = err.as_mut_ptr() as *mut c_void;
+
+        // Set up the error manager (`err` is the first field of cinfo).
+        let jpeg_std_error: libloading::Symbol<unsafe extern "C" fn(*mut c_void) -> *mut c_void> =
+            lib.get(b"jpeg_std_error").expect("jpeg_std_error");
+        let err_ret: *mut c_void = jpeg_std_error(err_ptr);
+        assert_eq!(err_ret, err_ptr, "jpeg_std_error must return its argument");
+        (cinfo_ptr as *mut *mut c_void).write(err_ptr);
+
+        // `jpeg_create_decompress` expands to
+        // `jpeg_CreateDecompress(cinfo, JPEG_LIB_VERSION, sizeof_struct)`.
+        let jpeg_create_decompress: libloading::Symbol<
+            unsafe extern "C" fn(*mut c_void, c_int, usize),
+        > = lib
+            .get(b"jpeg_CreateDecompress")
+            .expect("jpeg_CreateDecompress");
+        let jpeg_lib_version: c_int = 80; // JPEG_LIB_VERSION for libjpeg-turbo 3.x
+        jpeg_create_decompress(cinfo_ptr, jpeg_lib_version, CINFO_BYTES);
+
+        // Point the decoder at the in-memory JPEG bytes.
+        let jpeg_mem_src: libloading::Symbol<
+            unsafe extern "C" fn(*mut c_void, *const u8, c_ulong),
+        > = lib.get(b"jpeg_mem_src").expect("jpeg_mem_src");
+        jpeg_mem_src(cinfo_ptr, jpeg_bytes.as_ptr(), jpeg_bytes.len() as c_ulong);
+
+        // Parse the header.
+        let jpeg_read_header: libloading::Symbol<
+            unsafe extern "C" fn(*mut c_void, c_int) -> c_int,
+        > = lib.get(b"jpeg_read_header").expect("jpeg_read_header");
+        let rc: c_int = jpeg_read_header(cinfo_ptr, 1);
+        assert_eq!(rc, JPEG_HEADER_OK, "jpeg_read_header must succeed");
+
+        // Read back the arith_code field via the test accessor.
+        let get_arith_code: libloading::Symbol<unsafe extern "C" fn(*mut c_void) -> c_int> = lib
+            .get(b"jpeg_capi_test_arith_code")
+            .expect("jpeg_capi_test_arith_code");
+        let arith_code: c_int = get_arith_code(cinfo_ptr);
+
+        // Tear down cleanly.
+        let jpeg_destroy_decompress: libloading::Symbol<unsafe extern "C" fn(*mut c_void)> = lib
+            .get(b"jpeg_destroy_decompress")
+            .expect("jpeg_destroy_decompress");
+        jpeg_destroy_decompress(cinfo_ptr);
+
+        arith_code
+    }
+}
+
+/// `testimgari.jpg` is an arithmetic-coded JPEG (SOF9). After
+/// `jpeg_read_header`, `cinfo.arith_code` must be 1.
+#[test]
+fn arith_code_is_1_for_arithmetic_coded_jpeg() {
+    let path: PathBuf = cdylib_path();
+    let lib: libloading::Library =
+        unsafe { libloading::Library::new(&path) }.expect("dlopen cdylib");
+
+    // testimgari.jpg — arithmetic-coded (SOF9).
+    // Locate via CARGO_MANIFEST_DIR (crates/libjpeg-turbo-rs-capi/) → ../../references/
+    let manifest_dir: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let testimgari: PathBuf =
+        manifest_dir.join("../../references/libjpeg-turbo/testimages/testimgari.jpg");
+    if !testimgari.exists() {
+        eprintln!(
+            "SKIP: testimgari.jpg not found at {} — submodule not initialised",
+            testimgari.display()
+        );
+        return;
+    }
+    let jpeg_bytes: Vec<u8> = std::fs::read(&testimgari)
+        .unwrap_or_else(|e| panic!("could not read {}: {e}", testimgari.display()));
+
+    let arith_code: c_int = read_arith_code_flag(&lib, &jpeg_bytes);
+    assert_eq!(
+        arith_code, 1,
+        "arith_code must be 1 for arithmetic-coded JPEG (got {arith_code})"
+    );
+}
+
+/// `testimgint.jpg` is a progressive Huffman-coded JPEG (SOF2). After
+/// `jpeg_read_header`, `cinfo.arith_code` must be 0.
+#[test]
+fn arith_code_is_0_for_huffman_coded_jpeg() {
+    let path: PathBuf = cdylib_path();
+    let lib: libloading::Library =
+        unsafe { libloading::Library::new(&path) }.expect("dlopen cdylib");
+
+    // testimgint.jpg — progressive Huffman-coded (SOF2).
+    // Locate via CARGO_MANIFEST_DIR (crates/libjpeg-turbo-rs-capi/) → ../../references/
+    let manifest_dir: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let testimgint: PathBuf =
+        manifest_dir.join("../../references/libjpeg-turbo/testimages/testimgint.jpg");
+    if !testimgint.exists() {
+        eprintln!(
+            "SKIP: testimgint.jpg not found at {} — submodule not initialised",
+            testimgint.display()
+        );
+        return;
+    }
+    let jpeg_bytes: Vec<u8> = std::fs::read(&testimgint)
+        .unwrap_or_else(|e| panic!("could not read {}: {e}", testimgint.display()));
+
+    let arith_code: c_int = read_arith_code_flag(&lib, &jpeg_bytes);
+    assert_eq!(
+        arith_code, 0,
+        "arith_code must be 0 for Huffman-coded JPEG (got {arith_code})"
+    );
+}

--- a/src/decode/pipeline.rs
+++ b/src/decode/pipeline.rs
@@ -498,6 +498,15 @@ impl<'a> Decoder<'a> {
         )
     }
 
+    /// Whether the source uses arithmetic entropy coding (SOF9 / SOF10 / SOF11).
+    ///
+    /// Returns `true` for arithmetic-coded streams and `false` for
+    /// Huffman-coded streams (SOF0 / SOF1 / SOF2 / SOF3).  Mirrors stock
+    /// libjpeg's `cinfo.arith_code` populated by `jpeg_read_header`.
+    pub fn is_arithmetic(&self) -> bool {
+        self.metadata.is_arithmetic
+    }
+
     /// Set the desired output pixel format.
     pub fn set_output_format(&mut self, format: PixelFormat) {
         self.output_format = Some(format);


### PR DESCRIPTION
## Summary

The shim hardcoded `arith_code = 0` in `jpeg_read_header` regardless of the actual SOF marker type. Any classic-API caller loading `testimgari.jpg` (SOF9 — arithmetic) would see `cinfo.arith_code == 0` instead of 1, causing silent misbehaviour for tools that branch on this field (codec dispatch, metadata printing, e.g. `djpeg -verbose`).

## What changed

- **`src/decode/pipeline.rs`** — adds `Decoder::is_arithmetic() -> bool` public accessor backed by `JpegMetadata::is_arithmetic` (already set correctly from SOF9/10/11 markers by the marker reader).
- **`crates/libjpeg-turbo-rs-capi/src/jpeglib.rs`** — replaces `c.arith_code = 0` with `c.arith_code = if decoder.is_arithmetic() { 1 } else { 0 }` in `jpeg_read_header`; adds `jpeg_capi_test_arith_code()` test-only accessor following the existing `jpeg_capi_test_*` pattern.
- **`crates/libjpeg-turbo-rs-capi/tests/arith_code_flag.rs`** — new dlopen tests:
  - `arith_code_is_1_for_arithmetic_coded_jpeg` — reads `testimgari.jpg` (SOF9), asserts `cinfo.arith_code == 1`.
  - `arith_code_is_0_for_huffman_coded_jpeg` — reads `testimgint.jpg` (SOF2), asserts `cinfo.arith_code == 0`.
  - Both skip gracefully when the submodule is not initialised.

## Test plan

- [x] `cargo test -p libjpeg-turbo-rs-capi --test arith_code_flag` — 2/2 pass (submodule-skip path in worktree; full assertion path in CI where submodule is present).
- [x] `cargo test -p libjpeg-turbo-rs-capi --test capi_jpeglib_decode --test precision --test legacy_aliases --test header_ops` — all pass, no regressions.
- [x] `cargo fmt --all --check` and `cargo clippy --lib -- -D warnings` — clean.
- [x] `codex review --commit 5dcafcc` — run; no P1/P2 issues surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)