### PR TITLE
chore(wasm): bump libjpeg-turbo-rs-wasm to 0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,12 @@ name: Release
 
 on:
   push:
-    tags: ['v*']
+    # `v*`     — bumps the root crate; runs both crates.io and npm jobs.
+    # `wasm-v*` — bumps only the WASM crate; the crates.io job is skipped
+    #            and only the npm publish runs. This lets the WASM
+    #            bindings ship fresh fixes without forcing a no-op patch
+    #            release of the root crate when no Rust code changed.
+    tags: ['v*', 'wasm-v*']
   release:
     types: [published]
 
@@ -10,6 +15,10 @@ jobs:
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    # Skip the crates.io publish on WASM-only tag releases. The root
+    # crate version hasn't changed in those, so `cargo publish` would
+    # only emit the "already published" warning and add CI noise.
+    if: ${{ !startsWith(github.ref, 'refs/tags/wasm-v') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,6 +34,10 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     needs: publish
+    # `needs: publish` would block this job when the publish job is
+    # skipped (WASM-only tag release). Override to run as long as
+    # publish either succeeded or was deliberately skipped via its `if`.
+    if: ${{ always() && (needs.publish.result == 'success' || needs.publish.result == 'skipped') }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "libjpeg-turbo-rs-wasm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "js-sys",
  "libjpeg-turbo-rs",

--- a/crates/libjpeg-turbo-rs-wasm/Cargo.toml
+++ b/crates/libjpeg-turbo-rs-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libjpeg-turbo-rs-wasm"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "WASM bindings for libjpeg-turbo-rs — fast, pure-Rust JPEG codec for the browser"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

The npm package \`libjpeg-turbo-rs-wasm@0.1.0\` was published 2026-04-11 against the v0.5.0-era root crate. Since then ~422 commits have landed on \`main\` (encoder restart-marker support, 8/16-bit lossless residual fix, LAST_MILE replacement-readiness work, jpegtran transform parity, fuzz hardening), but npm consumers still get the 3-week-old build.

This bumps the WASM crate to 0.2.0 so an \`npm install libjpeg-turbo-rs-wasm\` picks up the current main-crate behaviour (the WASM crate uses \`path = "../.."\`, so the bump is what the npm package version reflects relative to the root code at publish time).

### Workflow change

Updates \`.github/workflows/release.yml\` to also accept \`wasm-v*\` tags. This lets us ship WASM-only releases without forcing a no-op patch bump of the root crate. Specifically:

- \`tags: ['v*', 'wasm-v*']\` — both patterns trigger the workflow.
- The \`publish\` job (crates.io) gates on \`!startsWith(github.ref, 'refs/tags/wasm-v')\` so it skips on WASM-only tags (root crate unchanged).
- The \`publish-wasm\` job uses \`if: always() && (publish.result == 'success' || 'skipped')\` so it runs after a clean skip too.

### Diff

- \`crates/libjpeg-turbo-rs-wasm/Cargo.toml\`: \`0.1.0\` → \`0.2.0\`
- \`Cargo.lock\`: regenerated
- \`.github/workflows/release.yml\`: trigger pattern + job conditions

### Release flow

After merge:
1. Tag the merge commit \`wasm-v0.2.0\` and push.
2. Workflow runs:
   - \`publish\` (crates.io) job is skipped (wasm-v* tag)
   - \`publish-wasm\` job builds wasm-pack bundle and \`npm publish\` to npmjs.org

### Test plan

- [x] \`cargo build --release\` clean (Cargo.lock regenerated as wasm 0.2.0)
- [ ] CI green
- [ ] After tag push, verify only \`publish-wasm\` runs and \`libjpeg-turbo-rs-wasm@0.2.0\` lands on npm