### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "libjpeg-turbo-rs"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "criterion",
  "loom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/libjpeg-turbo-rs-wasm", "crates/libjpeg-turbo-rs-image",
 
 [package]
 name = "libjpeg-turbo-rs"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.87"
 description = "Pure Rust reimplementation of libjpeg-turbo with NEON/AVX2 SIMD acceleration"


### PR DESCRIPTION
## Summary

Patch release containing the BitReader multi-FF run stall fix and CI hardening landed in #260.

### Closed LAST_MILE follow-ups (both root-caused to the same BitReader fix)

- **Baseline 16×16 RGB achromatic-output divergence** — `BitReader.get_byte` looped forever on `FF FF…` runs (libjpeg-turbo's `jpeg_fill_bit_buffer` walks past them). The infinite zero-bit stream over-consumed Y plane bandwidth and starved Cb/Cr to immediate-EOB, producing fully achromatic output. Pinned regression in `tests/bitstream_multi_ff_run.rs`.
- **Transform encoder small-image entropy divergence** — surprise: same root cause. Transform path reads source coefficients through the same BitReader. With the fix, all 6 fixtures × ops now produce byte-exact output to `jpegtran -copy all`. Pinned in `tests/transform_small_image_byte_exact.rs`.

### Bundled changes since v0.6.0

- `1e9c1bb` fix(decode): walk past multi-FF runs in BitReader
- `0313800` perf(decode): O(1) refill at multi-FF marker boundary (codex P2)
- `cbe0106` test(transform): pin small-image fixtures byte-exact vs jpegtran
- `735f54f` test(transform): use shared require_c_tool helper for jpegtran (codex P2)
- `cdbea40` test(decode): use shared require_c_tool helper for djpeg (codex stop-hook)
- `070dc19` ci(fuzz-smoke): install cargo-fuzz as prebuilt binary
- `70f3938` ci(fuzz-smoke): force --target x86_64-unknown-linux-gnu

### Compatibility

No public API changes. Non-breaking patch bump (0.6.0 → 0.6.1). Tagging `v0.6.1` after merge will trigger the release.yml workflow which publishes to crates.io.

## Test plan

- [x] `cargo test --release` — 173 test groups all green
- [x] `cargo clippy --lib -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Fuzz-smoke (manual dispatch run 25427429538): all 11 fuzz targets pass under sanitizer + 60s
- [ ] CI green on this PR
- [ ] After merge: tag `v0.6.1` → release.yml publishes to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)