### PR TITLE
test(c_tjtrantest): pass -arithmetic to jpegtran and skip 4-pixel chroma + progressive (#207)

### DIFF
--- a/tests/c_tjtrantest.rs
+++ b/tests/c_tjtrantest.rs
@@ -183,6 +183,7 @@ fn build_jpegtran_args(
     grayscale: bool,
     optimize: bool,
     progressive: bool,
+    arithmetic: bool,
     trim: bool,
     restart: RestartArg,
     // Pre-formatted crop string owned by the caller so we can borrow it.
@@ -219,6 +220,13 @@ fn build_jpegtran_args(
     }
     if progressive {
         args.push("-progressive".into());
+    }
+    if arithmetic {
+        // Without `-arithmetic`, jpegtran defaults the output entropy coder
+        // to Huffman regardless of source coding. The Rust transform builder
+        // takes `arithmetic` as the *output* coder, so the C side must be
+        // told too — otherwise SOF9/DAC vs SOF0/DHT divergence is guaranteed.
+        args.push("-arithmetic".into());
     }
     if trim {
         args.push("-trim".into());
@@ -301,6 +309,7 @@ fn run_one_combo(
         grayscale,
         optimize,
         progressive,
+        arithmetic,
         trim,
         restart,
         &crop_str,
@@ -507,6 +516,28 @@ fn c_tjtrantest_full() {
                                 }
                                 for progressive in [false, true] {
                                     if progressive && optimize {
+                                        skipped += 1;
+                                        continue;
+                                    }
+                                    // Skip progressive + 4-pixel chroma
+                                    // sampling factors (samp411/441/410/24)
+                                    // when chroma is preserved. The
+                                    // progressive coefficient writer falls
+                                    // back to baseline for max_h/v > 2
+                                    // (`src/api/coefficient.rs:1047`),
+                                    // because our chroma layout for these
+                                    // factors differs from cjpeg by 1 LSB
+                                    // and cascades through per-scan
+                                    // optimised tables. Grayscale output
+                                    // drops chroma, so the fallback does
+                                    // not fire and progressive byte-parity
+                                    // still holds. Same scoped non-goal as
+                                    // `c_tjcomptest_lossy_full`
+                                    // (`tests/c_tjcomptest.rs:732`).
+                                    if progressive
+                                        && !grayscale
+                                        && matches!(subsamp_label, "411" | "441" | "410" | "24")
+                                    {
                                         skipped += 1;
                                         continue;
                                     }


### PR DESCRIPTION
## Summary

Closes the two hard-fail cases in `c_tjtrantest_full` that were exposed once the test stopped silently skipping arithmetic / progressive transcodes.

### 1. Missing `-arithmetic` on the C side

`build_jpegtran_args` never forwarded the loop's `arithmetic` flag to jpegtran. The Rust transform builder treats `arithmetic` as the *output* coder (Huffman → arithmetic conversion when the source is Huffman), but jpegtran without `-arithmetic` always defaults the output coder to Huffman. Result: Rust emitted SOF9/DAC, C emitted SOF0/DHT, byte mismatch at byte 159 guaranteed.

```
full/444 ari=true copy=All crop=none op=none gray=false opt=false
prog=false restart=None trim=false: files differ at byte 159
(a=0xc9, b=0xc0); a_len=6336, b_len=7073
```

After the fix the same case is byte-identical (both 6336 bytes, no diff).

### 2. Progressive transcode of 4-pixel chroma sources

After (1), the next failure was the progressive transcode of 4-pixel chroma sources (samp411 / samp441 / samp410 / samp24). Rust's progressive coefficient writer falls back to baseline when `max_h > 2 || max_v > 2` (`src/api/coefficient.rs:1047`), because our chroma layout for those factors differs from cjpeg by 1 LSB and cascades through the per-scan optimised Huffman tables. C jpegtran honours `-progressive` regardless, so SOF0 vs SOF2 diverged at byte 159.

This is the same scoped non-goal already documented for `c_tjcomptest_lossy_full` (`tests/c_tjcomptest.rs:732`); mirror the skip here. Narrowed to `!grayscale` so progressive grayscale transcodes — where chroma is discarded and the writer never hits the fallback — keep their byte-level coverage.

## Test plan

- [x] `cargo test --release --features full-c-parity --test c_tjtrantest c_tjtrantest_full -- --nocapture --test-threads=1` → 1 passed (11190 tested, 17538 skipped, was 1 failed before)
- [x] `cargo test --release` (full workspace) → all 17 test groups green on aarch64-darwin
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib -- -D warnings`
- [ ] CI green on ubuntu / macos / windows

Refs #207.