### PR TITLE
fix(capi): jpeg_read_header invokes error_exit on malformed input (P3-5 pattern #8)

### DIFF
--- a/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
+++ b/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
@@ -797,6 +797,40 @@ unsafe extern "C" fn default_output_message(_cinfo: *mut c_void) {
     // No-op by default — real libjpeg routes through stderr.
 }
 
+/// Invoke `cinfo->err->error_exit(cinfo)` with the given `msg_code`,
+/// mirroring upstream's `ERREXIT` macro family in `jerror.h`.
+///
+/// libjpeg's contract (libjpeg.txt §3) is that whenever the library
+/// detects an unrecoverable error during a public-API call (corrupt
+/// stream, bogus marker length, out-of-range parameter, …), it must
+/// route through `cinfo->err->error_exit(cinfo)`. Consumers override
+/// `error_exit` with a `setjmp`/`longjmp` handler so the call returns
+/// control to user code rather than aborting the process.
+///
+/// Most consumer overrides longjmp out and never return; this helper
+/// still returns cleanly if a custom handler does return (which
+/// violates the libjpeg contract, but defensive code is cheap), so the
+/// caller can fall through to its own error-return path.
+fn invoke_error_exit(cinfo: *mut c_void, msg_code: c_int) {
+    if cinfo.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees `cinfo` is a valid `j_common_ptr`-shaped
+    // struct whose first pointer-sized field is the `err` slot.
+    unsafe {
+        let err_pp: *const *mut JpegErrorMgr = cinfo as *const *mut JpegErrorMgr;
+        let err_ptr: *mut JpegErrorMgr = err_pp.read();
+        if err_ptr.is_null() {
+            return;
+        }
+        let err: &mut JpegErrorMgr = &mut *err_ptr;
+        err.msg_code = msg_code;
+        if let Some(exit) = err.error_exit {
+            exit(cinfo);
+        }
+    }
+}
+
 unsafe extern "C" fn default_format_message(cinfo: *mut c_void, buffer: *mut u8) {
     if buffer.is_null() {
         return;
@@ -1629,6 +1663,37 @@ pub extern "C" fn jpeg_read_header(cinfo: *mut c_void, _require_image: CBoolean)
         Err(e) => {
             priv_state.last_error =
                 CString::new(format!("jpeg_read_header: {e}")).unwrap_or_default();
+            // Distinguish "input is incomplete (need more data)" from
+            // "input is syntactically complete but corrupt." Bytes ending
+            // in EOI (FF D9) are syntactically complete, so a decoder
+            // error means real corruption — invoke the consumer's
+            // `error_exit` per the libjpeg.txt §3 contract so a
+            // setjmp/longjmp handler can recover. Bytes without EOI may
+            // still be truncated, so leave the existing JPEG_SUSPENDED
+            // semantics intact and let the consumer feed more.
+            //
+            // The `bytes.len() >= 4` guard avoids a false positive on
+            // tiny inputs whose entire content happens to look like
+            // `FF D9` — a real JPEG always has SOI (FF D8) before EOI.
+            let appears_complete: bool = bytes.len() >= 4
+                && bytes[bytes.len() - 2] == 0xFF
+                && bytes[bytes.len() - 1] == 0xD9;
+            if appears_complete {
+                // Code 12 maps to JERR_BAD_LENGTH in the upstream v8
+                // alphabetical enum (jerror.h, with JPEG_LIB_VERSION=80
+                // excluding JERR_ARITH_NOTIMPL). It's the closest fit
+                // for the most common decoder rejection cause (bogus
+                // marker length); other causes still land here with the
+                // same code, and the consumer's `format_message` looks
+                // up the description in the message table. Consumers
+                // that care about the specific cause read
+                // `priv_state.last_error` (already populated above).
+                invoke_error_exit(cinfo, 12);
+                // If a custom handler returns instead of longjmping
+                // (which violates the libjpeg contract), fall through
+                // to JPEG_SUSPENDED so the caller still sees a
+                // non-success return.
+            }
             return JPEG_SUSPENDED;
         }
     };

--- a/crates/libjpeg-turbo-rs-capi/tests/capi_classic_lifecycle.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/capi_classic_lifecycle.rs
@@ -1414,15 +1414,6 @@ fn pattern_7_buffered_image_multi_pass_progressive() {
 
 // ---------- pattern #8: setjmp/longjmp error cleanup with custom error_exit ----------
 
-// NOTE: pattern_8 is currently #[ignore]'d below — running it surfaces a
-// real shim bug (`jpeg_read_header` returns `JPEG_SUSPENDED` on
-// EOI-terminated malformed input instead of invoking `error_exit`,
-// breaking the canonical setjmp/longjmp pattern in libjpeg.txt §3).
-// The C harness below is preserved verbatim so the follow-up PR that
-// fixes the shim only needs to flip the `#[ignore]` attribute, not
-// re-author the test. Until that fix lands, the harness is dead code
-// — kept under `#[allow(dead_code)]` so clippy doesn't flag it.
-#[allow(dead_code)]
 const PATTERN_8_SETJMP_LONGJMP: &str = r#"
 #include <setjmp.h>
 
@@ -1504,7 +1495,6 @@ int main(void) {
 "#;
 
 #[test]
-#[ignore = "P3-5 follow-up: jpeg_read_header must invoke cinfo->err->error_exit on Decoder::new errors for EOI-terminated input — currently returns JPEG_SUSPENDED for both truncated and corrupt input, breaking the libjpeg.txt §3 setjmp/longjmp contract. Fix in a separate PR; harness is ready (PATTERN_8_SETJMP_LONGJMP) — flip this attribute when shim fix lands."]
 fn pattern_8_setjmp_longjmp_error_cleanup() {
     let c_src = format!("{C_PREAMBLE}\n{PATTERN_8_SETJMP_LONGJMP}");
     run_or_skip("lifecycle_setjmp_longjmp", &c_src);

--- a/docs/LAST_MILE.md
+++ b/docs/LAST_MILE.md
@@ -44,10 +44,10 @@ Do not call the project a libjpeg-turbo C replacement until all are true:
 | ID | Title | Phase | Priority |
 | --- | --- | --- | --- |
 | **P3-4** | 4-Pixel Chroma Progressive Transform Writer Gate | [phase3](last_mile/phase3.md#p3-4-4-pixel-chroma-progressive-transform-writer-gate--open-root-cause-scoped-2026-05-07-full-fix-deferred) | P3 |
-| **P3-5** | Classic `jpeglib.h` Lifecycle / Custom-I/O / Suspension C Harness | [phase3](last_mile/phase3.md#p3-5-classic-jpeglibh-lifecycle--custom-io--suspension-c-harness--open) | P3 |
+| **P3-5** | Classic `jpeglib.h` Lifecycle / Custom-I/O / Suspension C Harness — **PARTIAL** (7/8 patterns landed; #4 deferred) | [phase3](last_mile/phase3.md#p3-5-classic-jpeglibh-lifecycle--custom-io--suspension-c-harness--partial-78-patterns-landed-4-destination-suspension-deferred) | P3 |
 | **P3-6** | Non-Standard Sampling / RGB565 Merged-Upsample | [phase3](last_mile/phase3.md#p3-6-non-standard-sampling--rgb565-merged-upsample--open-p2-priority) | P3 (P2 priority) |
 
-**Next up** (per Phase 3 Suggested Order below): **P3-5** (classic lifecycle harness — most expensive but structural).
+**Next up** (per Phase 3 Suggested Order below): **P3-4** (4-pixel chroma transform writer gate). P3-5 is now PARTIAL — pattern #4 (destination suspension) is the remaining tracked follow-up; the classic-lifecycle harness, suspension semantics, and shim-side `error_exit` invocation are all landed.
 
 ---
 
@@ -59,7 +59,7 @@ Each phase file is self-contained. Read only the one you need.
 | --- | --- | --- | --- |
 | **Phase 1** | [last_mile/phase1.md](last_mile/phase1.md) | Original release gate: P0-1..4, P1 (Soft-Skip / Encode SIMD / Legacy / Precision / YUV), Phase-1 P2 (tjbench / PNG), Execution Plan (Tasks 1-7), Definition of Done. | All CLOSED — historical reference. |
 | **Phase 2** | [last_mile/phase2.md](last_mile/phase2.md) | System-library drop-in hardening: P2-1..11 (workflow flags, printf expansion, ABI cross-check, symbol inventory, install layout, fuzzing, distro consumers, progressive-encode samp411, crates.io publish). | All CLOSED. |
-| **Phase 3** | [last_mile/phase3.md](last_mile/phase3.md) | Long-tail C compatibility: P3-1 (ABI offset cross-check), P3-2 (12-bit raw-data stubs), P3-3 (legacy TJ aliases), P3-4 (4-pixel chroma transform gate), P3-5 (classic lifecycle harness), P3-6 (non-standard sampling / RGB565). | P3-1 PARTIAL, P3-2 PARTIAL, P3-3 CLOSED; P3-4..6 OPEN. |
+| **Phase 3** | [last_mile/phase3.md](last_mile/phase3.md) | Long-tail C compatibility: P3-1 (ABI offset cross-check), P3-2 (12-bit raw-data stubs), P3-3 (legacy TJ aliases), P3-4 (4-pixel chroma transform gate), P3-5 (classic lifecycle harness), P3-6 (non-standard sampling / RGB565). | P3-1/P3-2/P3-5 PARTIAL, P3-3 CLOSED; P3-4 + P3-6 OPEN. |
 | **Reference** | [last_mile/reference_commands.md](last_mile/reference_commands.md) | Common verification commands (workspace test, stock-tool build, encode bench matrix, etc.). | — |
 
 ---
@@ -71,7 +71,7 @@ Each phase file is self-contained. Read only the one you need.
 1. ~~**P3-1** — extend `tests/abi_offsets.rs` to compress / error_mgr / source_mgr / destination_mgr.~~ **PARTIAL 2026-05-06** — 5 struct cross-checks pass; marker / virt_barray deferred.
 2. ~~**P3-3** — implement the 19 legacy TurboJPEG aliases as forwarding wrappers; remove from allowlist.~~ **CLOSED 2026-05-06**.
 3. ~~**P3-2** — `jpeg12_*_raw_data` stub semantics.~~ **PARTIAL 2026-05-06** — silent-zero return replaced by `JERR_NOTIMPL` `error_exit`; full backend deferred.
-4. **P3-5** — classic `jpeglib.h` lifecycle / custom-I/O / suspension C harness (≥ 8 tests). Most expensive item; defer until 1–3 are clean.
+4. ~~**P3-5** — classic `jpeglib.h` lifecycle / custom-I/O / suspension C harness (≥ 8 tests).~~ **PARTIAL 2026-05-07** — 7/8 patterns landed (custom src/dst mgr, source suspension, abort+reuse for both, buffered-image multi-pass, setjmp/longjmp). Pattern #4 (destination suspension) deferred as a tracked follow-up. Shim defect uncovered + fixed in `jpeg_read_header` (now invokes `error_exit` on EOI-terminated malformed input per libjpeg.txt §3).
 5. **P3-4** — lift the 4-pixel chroma transform writer gate. Root cause scoped 2026-05-07; gate stays until the underlying drift in `src/transform/*` or `write_coefficients_progressive` is fixed.
 6. **P3-6** — non-standard sampling / RGB565 merged-upsample minimum fixture set. Lower priority; do only if a downstream consumer requests it or after 1–5 are clean.
 

--- a/docs/last_mile/phase3.md
+++ b/docs/last_mile/phase3.md
@@ -14,7 +14,7 @@ For each item below, the **agreement** line states whether the gap is reproducib
 | P3-2 | PARTIAL (silent-zero stub eliminated; full backend deferred) |
 | P3-3 | CLOSED 2026-05-06 |
 | **P3-4** | **OPEN** (root cause scoped 2026-05-07; full fix deferred) |
-| **P3-5** | **OPEN** |
+| **P3-5** | **PARTIAL** (7/8 patterns landed; #4 destination suspension deferred) |
 | **P3-6** | **OPEN** (P2 priority — narrow consumer impact) |
 
 ---
@@ -170,9 +170,13 @@ The closure title reflects the actual delta: stub *semantics* moved from "silent
 
 ---
 
-## P3-5. Classic `jpeglib.h` Lifecycle / Custom-I/O / Suspension C Harness — **OPEN**
+## P3-5. Classic `jpeglib.h` Lifecycle / Custom-I/O / Suspension C Harness — **PARTIAL: 7/8 patterns landed; #4 destination suspension deferred**
 
-**Agreement:** verified open. The harnesses in `crates/libjpeg-turbo-rs-capi/tests/` cover Pillow / ImageMagick / libvips / FFmpeg / GD / SDL_image consumers and the raw-data symbol exports, but not the *classic state-machine* edge cases an arbitrary C consumer can construct. Specifically missing:
+**Status (2026-05-07): 7 of 8 patterns landed.** `crates/libjpeg-turbo-rs-capi/tests/capi_classic_lifecycle.rs` exercises patterns #1, #2, #3, #5, #6, #7, #8 against the cdylib via real C harnesses; `cargo test --release -p libjpeg-turbo-rs-capi --test capi_classic_lifecycle` reports `7 passed, 1 ignored, 0 failed`. The single deferred pattern (#4 destination suspension via `empty_output_buffer` returning `FALSE`) is annotated with the next-investigator scope-tracking note in the test file's `#[ignore]` reason.
+
+**Shim fix landed alongside pattern #8.** Pattern #8 surfaced a real shim defect: `jpeg_read_header` in `crates/libjpeg-turbo-rs-capi/src/jpeglib.rs` returned `JPEG_SUSPENDED` (= 0) on every `Decoder::new` rejection, conflating "input is incomplete (need more data)" with "input is syntactically complete but corrupt." The libjpeg.txt §3 contract is to invoke `cinfo->err->error_exit` for the second case so a `setjmp`/`longjmp` consumer can recover. Fix: a new `invoke_error_exit` helper that walks `cinfo->err` and dispatches `error_exit`, plus a guarded call site in `jpeg_read_header` that fires it only when the input bytes terminate in `FF D9` (a heuristic for "syntactically complete"). Truncated input still returns `JPEG_SUSPENDED`, preserving pattern #3's suspension semantics.
+
+**Agreement (historical, original gap):** verified open. The harnesses in `crates/libjpeg-turbo-rs-capi/tests/` cover Pillow / ImageMagick / libvips / FFmpeg / GD / SDL_image consumers and the raw-data symbol exports, but not the *classic state-machine* edge cases an arbitrary C consumer can construct. Specifically missing:
 
 1. Custom `jpeg_source_mgr` (callback-driven, small buffers).
 2. Custom `jpeg_destination_mgr` with `empty_output_buffer` flush stress.
@@ -210,7 +214,7 @@ The closure title reflects the actual delta: stub *semantics* moved from "silent
 1. ~~**P3-1** — Extend `tests/abi_offsets.rs` to `jpeg_compress_struct`, `jpeg_error_mgr`, `jpeg_source_mgr`, `jpeg_destination_mgr`.~~ **PARTIAL 2026-05-06** — five struct cross-checks now pass (`jpeg_decompress_struct` + four new ones); marker / virt_barray are deferred per their consumer-impact rationale.
 2. ~~**P3-3** — Implement the 19 legacy TurboJPEG aliases as forwarding wrappers and delete them from the allowlist.~~ **CLOSED 2026-05-06** — `crates/libjpeg-turbo-rs-capi/tests/symbol_inventory.rs::allowlisted_missing_symbols()` returns an empty `HashSet`; both `cdylib_exports_every_upstream_*` tests pass without exemptions. The wrappers live in `crates/libjpeg-turbo-rs-capi/src/legacy.rs` (~390 lines for the new section).
 3. ~~**P3-2** — Either implement `jpeg12_write_raw_data` / `jpeg12_read_raw_data` against the existing 12-bit encode/decode backend, or downgrade them to feature-gated absence. The "stub returning 0" middle ground must end.~~ **PARTIAL 2026-05-06** — middle ground eliminated: stubs now invoke `cinfo->err->error_exit(cinfo)` with `msg_code = JERR_NOTIMPL`, so callers either longjmp out cleanly or hit a default abort. Full 12-bit raw-data backend deferred to Phase 4 (gated on downstream demand).
-4. **P3-5** — Classic `jpeglib.h` lifecycle / custom-I/O / suspension C harness (≥ 8 tests). The most expensive item; defer until 1–3 are clean.
+4. ~~**P3-5** — Classic `jpeglib.h` lifecycle / custom-I/O / suspension C harness (≥ 8 tests).~~ **PARTIAL 2026-05-07** — 7/8 patterns landed in `crates/libjpeg-turbo-rs-capi/tests/capi_classic_lifecycle.rs` (custom src/dst mgr, source suspension, abort+reuse for both decompress/compress, buffered-image multi-pass, setjmp/longjmp). Pattern #4 destination suspension stays `#[ignore]`'d as a tracked follow-up (annotated with the next-investigator scope-tracking note). The setjmp/longjmp pattern also surfaced + fixed a real shim defect: `jpeg_read_header` now invokes `error_exit` on EOI-terminated malformed input (previously returned `JPEG_SUSPENDED` for both truncated AND corrupt input, breaking the libjpeg.txt §3 contract).
 5. **P3-4** — Lift the 4-pixel chroma transform writer gate; close the P2-12 follow-up. **Open (root cause scoped 2026-05-07)** — `tests/c_tjtrantest.rs:529-543` confirms the gate is masking a 1-LSB chroma layout drift in the transform path, not a redundant guard. The gate stays in place until the underlying drift in `src/transform/*` (block-reorder math) or `src/api/coefficient.rs::write_coefficients_progressive` (per-scan iMCU traversal) is fixed; the entry above documents next-session investigation start points.
 6. **P3-6** — Non-standard sampling / RGB565 merged-upsample minimum fixture set. P2 priority; do only if a downstream consumer requests it or after 1–5 are clean.
 


### PR DESCRIPTION
## Summary

Closes the second-to-last P3-5 follow-up. Pattern #8 of the lifecycle harness (#266) had been staged \`#[ignore]\`'d because running it surfaced a real shim defect: \`jpeg_read_header\` returned \`JPEG_SUSPENDED\` (= 0) on every \`Decoder::new\` rejection, regardless of whether the input was truncated (where \`SUSPENDED\` is correct) or syntactically complete + corrupt (where the libjpeg.txt §3 contract is to invoke \`cinfo->err->error_exit\` so a \`setjmp\`/\`longjmp\` consumer can recover). A canonical setjmp/longjmp consumer would silently see \"success-ish\" on malformed input and proceed with garbage state.

## The fix

Two parts in \`crates/libjpeg-turbo-rs-capi/src/jpeglib.rs\`:

- New \`invoke_error_exit(cinfo, msg_code)\` helper next to \`default_error_exit\`: walks \`cinfo->err\`, sets \`msg_code\`, dispatches \`error_exit\`. Mirrors upstream's \`ERREXIT\` macro family. Defensive: returns cleanly if a custom handler returns instead of longjmping.
- \`jpeg_read_header\` \`Decoder::new\` Err arm now distinguishes complete-but-corrupt input from truncated input by checking whether \`bytes\` terminates in \`FF D9\` (EOI). When the trailer is present, invoke \`invoke_error_exit(cinfo, 12)\` (= \`JERR_BAD_LENGTH\` in the upstream v8 alphabetical enum, the closest fit for the most common decoder rejection cause). Truncated input (no EOI) preserves \`JPEG_SUSPENDED\` semantics — pattern #3's source-suspension test passes without modification.

## P3-5 status

Goes from PARTIAL (6/8) → PARTIAL (7/8). Only pattern #4 (destination suspension via \`empty_output_buffer\` returning \`FALSE\`) remains as a tracked follow-up.

## Doc updates

- \`docs/last_mile/phase3.md\` P3-5 heading flipped to \`**PARTIAL: 7/8 patterns landed; #4 destination suspension deferred**\`. Added Status line citing the closure evidence and describing the shim fix. Suggested-Order entry #4 strike-through.
- \`docs/LAST_MILE.md\` index: OPEN-Items row for P3-5 reflects PARTIAL status with the new section anchor; \"Next up\" points at P3-4; Phase Map row updated; Suggested Order #4 strike-through.

## Verification

- \`cargo test --release -p libjpeg-turbo-rs-capi --test capi_classic_lifecycle\` → 7 passed, 1 ignored, 0 failed.
- \`cargo clippy --release -p libjpeg-turbo-rs-capi --lib -- -D warnings\` clean.
- \`cargo clippy --release -p libjpeg-turbo-rs-capi --test capi_classic_lifecycle -- -D warnings\` clean.
- \`cargo fmt --check\` clean.
- All 5 LAST_MILE doc tree internal links re-verified via github-slugger algorithm — 0 broken.
- Pre-existing \`imagemagick_roundtrips_through_our_cdylib\` failure (PSNR=22.6 dB) is unaffected — same failure mode documented in phase3.md P3-2 closure as a separate gap (\`docs/fix-arith-contradiction\` baseline).

## Test plan

- [x] All 7 active P3-5 lifecycle patterns pass locally on macOS aarch64.
- [x] Pre-existing tests not regressed by the shim change.
- [ ] CI matrix green on Linux x86_64 / macOS / Windows.

Related: #266 (P3-5 6/8 patterns), #265 (LAST_MILE doc reorg).