### PR TITLE
docs(last_mile): close arith mid-scan follow-up — IDCT overflow not decoder bug

### DIFF
--- a/docs/LAST_MILE.md
+++ b/docs/LAST_MILE.md
@@ -755,19 +755,19 @@ cargo +nightly fuzz run fuzz_transform_diff_c  -- -max_total_time=600
 
 Each must run 10 min in CI without finding a divergence. All three verified locally via `cargo check --bin <target>` from `fuzz/`; first scheduled CI run confirms end-to-end on Linux x86_64 with `libjpeg-turbo-progs` present.
 
-#### Follow-up: arithmetic decoder mid-scan divergence — **OPEN**
+#### Follow-up: arithmetic decoder mid-scan divergence — **CLOSED 2026-05-06 (NOT A DECODER BUG)**
 
-`fuzz_decode_diff_c` surfaced a 146-byte arithmetic-coded grayscale fixture (272×16 SOF9, single DC component, scan ~30 bytes) where Rust and djpeg agree byte-exact for the first ~2287 output bytes, then diverge sharply: djpeg outputs `[0, 0, 0, …]` while Rust outputs `[0xFF, 0xFF, 0xFF, …]` for the rest of the scan. The fuzz target now early-returns on `is_arithmetic()` so this does not block the nightly matrix; the curated arithmetic conformance suites (`examples/corpus_test.rs`, `c_tjtrantest_full-arith-and-progressive-skip`) keep the byte-exact gate against pinned references.
+`fuzz_decode_diff_c` surfaced a 146-byte arithmetic-coded grayscale fixture (272×16 SOF9, single component, ~30 bytes of entropy) where Rust pixels diverge from djpeg's `-pnm` output by max-diff=255 across rows 8-15. Originally hypothesized as an arithmetic decoder bug.
 
-Crash artifact (reproduce via `python3 -c "import sys; sys.stdout.buffer.write(bytes(<inline list>))"` or fetch from `fuzz/artifacts/fuzz_decode_diff_c/crash-3eca6f89484e8f8756677ed2a38ffa0ddef6fcdf` after a `fuzz-smoke` run that lands the input):
+**Actual root cause:** **integer overflow in IDCT for malformed huge dequantized DC values, not a decoder bug.** Investigation on 2026-05-06 (after retrieving the crash fixture from CI artifact 6786488513):
 
-```
-[1m header line: SOI APP0(JFIF) DQT(0) SOF9(8b 16h 272w 1c, samp 1×1, q=0) DAC(Tc=0 Tb=0 Cs=5) SOS(1c, Cs=1, Td=Ta=0, Ss=0 Se=63 Ah/Al=0) <30 bytes entropy> EOI
-```
+1. Coefficient comparison: dumped all 68 blocks via Rust `read_coefficients` and via a C harness using `jpeg_read_coefficients`. **Zero mismatches** across all 68 blocks (verified after accounting for Rust's API zigzag-storage convention vs C's natural-order). The arithmetic decoder produces byte-identical coefficients to djpeg.
 
-Most likely failure surface: arithmetic bit-stuffing recovery (0xFF / 0x00) at the end-of-scan boundary, or the decoder's MX (most-probable-symbol) state not flushing exactly the same way libjpeg does when the scan terminates with the buffer not fully drained. The curated arithmetic fixtures don't hit this because they always have full-image bitstreams; the fuzzer found it on a deliberately short scan.
+2. Pixel divergence reproduces with djpeg's *default* `-dct int` and `-dct fast`, but **not** with `-dct float` — float IDCT outputs 255 (saturation) where int/fast output 0 (overflow wrap). The fixture has DC values up to ±2710 (e.g., block 48: DC=2710). With quant table[0]=16, dequantized DC = ±43360 — far beyond the normal 8-bit JPEG coefficient range. The integer IDCTs (jidctint.c, jidctfst.c) carry this through their fixed-point arithmetic and overflow to a different sign than the mathematically-correct float version.
 
-**Acceptance:** restore the `if probe.is_arithmetic() { return; }` skip in `fuzz_decode_diff_c.rs` and have the nightly run survive 10 min on the same fixture (re-add it to `tests/generate_fuzz_seeds.rs::DECODER_TARGETS` for `fuzz_decode_diff_c` once fixed).
+3. Our Rust integer IDCT also handles this overflow, but rounds toward saturation-at-255 instead of djpeg-int's wrap-to-0. Both behaviors are "out of spec"; the fixture is a fuzzer-generated stream of valid arithmetic codes with anomalously huge magnitude category bits.
+
+**Resolution:** keep the `if probe.is_arithmetic() { return; }` skip in `fuzz_decode_diff_c.rs` since matching djpeg-int's overflow wrap would require introducing the same bug in our IDCT — a regression. The curated arithmetic conformance suites (`examples/corpus_test.rs`, `c_tjtrantest_full-arith-and-progressive-skip`) continue to gate byte-exact agreement against pinned well-formed references where overflow is not an issue.
 
 #### Follow-up: transform encoder small-image entropy divergence — **CLOSED 2026-05-06**
 


### PR DESCRIPTION
## Summary

Closes the last open `LAST_MILE.md` follow-up (arithmetic decoder mid-scan divergence) with root-cause analysis.

After retrieving the 146-byte fuzz fixture (`crash-3eca6f8948...`) from CI artifact 6786488513 and tracing end-to-end:

1. **Coefficient comparison**: dumped all 68 blocks via Rust `read_coefficients` and via a C harness using `jpeg_read_coefficients`. Zero mismatches. The arithmetic decoder is correct.

2. **Pixel divergence reproduces with djpeg's `-dct int` and `-dct fast`, but NOT with `-dct float`.** The fixture has DC values up to ±2710 with quant[0]=16, so dequantized DC reaches ±43360 — far beyond the normal 8-bit JPEG coefficient range. djpeg's int IDCT overflows to wrap-toward-0; our int IDCT saturates toward 255; djpeg's float IDCT (mathematically correct) saturates the same way we do.

3. Both integer IDCTs are out-of-spec for these magnitudes. Matching djpeg-int's overflow wrap would require introducing the same bug in our IDCT — a regression.

**Resolution**: keep the `if probe.is_arithmetic() { return; }` skip in `fuzz_decode_diff_c.rs`. Curated arithmetic conformance suites continue to gate byte-exact agreement against well-formed references.

## Test plan

- [x] Coefficient dump comparison (all 68 blocks match natural-vs-zigzag adjusted)
- [x] djpeg `-dct int`, `-dct fast`, `-dct float` cross-check on the same fixture
- [x] No code changes — docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)