### PR TITLE
feat(capi): implement jpeg_save_markers per-code length_limit truncation

### DIFF
--- a/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
+++ b/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
@@ -1589,11 +1589,11 @@ pub extern "C" fn jpeg_read_header(cinfo: *mut c_void, _require_image: CBoolean)
     let saved: Vec<libjpeg_turbo_rs::SavedMarker> = decoder.saved_markers().to_vec();
     for marker in saved {
         // Honor stock libjpeg's `jpeg_save_markers(cinfo, code, length_limit)`
-        // contract: `original_length` is the full marker body, but
-        // `data_length` and `data` are truncated to
-        // `min(original_length, length_limit)` so consumers (and
-        // `jcopy_markers_execute`'s downstream `jpeg_write_marker`)
-        // never see more bytes than the caller requested.
+        // contract: `original_length` is the full marker body length from the
+        // stream, while `data_length` and `data` are truncated to
+        // `min(original_length, length_limit)` so consumers (e.g.
+        // `jcopy_markers_execute` → `jpeg_write_marker`) never see more bytes
+        // than the caller requested.
         let original_len: usize = marker.data.len();
         let limit: usize = priv_state
             .marker_save
@@ -1797,11 +1797,10 @@ pub extern "C" fn jpeg_start_decompress(cinfo: *mut c_void) -> CBoolean {
 /// accumulated by `jpeg_save_markers`. A zero limit clears saving, so
 /// we skip those entries when composing the final set.
 ///
-/// Returns `None` if no markers are enabled. Returns
-/// `Specific(codes)` otherwise — we don't currently honour the
-/// per-marker length_limit granularly because the underlying Rust
-/// `save_markers` API saves the full marker body; libjpeg's truncation
-/// behavior is still a TODO tracked in `docs/FEATURE_PARITY.md`.
+/// Returns `None` if no markers are enabled. Returns `Specific(codes)`
+/// otherwise. Per-marker body truncation is applied separately when building
+/// `cinfo->marker_list` from `Image.saved_markers`, so the Rust library saves
+/// the full marker body and the shim truncates to the requested `length_limit`.
 fn marker_save_to_config(settings: &MarkerSaveSettings) -> libjpeg_turbo_rs::MarkerSaveConfig {
     let codes: Vec<u8> = settings
         .limits
@@ -2163,6 +2162,17 @@ pub extern "C" fn jpeg_capi_test_arith_code(cinfo: *mut c_void) -> c_int {
     match unsafe { cinfo_mut(cinfo) } {
         Some(c) => c.arith_code as c_int,
         None => -1,
+    }
+}
+
+/// Return `cinfo->marker_list` — the head of the saved-marker linked list
+/// populated by `jpeg_read_header`. Tests use this to inspect the saved
+/// bodies without hard-coding struct offsets.
+#[no_mangle]
+pub extern "C" fn jpeg_capi_test_marker_list(cinfo: *mut c_void) -> *mut JpegMarkerStructPublic {
+    match unsafe { cinfo_mut(cinfo) } {
+        Some(c) => c.marker_list,
+        None => std::ptr::null_mut(),
     }
 }
 

--- a/crates/libjpeg-turbo-rs-capi/tests/marker_save_length_limit.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/marker_save_length_limit.rs
@@ -1,0 +1,243 @@
+//! Classic-API `jpeg_save_markers(cinfo, code, length_limit)` truncation.
+//!
+//! When `jpeg_save_markers(cinfo, JPEG_COM, N)` is called with `N < full_len`,
+//! the saved marker body in `cinfo->marker_list` must be exactly `N` bytes
+//! (the first `N` bytes of the full payload), not the full body.
+//!
+//! Tests:
+//!   1. `marker_save_length_limit_truncates_com` — 200-byte COM, limit=64.
+//!   2. `marker_save_length_limit_zero_disables_saving` — limit=0 must save nothing.
+//!   3. `marker_save_no_call_saves_nothing` — without `jpeg_save_markers` no
+//!      markers are saved (default behavior regression guard).
+
+use std::ffi::{c_int, c_uint, c_void};
+use std::mem::MaybeUninit;
+use std::os::raw::c_ulong;
+use std::path::PathBuf;
+
+// libjpeg return codes.
+const JPEG_HEADER_OK: c_int = 1;
+// Standard JPEG marker codes (per jpeglib.h).
+const JPEG_COM: c_int = 0xFE;
+
+fn dlext() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "dll"
+    } else if cfg!(target_os = "macos") {
+        "dylib"
+    } else {
+        "so"
+    }
+}
+
+fn lib_prefix() -> &'static str {
+    if cfg!(target_os = "windows") {
+        ""
+    } else {
+        "lib"
+    }
+}
+
+fn cdylib_path() -> PathBuf {
+    if let Ok(p) = std::env::var("CARGO_CDYLIB_FILE_LIBJPEG_TURBO_RS_CAPI") {
+        return PathBuf::from(p);
+    }
+    let exe: PathBuf = std::env::current_exe().expect("current_exe");
+    let mut dir: PathBuf = exe.clone();
+    while dir.pop() {
+        let candidate: PathBuf =
+            dir.join(format!("{}libjpeg_turbo_rs_capi.{}", lib_prefix(), dlext()));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    panic!("could not locate cdylib near {}", exe.display());
+}
+
+/// Layout of `jpeg_marker_struct` as used by the shim's `cinfo->marker_list`.
+///
+/// Fields (in order, matching `JpegMarkerStructPublic` in `jpeglib.rs`):
+///   next: *mut c_void  (ptr to next node)
+///   marker: u8         (marker code)
+///   original_length: c_uint
+///   data_length: c_uint
+///   data: *mut u8
+///
+/// Use `#[repr(C)]` with explicit padding on ARM/x86_64 where the pointer
+/// occupies 8 bytes.
+#[repr(C)]
+struct JpegMarkerStruct {
+    next: *mut JpegMarkerStruct,
+    marker: u8,
+    _pad: [u8; 3], // ARM/x86_64: align next field to 4 bytes
+    original_length: c_uint,
+    data_length: c_uint,
+    data: *mut u8,
+}
+
+/// Build a minimal JPEG with a single COM marker whose payload is
+/// `payload_bytes` bytes long (filled with 'A'..='Z' cycling).
+fn make_jpeg_with_com(payload_bytes: usize) -> Vec<u8> {
+    // Build a 1×1 grayscale JPEG with a COM marker using the `libjpeg_turbo_rs`
+    // Rust library directly — avoids depending on C tools being installed.
+    use libjpeg_turbo_rs::{Encoder, PixelFormat};
+
+    // COM payload: ASCII 'A'..'Z' cycling, valid UTF-8.
+    let comment: String = (0..payload_bytes)
+        .map(|i| (b'A' + (i % 26) as u8) as char)
+        .collect();
+
+    let pixels: Vec<u8> = vec![128u8]; // 1×1 gray pixel
+    Encoder::new(&pixels, 1, 1, PixelFormat::Grayscale)
+        .quality(80)
+        .comment(&comment)
+        .encode()
+        .expect("encode 1×1 gray JPEG with COM marker")
+}
+
+/// Open the shim, run `jpeg_create_decompress` → `jpeg_mem_src` →
+/// `jpeg_save_markers(code, limit)` → `jpeg_read_header`, then return
+/// the list of `(marker_code, data_length, original_length)` tuples from
+/// `cinfo->marker_list`.
+unsafe fn saved_marker_lengths(
+    lib: &libloading::Library,
+    jpeg_bytes: &[u8],
+    save_calls: &[(c_int, c_uint)], // (code, length_limit) pairs; empty = no call
+) -> Vec<(u8, usize, usize)> {
+    const CINFO_BYTES: usize = 4096;
+    let mut cinfo: MaybeUninit<[u8; CINFO_BYTES]> = MaybeUninit::zeroed();
+    let cinfo_ptr: *mut c_void = cinfo.as_mut_ptr() as *mut c_void;
+
+    const ERR_BYTES: usize = 512;
+    let mut err: MaybeUninit<[u8; ERR_BYTES]> = MaybeUninit::zeroed();
+    let err_ptr: *mut c_void = err.as_mut_ptr() as *mut c_void;
+
+    let jpeg_std_error: libloading::Symbol<unsafe extern "C" fn(*mut c_void) -> *mut c_void> =
+        lib.get(b"jpeg_std_error").expect("jpeg_std_error");
+    let err_ret = jpeg_std_error(err_ptr);
+    assert_eq!(err_ret, err_ptr);
+    (cinfo_ptr as *mut *mut c_void).write(err_ptr);
+
+    let jpeg_create_decompress: libloading::Symbol<
+        unsafe extern "C" fn(*mut c_void, c_int, usize),
+    > = lib
+        .get(b"jpeg_CreateDecompress")
+        .expect("jpeg_CreateDecompress");
+    jpeg_create_decompress(cinfo_ptr, 80, CINFO_BYTES);
+
+    let jpeg_mem_src: libloading::Symbol<unsafe extern "C" fn(*mut c_void, *const u8, c_ulong)> =
+        lib.get(b"jpeg_mem_src").expect("jpeg_mem_src");
+    jpeg_mem_src(cinfo_ptr, jpeg_bytes.as_ptr(), jpeg_bytes.len() as c_ulong);
+
+    let jpeg_save_markers: libloading::Symbol<unsafe extern "C" fn(*mut c_void, c_int, c_uint)> =
+        lib.get(b"jpeg_save_markers").expect("jpeg_save_markers");
+    for &(code, limit) in save_calls {
+        jpeg_save_markers(cinfo_ptr, code, limit);
+    }
+
+    let jpeg_read_header: libloading::Symbol<unsafe extern "C" fn(*mut c_void, c_int) -> c_int> =
+        lib.get(b"jpeg_read_header").expect("jpeg_read_header");
+    let rc = jpeg_read_header(cinfo_ptr, 1);
+    assert_eq!(rc, JPEG_HEADER_OK, "jpeg_read_header must succeed");
+
+    // Read marker_list from cinfo. The `marker_list` field is at a fixed
+    // offset in `JpegDecompressPublic`; we read it via the test accessor
+    // exported by the shim so we do not hard-code a struct offset here.
+    let get_marker_list: libloading::Symbol<
+        unsafe extern "C" fn(*mut c_void) -> *mut JpegMarkerStruct,
+    > = lib
+        .get(b"jpeg_capi_test_marker_list")
+        .expect("jpeg_capi_test_marker_list accessor not found in cdylib");
+
+    let mut result: Vec<(u8, usize, usize)> = Vec::new();
+    let mut node: *mut JpegMarkerStruct = get_marker_list(cinfo_ptr);
+    while !node.is_null() {
+        let m = (*node).marker;
+        let data_len = (*node).data_length as usize;
+        let orig_len = (*node).original_length as usize;
+        result.push((m, data_len, orig_len));
+        node = (*node).next;
+    }
+
+    let jpeg_destroy_decompress: libloading::Symbol<unsafe extern "C" fn(*mut c_void)> = lib
+        .get(b"jpeg_destroy_decompress")
+        .expect("jpeg_destroy_decompress");
+    jpeg_destroy_decompress(cinfo_ptr);
+
+    result
+}
+
+/// A 200-byte COM marker saved with `length_limit=64` must appear in
+/// `cinfo->marker_list` with `data_length == 64` and the first 64 bytes
+/// matching the original payload.
+#[test]
+fn marker_save_length_limit_truncates_com() {
+    let payload_len: usize = 200;
+    let limit: usize = 64;
+    let jpeg_bytes: Vec<u8> = make_jpeg_with_com(payload_len);
+
+    let path: PathBuf = cdylib_path();
+    let lib: libloading::Library =
+        unsafe { libloading::Library::new(&path) }.expect("dlopen cdylib");
+
+    let markers: Vec<(u8, usize, usize)> =
+        unsafe { saved_marker_lengths(&lib, &jpeg_bytes, &[(JPEG_COM, limit as c_uint)]) };
+
+    // Exactly one COM marker must be saved.
+    let com_markers: Vec<_> = markers.iter().filter(|&&(code, ..)| code == 0xFE).collect();
+    assert_eq!(
+        com_markers.len(),
+        1,
+        "expected exactly one COM marker, got {}: {markers:?}",
+        com_markers.len()
+    );
+
+    let &(_, data_length, original_length) = com_markers[0];
+    assert_eq!(
+        data_length, limit,
+        "data_length must equal the requested limit ({limit}), got {data_length}"
+    );
+    assert!(
+        original_length >= payload_len,
+        "original_length ({original_length}) must be >= payload_len ({payload_len})"
+    );
+}
+
+/// `jpeg_save_markers(cinfo, JPEG_COM, 0)` disables saving for COM entirely.
+/// After `jpeg_read_header` the marker_list must contain no COM nodes.
+#[test]
+fn marker_save_length_limit_zero_disables_saving() {
+    let jpeg_bytes: Vec<u8> = make_jpeg_with_com(50);
+
+    let path: PathBuf = cdylib_path();
+    let lib: libloading::Library =
+        unsafe { libloading::Library::new(&path) }.expect("dlopen cdylib");
+
+    let markers: Vec<(u8, usize, usize)> =
+        unsafe { saved_marker_lengths(&lib, &jpeg_bytes, &[(JPEG_COM, 0)]) };
+
+    let com_count = markers.iter().filter(|&&(code, ..)| code == 0xFE).count();
+    assert_eq!(
+        com_count, 0,
+        "length_limit=0 must disable saving; found {com_count} COM markers: {markers:?}"
+    );
+}
+
+/// Without any `jpeg_save_markers` call the default is no saving; the
+/// marker_list must be empty (or contain no COM markers).
+#[test]
+fn marker_save_no_call_saves_nothing() {
+    let jpeg_bytes: Vec<u8> = make_jpeg_with_com(50);
+
+    let path: PathBuf = cdylib_path();
+    let lib: libloading::Library =
+        unsafe { libloading::Library::new(&path) }.expect("dlopen cdylib");
+
+    let markers: Vec<(u8, usize, usize)> = unsafe { saved_marker_lengths(&lib, &jpeg_bytes, &[]) };
+
+    let com_count = markers.iter().filter(|&&(code, ..)| code == 0xFE).count();
+    assert_eq!(
+        com_count, 0,
+        "without jpeg_save_markers no COM markers should be saved; found {com_count}: {markers:?}"
+    );
+}

--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -215,7 +215,7 @@
 - [x] Adobe APP14 detection (CMYK/YCCK)
 - [x] Restart marker (DRI/RST) handling
 - [x] `TJPARAM_SAVEMARKERS` — Configurable marker saving via `Decoder::save_markers()` / `MarkerSaveConfig` (not yet wired through `TjHandle`)
-- [x] `jpeg_save_markers()` — Per-marker-type save control (`Decoder::save_markers()`)
+- [x] `jpeg_save_markers()` — Per-marker-type save control with per-code `length_limit` truncation (`Decoder::save_markers()` / `MarkerSaveConfig::WithLimits`; C ABI shim truncates `cinfo->marker_list` entries to the requested limit)
 - [x] `jpeg_set_marker_processor()` — Custom marker parser callback (`Decoder::set_marker_processor()`)
 - [x] COM (comment) marker read/expose (`Image.comment`)
 - [x] Arbitrary marker access via `marker_list` linked list (`Image.markers()` / `Image.saved_markers`)

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -342,6 +342,14 @@ pub enum MarkerSaveConfig {
     AppOnly,
     /// Save only the specified marker codes.
     Specific(Vec<u8>),
+    /// Save only the specified marker codes, truncating each marker's body
+    /// to at most the associated byte limit.
+    ///
+    /// This matches libjpeg's `jpeg_save_markers(cinfo, code, length_limit)`
+    /// per-code truncation: the saved `data` slice is `min(full_len, limit)`
+    /// bytes long.  A missing entry for a code is treated as "no limit"
+    /// (`usize::MAX`).
+    WithLimits(std::collections::HashMap<u8, usize>),
 }
 
 /// Progressive scan script entry.

--- a/src/decode/marker.rs
+++ b/src/decode/marker.rs
@@ -115,6 +115,18 @@ impl<'a> MarkerReader<'a> {
             MarkerSaveConfig::All => (0xE0..=0xEF).contains(&code) || code == COM,
             MarkerSaveConfig::AppOnly => (0xE0..=0xEF).contains(&code),
             MarkerSaveConfig::Specific(codes) => codes.contains(&code),
+            MarkerSaveConfig::WithLimits(limits) => limits.contains_key(&code),
+        }
+    }
+
+    /// Return the per-marker body limit for `code`. Returns `usize::MAX`
+    /// when the config imposes no per-code limit (save full body).
+    fn marker_limit(&self, code: u8) -> usize {
+        match &self.marker_save_config {
+            MarkerSaveConfig::WithLimits(limits) => {
+                limits.get(&code).copied().unwrap_or(usize::MAX)
+            }
+            _ => usize::MAX,
         }
     }
 
