### PR TITLE
fix(capi-test): capture full MCU-aligned rows from jpeg_read_raw_data

### DIFF
--- a/crates/libjpeg-turbo-rs-capi/tests/capi_jpeg_read_raw_data.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/capi_jpeg_read_raw_data.rs
@@ -283,20 +283,12 @@ unsafe fn collect_raw_planes_via_capi(
         );
 
         // Harvest rows: for each component, read `comp_vsf[i] * dct_size`
-        // rows. Discard rows that would exceed the true plane height
-        // (padding rows from MCU alignment).
+        // rows. Keep all rows including MCU padding — this matches what
+        // the C API actually delivers and what `decompress_raw` returns
+        // (both are MCU-aligned per upstream's raw-data contract).
         for comp_idx in 0..num_components {
             let rows_this_imcu: usize = comp_vsf[comp_idx] * dct_size;
-            // Plane height in rows for this component ≈
-            // ceil(output_height * comp_vsf[i] / max_vsf).
-            let plane_height_approx: usize =
-                ((output_height as usize * comp_vsf[comp_idx]) + max_vsf as usize - 1)
-                    / max_vsf as usize;
-            let already: usize = planes[comp_idx].len() / max_plane_width;
             for row_in_imcu in 0..rows_this_imcu {
-                if already + row_in_imcu >= plane_height_approx {
-                    break;
-                }
                 let src: &[u8] = &row_bufs[comp_idx][row_in_imcu][..max_plane_width];
                 planes[comp_idx].extend_from_slice(src);
             }


### PR DESCRIPTION
## Summary

`collect_raw_planes_via_capi` in `tests/capi_jpeg_read_raw_data.rs` was clamping captured rows to an image-region height (image_height × comp_vsf / max_vsf) — discarding the MCU-padding rows that the C API actually delivers. The reference (`libjpeg_turbo_rs::decompress_raw`) returns MCU-aligned planes, so the subsequent assertion `capi_h >= ref_height` failed:

```
comp[0] C-API height 149 < reference height 160
```

(testorig.jpg is 227×149 4:2:0 → MCU-aligned Y height = 160.)

## Why this slipped past CI on PR #240

The test gracefully `eprintln!("SKIP: ...")`s when `references/libjpeg-turbo/testimages/testorig.jpg` is not present (submodule not initialised). CI environments without the submodule init'd silently passed. The bug only surfaces locally on environments with the testimages submodule (and on platforms where the test isn't already skipping for a different reason).

## Fix

Drop the artificial clamp; capture every row `jpeg_read_raw_data` delivers. The MCU-aligned heights now match the reference, and pixel-equality across the full MCU plane (including padding rows) holds — both paths decode the same bitstream through the same core decoder, so padding bytes are identical.

## Test plan

- [x] `cargo test -p libjpeg-turbo-rs-capi --test capi_jpeg_read_raw_data` (2 passed locally on aarch64-darwin with submodule init'd; previously failed)
- [x] `cargo clippy --lib --workspace -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)