### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "libjpeg-turbo-rs"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "loom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/libjpeg-turbo-rs-wasm", "crates/libjpeg-turbo-rs-image",
 
 [package]
 name = "libjpeg-turbo-rs"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.87"
 description = "Pure Rust reimplementation of libjpeg-turbo with NEON/AVX2 SIMD acceleration"

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ Apple M1 Pro, C libjpeg-turbo 3.1.0, quality 75:
 
 ```toml
 [dependencies]
-libjpeg-turbo-rs = "0.5"
+libjpeg-turbo-rs = "0.6"
 
 # Optional: enable PNG support for tj3LoadImage8 / tj3SaveImage8
-# libjpeg-turbo-rs = { version = "0.5", features = ["png"] }
+# libjpeg-turbo-rs = { version = "0.6", features = ["png"] }
 ```
 
 ### Decompress


### PR DESCRIPTION
## Summary

Version bump for the v0.6.0 release. 422 commits since v0.5.0.

### Highlights

- **Encoder restart-marker support** across the optimised, arithmetic, progressive, and arithmetic-progressive paths (#204).
- **8-bit and 16-bit lossless residual realignment** to match libjpeg-turbo `JCOEF` (`int16_t`) storage semantics (#204 / #256).
- **`c_tjcomptest_full`** — exhaustive cjpeg byte-parity (lossy_full + lossless_full) closed (#204).
- **`c_tjtrantest_full`** — exhaustive jpegtran byte-parity closed: forward `-arithmetic` to jpegtran when set, mirror the 4-pixel-chroma + progressive scoped non-goal already documented for `c_tjcomptest_lossy_full` (#207).
- **LAST_MILE.md "replacement-ready" gate closed** (2026-04-30): every encode benchmark at `Rust/C ≤ 0.98×` on x86_64 with `RUSTFLAGS="-C target-cpu=native"`; aarch64 parity stable.
- Multiple fuzz hardening rounds.

### Diff

- `Cargo.toml`: `0.5.0` → `0.6.0`
- `Cargo.lock`: regenerated
- `README.md`: dependency snippets bumped to `"0.6"`

### Release flow

After merge:
1. Tag the merge commit `v0.6.0` and push.
2. `release.yml` workflow auto-publishes to crates.io and npm on tag push.

### Test plan

- [x] `cargo build --release` clean
- [x] `cargo publish --dry-run --allow-dirty` packages 300 files, verifies under `dev`, exits cleanly
- [x] `cargo test --release` workspace green
- [x] `cargo fmt --check` / `cargo clippy --lib -- -D warnings`
- [ ] CI green