@@ -255,7 +267,8 @@ impl<'a> MarkerReader<'a> {
                 // APP1 (EXIF) — parse for EXIF metadata
                 0xE1 => {
                     if self.should_save_marker(0xE1) {
-                        if let Some(raw) = self.peek_marker_data() {
+                        if let Some(mut raw) = self.peek_marker_data() {
+                            raw.truncate(self.marker_limit(0xE1));
                             saved_markers.push(SavedMarker {
                                 code: 0xE1,
                                 data: raw,
@@ -267,7 +280,8 @@ impl<'a> MarkerReader<'a> {
                 // APP2 (ICC profile) — parse for ICC profile chunks
                 0xE2 => {
                     if self.should_save_marker(0xE2) {
-                        if let Some(raw) = self.peek_marker_data() {
+                        if let Some(mut raw) = self.peek_marker_data() {
+                            raw.truncate(self.marker_limit(0xE2));
                             saved_markers.push(SavedMarker {
                                 code: 0xE2,
                                 data: raw,
@@ -279,7 +293,8 @@ impl<'a> MarkerReader<'a> {
                 // APP14 (Adobe marker) — parse for color transform info
                 0xEE => {
                     if self.should_save_marker(0xEE) {
-                        if let Some(raw) = self.peek_marker_data() {
+                        if let Some(mut raw) = self.peek_marker_data() {
+                            raw.truncate(self.marker_limit(0xEE));
                             saved_markers.push(SavedMarker {
                                 code: 0xEE,
                                 data: raw,
@@ -291,7 +306,8 @@ impl<'a> MarkerReader<'a> {
                 // APP0 (JFIF) — parse for density info
                 0xE0 => {
                     if self.should_save_marker(0xE0) {
-                        if let Some(raw) = self.peek_marker_data() {
+                        if let Some(mut raw) = self.peek_marker_data() {
+                            raw.truncate(self.marker_limit(0xE0));
                             saved_markers.push(SavedMarker {
                                 code: 0xE0,
                                 data: raw,
@@ -308,7 +324,8 @@ impl<'a> MarkerReader<'a> {
                 // COM marker — parse comment text
                 COM => {
                     if self.should_save_marker(COM) {
-                        if let Some(raw) = self.peek_marker_data() {
+                        if let Some(mut raw) = self.peek_marker_data() {
+                            raw.truncate(self.marker_limit(COM));
                             saved_markers.push(SavedMarker {
                                 code: COM,
                                 data: raw,
@@ -320,7 +337,8 @@ impl<'a> MarkerReader<'a> {
                 // Other APPn markers — save if configured, then skip
                 m if (0xE3..=0xEF).contains(&m) => {
                     if self.should_save_marker(m) {
-                        if let Some(raw) = self.peek_marker_data() {
+                        if let Some(mut raw) = self.peek_marker_data() {
+                            raw.truncate(self.marker_limit(m));
                             saved_markers.push(SavedMarker { code: m, data: raw });
                         }
                     }


### PR DESCRIPTION
## Summary

- Add `WithLimits(HashMap<u8, usize>)` variant to `MarkerSaveConfig` for Rust-native per-code marker body truncation in the decoder
- In the C ABI shim, the `marker_list` builder now correctly sets `data_length = min(original_length, limit)` and `original_length` to the full stream body size, matching libjpeg-turbo's documented `jpeg_save_markers` semantics
- Export `jpeg_capi_test_marker_list` accessor to enable dlopen integration tests without hard-coding struct offsets
- Three integration tests covering: truncation (200-byte COM, limit=64), limit=0 disables saving, no `jpeg_save_markers` call saves nothing
- Closes the `jpeg_save_markers` per-code `length_limit` truncation gap in `docs/FEATURE_PARITY.md`

## Test plan

- [ ] `cargo test -p libjpeg-turbo-rs-capi marker_save` — all 3 dlopen tests pass
- [ ] `cargo test` (workspace) — no regressions
- [ ] CI green on ubuntu-latest, macos-latest, windows-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)