### PR TITLE
fix(decode): wire merged-upsample for RGB565 — close P3-6

### DIFF
--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -195,7 +195,7 @@
 - [x] `do_block_smoothing` toggle (`Decoder::set_block_smoothing()`)
 - [x] `dct_method` selection (ISLOW/IFAST/FLOAT) (`Decoder::set_dct_method()`)
 - [x] RGB565 ordered dithering (`Decoder::set_dither_565()`)
-- [x] Merged upsampling (combined upsample + color convert for 422m/420m) (`Decoder::set_merged_upsample()`)
+- [x] Merged upsampling (combined upsample + color convert for 422m/420m) (`Decoder::set_merged_upsample()`). RGB and RGB565 output both wired through the SIMD merged kernels (NEON / AVX2 / WASM SIMD128 / scalar). Cross-validated against `djpeg -nosmooth` for S420/S422 in `tests/cross_check_p3_6_nonstandard_rgb565.rs`. Dedicated `_565` SIMD kernels (upstream `jdmrgext-*-565`) are deferred as a Phase 4 perf task — current path packs after the merged conversion.
 - [x] 4:1:0 (H=4,V=2) subsampling decode — arbitrary factor upsampling
 
 ### Error Handling

--- a/docs/LAST_MILE.md
+++ b/docs/LAST_MILE.md
@@ -10,15 +10,16 @@
 
 ## Current Status (2026-05-07)
 
-Project is **replacement-ready** for the Rust-application + stock-tool drop-in story. System-library drop-in (Phase 2) is closed. Long-tail C-compatibility (Phase 3) has 1 OPEN item left (P3-6).
+Project is **replacement-ready** for the Rust-application + stock-tool drop-in story. System-library drop-in (Phase 2) is closed. Long-tail C-compatibility (Phase 3) has **0 fully-OPEN items left** — P3-3 / P3-4 / P3-5 / P3-6 are all CLOSED; P3-1 and P3-2 retain narrow PARTIAL scope-tracking notes for follow-ups gated on downstream demand.
 
 **Live gate** (refresh whenever the inventory changes):
 
 | Check | Result |
 | --- | --- |
-| `cargo test --workspace --release` | **Passes** product-path — 2145 tests, 0 product failures, 1 ignored (one pre-existing capi `imagemagick_roundtrips_through_our_cdylib` PSNR regression tracked under `docs/fix-arith-contradiction`). |
+| `cargo test --workspace --release` | **Passes** product-path — 2149 tests, 0 product failures, 1 ignored (one pre-existing capi `imagemagick_roundtrips_through_our_cdylib` PSNR regression tracked under `docs/fix-arith-contradiction`). |
 | `cargo test -p libjpeg-turbo-rs --test cross_product_transform` | **Passes** all 12 cases. P0-1 closed. |
 | `cargo test -p libjpeg-turbo-rs --test regression_progressive_4pixel_chroma_transform` | **Passes** 256 cases byte-exact vs `jpegtran -progressive -copy all <op>`. P3-4 closed. |
+| `cargo test --test cross_check_p3_6_nonstandard_rgb565` | **Passes** 4 fixtures: 3x2 decode (vs `djpeg`), 3x2 encode (vs `cjpeg -sample 3x2,1x1,1x1` + `djpeg`), 3x1 decode, RGB565 merged-upsample (vs `djpeg -nosmooth` + 5-6-5 truncate chain). P3-6 closed. |
 | `cargo test --release --features full-c-parity --test c_tjtrantest c_tjtrantest_full` | **Passes** — 12,230 tested, 18,498 skipped (skip set covers unrelated tjtrantest exclusions, not P3-4). |
 | `examples/stock_djpeg_cjpeg/run.sh` | `OK all_byte_exact` — every fixture byte-exact vs stock djpeg/cjpeg/jpegtran. P0-2 + P0-4 closed. |
 | `cargo test --test capi_stock_tool_link` | **Passes** for djpeg/cjpeg/jpegtran + full TJXOP cross-product. |
@@ -43,11 +44,14 @@ Do not call the project a libjpeg-turbo C replacement until all are true:
 
 ## Open Items
 
-| ID | Title | Phase | Priority |
-| --- | --- | --- | --- |
-| **P3-6** | Non-Standard Sampling / RGB565 Merged-Upsample | [phase3](last_mile/phase3.md#p3-6-non-standard-sampling--rgb565-merged-upsample--open-p2-priority) | P3 (P2 priority) |
+No fully-OPEN items left in Phase 3. The PARTIAL closures are:
 
-**Next up** (per Phase 3 Suggested Order below): **P3-6** — non-standard sampling (3x2 / 3x1 / 1x3) + RGB565 merged-upsample minimum fixture set. P2 priority; do only if a downstream consumer requests it.
+| ID | Status | Deferred work | Trigger |
+| --- | --- | --- | --- |
+| P3-1 | PARTIAL | `jpeg_marker_struct` + `jvirt_*_control` ABI offset cross-checks | Downstream consumer pinning offsets in those structs |
+| P3-2 | PARTIAL | Full 12-bit raw-data backend (silent-zero stub eliminated; `JERR_NOTIMPL` `error_exit` semantics in place) | Downstream consumer needing 12-bit `jpeg_*_raw_data` |
+
+**Next up**: nothing scheduled. The release gate is satisfied for the standard-sampling / classic-lifecycle / lossless-transform / non-standard-sampling consumer surfaces. Future phases live in `docs/last_mile/phase4.md` or later if downstream surfaces a gap.
 
 ---
 
@@ -59,7 +63,7 @@ Each phase file is self-contained. Read only the one you need.
 | --- | --- | --- | --- |
 | **Phase 1** | [last_mile/phase1.md](last_mile/phase1.md) | Original release gate: P0-1..4, P1 (Soft-Skip / Encode SIMD / Legacy / Precision / YUV), Phase-1 P2 (tjbench / PNG), Execution Plan (Tasks 1-7), Definition of Done. | All CLOSED — historical reference. |
 | **Phase 2** | [last_mile/phase2.md](last_mile/phase2.md) | System-library drop-in hardening: P2-1..11 (workflow flags, printf expansion, ABI cross-check, symbol inventory, install layout, fuzzing, distro consumers, progressive-encode samp411, crates.io publish). | All CLOSED. |
-| **Phase 3** | [last_mile/phase3.md](last_mile/phase3.md) | Long-tail C compatibility: P3-1 (ABI offset cross-check), P3-2 (12-bit raw-data stubs), P3-3 (legacy TJ aliases), P3-4 (4-pixel chroma transform gate), P3-5 (classic lifecycle harness), P3-6 (non-standard sampling / RGB565). | P3-1/P3-2 PARTIAL, P3-3/P3-4/P3-5 CLOSED; P3-6 OPEN. |
+| **Phase 3** | [last_mile/phase3.md](last_mile/phase3.md) | Long-tail C compatibility: P3-1 (ABI offset cross-check), P3-2 (12-bit raw-data stubs), P3-3 (legacy TJ aliases), P3-4 (4-pixel chroma transform gate), P3-5 (classic lifecycle harness), P3-6 (non-standard sampling / RGB565). | P3-1/P3-2 PARTIAL; P3-3/P3-4/P3-5/P3-6 CLOSED. |
 | **Reference** | [last_mile/reference_commands.md](last_mile/reference_commands.md) | Common verification commands (workspace test, stock-tool build, encode bench matrix, etc.). | — |
 
 ---
@@ -73,7 +77,7 @@ Each phase file is self-contained. Read only the one you need.
 3. ~~**P3-2** — `jpeg12_*_raw_data` stub semantics.~~ **PARTIAL 2026-05-06** — silent-zero return replaced by `JERR_NOTIMPL` `error_exit`; full backend deferred.
 4. ~~**P3-5** — classic `jpeglib.h` lifecycle / custom-I/O / suspension C harness (≥ 8 tests).~~ **CLOSED 2026-05-08** — all 8 patterns active (custom src/dst mgr, source suspension, destination-suspension `JERR_CANT_SUSPEND` contract, abort+reuse for both, buffered-image multi-pass, setjmp/longjmp). Two shim defects uncovered + fixed: pattern #8 (2026-05-07) made `jpeg_read_header` invoke `error_exit` on EOI-terminated malformed input; pattern #4 (2026-05-08) made `push_bytes_through_dest_mgr` invoke `error_exit` with `JERR_CANT_SUSPEND` instead of silently dropping bytes when a custom dst mgr returns `FALSE` (the deferred-encode shim cannot honor upstream's per-MCU suspension at `jpeg_write_scanlines`).
 5. ~~**P3-4** — lift the 4-pixel chroma transform writer gate.~~ **CLOSED 2026-05-07** — gate at `transform_jpeg_with_options::progressive_safe` widened from `max_{h,v} ≤ 2` to `max_{h,v} ∈ {1,2,4}` (the eight standard TJSAMP factors); non-standard 3x sampling stays on baseline pending P3-6. Regression pinned in `tests/regression_progressive_4pixel_chroma_transform.rs` (256 cases, all byte-equal vs `jpegtran -progressive -copy all <op>`); `c_tjtrantest_full` runs 12,230 cases without divergence.
-6. **P3-6** — non-standard sampling / RGB565 merged-upsample minimum fixture set. Lower priority; do only if a downstream consumer requests it or after 1–5 are clean.
+6. ~~**P3-6** — non-standard sampling / RGB565 merged-upsample minimum fixture set.~~ **CLOSED 2026-05-08** — 4 fixtures (3x2 decode, 3x2 encode, 3x1 decode, RGB565 merged-upsample) green in `tests/cross_check_p3_6_nonstandard_rgb565.rs`. Shim fix: merged-upsample gate widened from `Rgb` to `Rgb || Rgb565` with a 5-6-5 truncation pass after the merged kernel.
 
 ---
 

--- a/docs/last_mile/phase3.md
+++ b/docs/last_mile/phase3.md
@@ -1,6 +1,6 @@
-# Phase 3 — Long-Tail C Compatibility (3 OPEN items)
+# Phase 3 — Long-Tail C Compatibility (0 OPEN items; P3-1/P3-2 PARTIAL)
 
-> **Index:** [docs/LAST_MILE.md](../LAST_MILE.md). This phase has open work — keep this file in mind when planning new gaps.
+> **Index:** [docs/LAST_MILE.md](../LAST_MILE.md). This phase has no fully-OPEN items left — P3-1 and P3-2 retain narrow PARTIAL scope-tracking notes for follow-ups gated on downstream demand.
 
 External review on 2026-05-06 (`libjpeg_turbo_rs_replacement_analysis.md`) graded the project's *Rust-application replacement* and *stock-tool drop-in* posture as ready, but flagged a long-tail of C-compatibility gaps that block the stronger claim "**any existing C binary linked against `libjpeg.so` / `libturbojpeg.so` runs unchanged**." Six of the seven gaps reproduce in this repository today. The seventh — `libjpeg.so.62` SONAME policy — is already closed under [P2-9](phase2.md#p2-9-v6b--v7--v8-abi-compatibility-matrix--closed) and is not re-listed here.
 
@@ -15,7 +15,7 @@ For each item below, the **agreement** line states whether the gap is reproducib
 | P3-3 | CLOSED 2026-05-06 |
 | P3-4 | CLOSED 2026-05-07 |
 | P3-5 | CLOSED 2026-05-08 |
-| **P3-6** | **OPEN** (P2 priority — narrow consumer impact) |
+| P3-6 | CLOSED 2026-05-08 |
 
 ---
 
@@ -195,16 +195,28 @@ The closure title reflects the actual delta: stub *semantics* moved from "silent
 
 ---
 
-## P3-6. Non-Standard Sampling / RGB565 Merged-Upsample — **OPEN (P2 priority)**
+## P3-6. Non-Standard Sampling / RGB565 Merged-Upsample — **CLOSED 2026-05-08**
 
-**Agreement:** verified partially open. `src/encode/pipeline.rs:9952` claims support for "non-standard sampling configurations such as 3x2, 3x1, 1x3"; `src/decode/pipeline.rs:18` and `src/decode/color.rs:98+98` cover RGB565 + dithered RGB565 *output*, but the **merged-upsample** SIMD path (`jdmrgext-sse2.asm` / `jdmrgext-avx2.asm` in upstream) is not wired against the RGB565 output type, and there is no fixture matrix verifying 3x2 sampling decode/encode round-trip against C.
+**Status (2026-05-08): closed.** All four minimum-coverage fixtures land in `tests/cross_check_p3_6_nonstandard_rgb565.rs`:
 
-**Why this matters:** lower priority than P3-1..P3-5 because the consumer demand is narrower (classic `jpeglib.h` callers that override `comp_info[i].h_samp_factor` / `v_samp_factor` to non-power-of-two values, plus embedded-display callers using RGB565). Still a real parity gap if "anything `cjpeg` / `djpeg` accepts must round-trip through us" is the goal.
+- **3x2 decode** — `cjpeg -sample 3x2,1x1,1x1` produces a JPEG; Rust decode pixel-identical to `djpeg`.
+- **3x2 encode** — Rust encodes at `(3,2)/(1,1)/(1,1)`; `djpeg` decode of Rust's output is within `max_diff ≤ 8` of the `cjpeg`+`djpeg` reference pipeline (lossy-encode quantization tolerance).
+- **3x1 decode** — `cjpeg -sample 3x1,1x1,1x1` produces a JPEG; Rust decode pixel-identical to `djpeg`.
+- **RGB565 merged-upsample** — Rust `merged_upsample=true + RGB565` for S420/S422 byte-identical to `djpeg -nosmooth RGB → 5-6-5 truncate` chain.
 
-**Acceptance (minimum, not a full sweep):**
-- One fixture per: `3x2` decode, `3x2` encode, `3x1` decode, RGB565 merged-upsample (encode → decode through merged path).
-- Cross-validate against upstream `cjpeg -sample 3x2,1x1,1x1` and `djpeg -rgb565`.
-- If gaps remain after that minimum is in, document them in `docs/FEATURE_PARITY.md` rather than silently passing.
+**Shim fix landed alongside the RGB565 fixture (2026-05-08).** The merged-upsample gate at `src/decode/pipeline.rs::Decoder::decode` previously bound `out_format == PixelFormat::Rgb`, so `set_merged_upsample(true) + Rgb565` silently fell through to the slow path. Fix: lift the gate to also accept `Rgb565` and route the merged kernel's RGB output through a 5-6-5 truncation pass (matches upstream's `jdmrgext-*-565` semantics for the no-dither case). The dedicated SIMD `_565` kernels remain a Phase 4 perf task — the current path keeps the SIMD merged conversion to RGB and packs to RGB565 in scalar; pixel-correctness is unaffected.
+
+**`cjpeg -sample 3x2,1x1,1x1` baseline.** The non-standard sampling factor matrix at the C cross-check now covers (3,2)/(1,1)/(1,1) and (3,1)/(1,1)/(1,1) — the two configurations the upstream documentation explicitly calls out as "non-standard" while still being valid per ITU-T T.81 Annex B (max sampling factor ≤ 4, sum of products ≤ 10).
+
+**Closure delta:**
+- `src/decode/pipeline.rs::Decoder::decode` — widen the merged-upsample gate from `out_format == PixelFormat::Rgb` to `Rgb || Rgb565`; pack RGB → RGB565 LE after the merged kernel runs.
+- `tests/cross_check_p3_6_nonstandard_rgb565.rs` — new file with 4 fixtures matching the acceptance bar.
+- `docs/FEATURE_PARITY.md` — update the "Merged upsampling" entry to reflect RGB + RGB565 wiring and call out the deferred SIMD `_565` kernels.
+
+**Acceptance (historical):**
+- ~~One fixture per: `3x2` decode, `3x2` encode, `3x1` decode, RGB565 merged-upsample (encode → decode through merged path).~~ **Done** — see test file above.
+- ~~Cross-validate against upstream `cjpeg -sample 3x2,1x1,1x1` and `djpeg -rgb565`.~~ **Done** — `cjpeg -sample` for the 3x cases; `djpeg -nosmooth` for the merged-RGB565 chain (djpeg's `-rgb565` flag emits 24-bpp BMP, not a comparable raw 16-bpp file, so the chain via RGB → 5-6-5 truncation is the byte-comparable form).
+- ~~If gaps remain after that minimum is in, document them in `docs/FEATURE_PARITY.md`.~~ **Done** — the deferred dedicated `_565` SIMD kernels are recorded there as a Phase 4 perf task.
 
 ---
 
@@ -215,6 +227,6 @@ The closure title reflects the actual delta: stub *semantics* moved from "silent
 3. ~~**P3-2** — Either implement `jpeg12_write_raw_data` / `jpeg12_read_raw_data` against the existing 12-bit encode/decode backend, or downgrade them to feature-gated absence. The "stub returning 0" middle ground must end.~~ **PARTIAL 2026-05-06** — middle ground eliminated: stubs now invoke `cinfo->err->error_exit(cinfo)` with `msg_code = JERR_NOTIMPL`, so callers either longjmp out cleanly or hit a default abort. Full 12-bit raw-data backend deferred to Phase 4 (gated on downstream demand).
 4. ~~**P3-5** — Classic `jpeglib.h` lifecycle / custom-I/O / suspension C harness (≥ 8 tests).~~ **CLOSED 2026-05-08** — all 8 patterns active in `crates/libjpeg-turbo-rs-capi/tests/capi_classic_lifecycle.rs` (custom src/dst mgr, source suspension, destination-suspension `JERR_CANT_SUSPEND` contract, abort+reuse for both decompress/compress, buffered-image multi-pass, setjmp/longjmp). Pattern #4 surfaced + fixed a real shim defect: `push_bytes_through_dest_mgr` previously ignored `empty_output_buffer`'s `FALSE` return and called `term_destination` anyway, silently dropping the post-suspension bytes. Architectural reality is that the deferred-encode shim cannot honor upstream's per-MCU streaming-suspension contract at `jpeg_write_scanlines` (no encoding happens there), so the closure invokes `cinfo->err->error_exit` with `JERR_CANT_SUSPEND` (upstream code 25, "Suspension not allowed here") rather than inventing a non-upstream resume contract; a `setjmp`/`longjmp` consumer recovers cleanly. The earlier P3-5 pattern #8 fix (2026-05-07) wired `jpeg_read_header` to invoke `error_exit` on EOI-terminated malformed input.
 5. ~~**P3-4** — Lift the 4-pixel chroma transform writer gate; close the P2-12 follow-up.~~ **CLOSED 2026-05-07** — gate at `transform_jpeg_with_options::progressive_safe` widened from `max_{h,v} ≤ 2` to `max_{h,v} ∈ {1,2,4}` (the eight standard TJSAMP factors verified by `c_tjtrantest_full`); `tests/c_tjtrantest.rs` skip removed; regression pinned in `tests/regression_progressive_4pixel_chroma_transform.rs` (256 cases). Full matrix runs 12,230 cases without divergence. The 2026-05-07 "1-LSB drift" hypothesis turned out to be an artefact of the encoder-side clamp that P2-11 had already removed; the transform writer inherits the corrected chroma layout via `read_coefficients`. Non-standard 3x sampling stays gated to baseline pending P3-6.
-6. **P3-6** — Non-standard sampling / RGB565 merged-upsample minimum fixture set. P2 priority; do only if a downstream consumer requests it or after 1–5 are clean.
+6. ~~**P3-6** — Non-standard sampling / RGB565 merged-upsample minimum fixture set.~~ **CLOSED 2026-05-08** — 4 fixtures (3x2 decode, 3x2 encode, 3x1 decode, RGB565 merged-upsample) all green in `tests/cross_check_p3_6_nonstandard_rgb565.rs`. Shim fix: merged-upsample gate widened from `Rgb` to `Rgb || Rgb565` with a 5-6-5 truncation pass after the merged kernel; dedicated `_565` SIMD kernels deferred as a Phase 4 perf task.
 
 The order is intentional: P3-1 is the cheapest blast-radius reduction (one test file expansion catches a whole class of encode-side ABI drift); P3-3 is the most valuable gate-removal (19 symbols disappear from "trust me" status); P3-2 fixes a specific stub; P3-5 is structural but expensive; P3-4 / P3-6 are correctness gaps with narrower consumer impact.

--- a/src/decode/pipeline.rs
+++ b/src/decode/pipeline.rs
@@ -3739,9 +3739,18 @@ impl<'a> Decoder<'a> {
                 // Merged upsample path: combine upsample + color convert in one pass
                 // for H2V1 (4:2:2) and H2V2 (4:2:0), avoiding intermediate chroma buffers.
                 // Only available when both chroma components have the same sampling factors.
+                // RGB565 routes through this merged branch only when
+                // dithering is OFF — upstream has a separate `*_565D`
+                // merged path for ordered-dither RGB565, which the shim
+                // doesn't yet implement; falling through to the slow
+                // path preserves the pre-fix behavior for that combo
+                // (ordered dither honored via the non-merged dithered
+                // RGB565 writer). Dither + merged is tracked as a
+                // Phase 4 perf follow-up.
+                let merged_rgb565_ok: bool = out_format == PixelFormat::Rgb565 && !self.dither_565;
                 if self.merged_upsample
                     && uniform_chroma
-                    && (out_format == PixelFormat::Rgb || out_format == PixelFormat::Rgb565)
+                    && (out_format == PixelFormat::Rgb || merged_rgb565_ok)
                     && h_factor == 2
                     && (v_factor == 1 || v_factor == 2)
                 {
@@ -3749,11 +3758,10 @@ impl<'a> Decoder<'a> {
                     // routes through an intermediate RGB buffer + 5-6-5
                     // truncation; this preserves the merged-upsample SIMD
                     // hot path and matches upstream's `_565` jdmerge.c
-                    // semantics (truncation, no dither — dither lives in
-                    // the non-merged dithered path). P3-6 acceptance asks
-                    // for a minimum fixture, not a full sweep, so the
-                    // dedicated `_565` SIMD kernels (jdmrgext-*-565) are
-                    // deferred to a Phase 4 perf task.
+                    // semantics (truncation only, no dither). The
+                    // dedicated `_565` and `_565D` SIMD kernels
+                    // (jdmrgext-*-565*) are deferred to a Phase 4 perf
+                    // task.
                     let merged_bpp: usize = 3;
                     let merged_size: usize = out_width * out_height * merged_bpp;
                     let mut merged_rgb: Vec<u8> = vec![0u8; merged_size];

--- a/src/decode/pipeline.rs
+++ b/src/decode/pipeline.rs
@@ -3741,12 +3741,22 @@ impl<'a> Decoder<'a> {
                 // Only available when both chroma components have the same sampling factors.
                 if self.merged_upsample
                     && uniform_chroma
-                    && out_format == PixelFormat::Rgb
+                    && (out_format == PixelFormat::Rgb || out_format == PixelFormat::Rgb565)
                     && h_factor == 2
                     && (v_factor == 1 || v_factor == 2)
                 {
-                    let data_size: usize = out_width * out_height * bpp;
-                    let mut data: Vec<u8> = vec![0u8; data_size];
+                    // The merged kernels produce RGB at bpp=3. RGB565 output
+                    // routes through an intermediate RGB buffer + 5-6-5
+                    // truncation; this preserves the merged-upsample SIMD
+                    // hot path and matches upstream's `_565` jdmerge.c
+                    // semantics (truncation, no dither — dither lives in
+                    // the non-merged dithered path). P3-6 acceptance asks
+                    // for a minimum fixture, not a full sweep, so the
+                    // dedicated `_565` SIMD kernels (jdmrgext-*-565) are
+                    // deferred to a Phase 4 perf task.
+                    let merged_bpp: usize = 3;
+                    let merged_size: usize = out_width * out_height * merged_bpp;
+                    let mut merged_rgb: Vec<u8> = vec![0u8; merged_size];
 
                     if v_factor == 1 {
                         // H2V1 (4:2:2): one chroma row per Y row
@@ -3755,7 +3765,7 @@ impl<'a> Decoder<'a> {
                                 &y_plane[y * y_width + comp_x_offsets[0]..],
                                 &component_planes[1][y * cb_w + comp_x_offsets[1]..],
                                 &component_planes[2][y * cb_w + comp_x_offsets[2]..],
-                                &mut data[y * out_width * bpp..],
+                                &mut merged_rgb[y * out_width * merged_bpp..],
                                 out_width,
                             );
                         }
@@ -3766,10 +3776,9 @@ impl<'a> Decoder<'a> {
                             let y0: usize = pair * 2;
                             let y1: usize = pair * 2 + 1;
                             let chroma_row: usize = pair;
-                            let out0_start: usize = y0 * out_width * bpp;
-                            let out1_start: usize = y1 * out_width * bpp;
-                            // Split data into two non-overlapping mutable slices
-                            let (top, bottom) = data.split_at_mut(out1_start);
+                            let out0_start: usize = y0 * out_width * merged_bpp;
+                            let out1_start: usize = y1 * out_width * merged_bpp;
+                            let (top, bottom) = merged_rgb.split_at_mut(out1_start);
                             Self::merged_h2v2(
                                 &y_plane[y0 * y_width + comp_x_offsets[0]..],
                                 &y_plane[y1 * y_width + comp_x_offsets[0]..],
@@ -3780,7 +3789,6 @@ impl<'a> Decoder<'a> {
                                 out_width,
                             );
                         }
-                        // Handle odd height: last row uses H2V1 with last chroma row
                         if out_height & 1 != 0 {
                             let last_y: usize = out_height - 1;
                             let chroma_row: usize = last_y / 2;
@@ -3788,11 +3796,29 @@ impl<'a> Decoder<'a> {
                                 &y_plane[last_y * y_width + comp_x_offsets[0]..],
                                 &component_planes[1][chroma_row * cb_w + comp_x_offsets[1]..],
                                 &component_planes[2][chroma_row * cb_w + comp_x_offsets[2]..],
-                                &mut data[last_y * out_width * bpp..],
+                                &mut merged_rgb[last_y * out_width * merged_bpp..],
                                 out_width,
                             );
                         }
                     }
+
+                    let data: Vec<u8> = if out_format == PixelFormat::Rgb {
+                        merged_rgb
+                    } else {
+                        // RGB565 little-endian: word = (R5 << 11) | (G6 << 5) | B5,
+                        // with 5-6-5 truncation matching upstream.
+                        let mut packed: Vec<u8> = vec![0u8; out_width * out_height * bpp];
+                        for i in 0..(out_width * out_height) {
+                            let r: u16 = merged_rgb[i * 3] as u16;
+                            let g: u16 = merged_rgb[i * 3 + 1] as u16;
+                            let b: u16 = merged_rgb[i * 3 + 2] as u16;
+                            let word: u16 = ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3);
+                            let bytes = word.to_le_bytes();
+                            packed[i * 2] = bytes[0];
+                            packed[i * 2 + 1] = bytes[1];
+                        }
+                        packed
+                    };
 
                     return Ok(Image {
                         width: out_width,

--- a/tests/cross_check_p3_6_nonstandard_rgb565.rs
+++ b/tests/cross_check_p3_6_nonstandard_rgb565.rs
@@ -284,5 +284,34 @@ fn p3_6_rgb565_merged_decode_matches_djpeg_rgb_chain() {
             "{}: Rust merged+RGB565 != pack(djpeg -nosmooth RGB) — pixel divergence vs C",
             name,
         );
+
+        // Regression guard: enabling dither_565 alongside merged_upsample
+        // must NOT take the truncation-only merged branch. The shim
+        // doesn't ship a `*_565D` merged path yet; the gate must fall
+        // through to the slow dithered path so the dither setting is
+        // honored. Caught originally by codex review on the P3-6 commit.
+        let mut dec_dither =
+            libjpeg_turbo_rs::Decoder::new(&jpeg).expect("Decoder::new for dither path");
+        dec_dither.set_merged_upsample(true);
+        dec_dither.set_dither_565(true);
+        dec_dither.set_output_format(PixelFormat::Rgb565);
+        let dithered = dec_dither
+            .decode_image()
+            .expect("merged + dither_565 + RGB565 decode");
+        assert_eq!(
+            dithered.data.len(),
+            TEST_W * TEST_H * 2,
+            "{}: dither len",
+            name
+        );
+        // The dithered output must differ from the plain-truncation
+        // output for at least some pixels of a non-trivial gradient.
+        // (If they match, the dither pass was silently skipped.)
+        assert_ne!(
+            dithered.data, rust_565.data,
+            "{}: dither_565 + merged produced identical bytes to plain merged — \
+             dither setting was silently dropped (regression of P3-6 codex review)",
+            name,
+        );
     }
 }

--- a/tests/cross_check_p3_6_nonstandard_rgb565.rs
+++ b/tests/cross_check_p3_6_nonstandard_rgb565.rs
@@ -1,0 +1,288 @@
+//! P3-6 minimum-coverage fixtures: non-standard sampling (3x2, 3x1) and
+//! RGB565 merged-upsample, cross-validated against stock C tools.
+//!
+//! Acceptance bar from `docs/last_mile/phase3.md` P3-6:
+//!   - One fixture per: 3x2 decode, 3x2 encode, 3x1 decode, RGB565 merged-upsample.
+//!   - Cross-validate against upstream `cjpeg -sample 3x2,1x1,1x1` and `djpeg -rgb565`.
+//!   - Gaps remaining after this minimum land in `docs/FEATURE_PARITY.md`.
+//!
+//! Skip rules: `cjpeg` / `djpeg` not on PATH is a developer-machine skip;
+//! in CI (`CI=true` / `GITHUB_ACTIONS=true`) the same conditions hard-fail
+//! so the lifted P3-6 gate cannot disappear into a green skip.
+
+mod helpers;
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use libjpeg_turbo_rs::{decompress_to, Encoder, PixelFormat, ScanlineDecoder};
+
+const TEST_W: usize = 48;
+const TEST_H: usize = 48;
+const QUALITY: u8 = 90;
+
+fn require_tools_or_skip() -> Option<(PathBuf, PathBuf)> {
+    let cjpeg = match helpers::cjpeg_path() {
+        Some(p) => p,
+        None => {
+            if helpers::is_ci() {
+                panic!("P3-6 cross-check requires cjpeg in CI");
+            }
+            eprintln!("SKIP: cjpeg not found in /opt/homebrew/bin or /usr/local/bin");
+            return None;
+        }
+    };
+    let djpeg = match helpers::djpeg_path() {
+        Some(p) => p,
+        None => {
+            if helpers::is_ci() {
+                panic!("P3-6 cross-check requires djpeg in CI");
+            }
+            eprintln!("SKIP: djpeg not found in /opt/homebrew/bin or /usr/local/bin");
+            return None;
+        }
+    };
+    Some((cjpeg, djpeg))
+}
+
+fn make_gradient(w: usize, h: usize) -> Vec<u8> {
+    helpers::generate_gradient(w, h)
+}
+
+fn write_ppm_tmp(label: &str, w: usize, h: usize, pixels: &[u8]) -> helpers::TempFile {
+    let f = helpers::TempFile::new(&format!("{}.ppm", label));
+    helpers::write_ppm_file(f.path(), w, h, pixels);
+    f
+}
+
+fn cjpeg_encode_with_sample(cjpeg: &Path, sample: &str, ppm_path: &Path) -> Vec<u8> {
+    let out_file: helpers::TempFile = helpers::TempFile::new("p3_6_cjpeg_out.jpg");
+    helpers::run_c_cjpeg(
+        cjpeg,
+        &["-sample", sample, "-quality", &QUALITY.to_string()],
+        ppm_path,
+        out_file.path(),
+    );
+    std::fs::read(out_file.path()).expect("read cjpeg output")
+}
+
+/// 5-6-5 truncation (no dither), matching upstream and the merged path.
+fn pack_rgb_to_rgb565_le(rgb: &[u8]) -> Vec<u8> {
+    assert_eq!(rgb.len() % 3, 0);
+    let mut out: Vec<u8> = vec![0u8; (rgb.len() / 3) * 2];
+    for i in 0..(rgb.len() / 3) {
+        let r: u16 = rgb[i * 3] as u16;
+        let g: u16 = rgb[i * 3 + 1] as u16;
+        let b: u16 = rgb[i * 3 + 2] as u16;
+        let word: u16 = ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3);
+        let bytes = word.to_le_bytes();
+        out[i * 2] = bytes[0];
+        out[i * 2 + 1] = bytes[1];
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Fixture #1: 3x2 sampling decode — Rust must match djpeg pixel-for-pixel.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn p3_6_3x2_sampling_decode_matches_djpeg() {
+    let (cjpeg, djpeg) = match require_tools_or_skip() {
+        Some(t) => t,
+        None => return,
+    };
+
+    let pixels: Vec<u8> = make_gradient(TEST_W, TEST_H);
+    let ppm: helpers::TempFile = write_ppm_tmp("p3_6_3x2_decode", TEST_W, TEST_H, &pixels);
+
+    // C cjpeg encodes a 3x2-sampled JPEG.
+    let jpeg: Vec<u8> = cjpeg_encode_with_sample(&cjpeg, "3x2,1x1,1x1", ppm.path());
+
+    // Rust decode.
+    let rust_img = decompress_to(&jpeg, PixelFormat::Rgb).expect("Rust decode 3x2");
+    assert_eq!(rust_img.width, TEST_W);
+    assert_eq!(rust_img.height, TEST_H);
+
+    // C djpeg decode.
+    let (cw, ch, c_rgb) = helpers::decode_with_c_djpeg(&djpeg, &jpeg, "p3_6_3x2_decode");
+    assert_eq!(cw, TEST_W);
+    assert_eq!(ch, TEST_H);
+
+    helpers::assert_pixels_identical(&rust_img.data, &c_rgb, TEST_W, TEST_H, 3, "p3_6_3x2_decode");
+}
+
+// ---------------------------------------------------------------------------
+// Fixture #2: 3x2 sampling encode — Rust output must decode (via djpeg)
+// to pixels identical to the cjpeg-baseline + djpeg pipeline. JPEG-encode
+// is lossy so byte-level parity isn't expected, but the SOF1/sampling
+// factors round-trip and the decoded pixels must match within JPEG-encoder
+// quantization bounds (PSNR ≥ 35 dB, no max-diff > 8 for q=90).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn p3_6_3x2_sampling_encode_round_trips() {
+    let (cjpeg, djpeg) = match require_tools_or_skip() {
+        Some(t) => t,
+        None => return,
+    };
+
+    let pixels: Vec<u8> = make_gradient(TEST_W, TEST_H);
+    let ppm: helpers::TempFile = write_ppm_tmp("p3_6_3x2_encode", TEST_W, TEST_H, &pixels);
+
+    // Rust-encoded with custom 3x2 sampling.
+    let rust_jpeg: Vec<u8> = Encoder::new(&pixels, TEST_W, TEST_H, PixelFormat::Rgb)
+        .quality(QUALITY)
+        .sampling_factors(vec![(3, 2), (1, 1), (1, 1)])
+        .encode()
+        .expect("Rust encode 3x2");
+
+    // Decode the Rust output via djpeg — establishes that the SOF1/scan
+    // structure round-trips through stock C tooling.
+    let (rw, rh, rust_via_c) =
+        helpers::decode_with_c_djpeg(&djpeg, &rust_jpeg, "p3_6_3x2_rust_via_c");
+    assert_eq!(rw, TEST_W);
+    assert_eq!(rh, TEST_H);
+
+    // Reference pipeline: cjpeg -sample 3x2,1x1,1x1 + djpeg.
+    let c_jpeg: Vec<u8> = cjpeg_encode_with_sample(&cjpeg, "3x2,1x1,1x1", ppm.path());
+    let (cw, ch, c_pixels) = helpers::decode_with_c_djpeg(&djpeg, &c_jpeg, "p3_6_3x2_c_baseline");
+    assert_eq!(cw, TEST_W);
+    assert_eq!(ch, TEST_H);
+
+    // Both decodes operate on the same source pixels at the same quality;
+    // the Rust encoder + djpeg pipeline should land within the C
+    // baseline's quantization neighborhood. Use the same tolerance the
+    // existing standard-sampling cross-checks use against the source.
+    let max_diff: u8 = pixel_max_diff(&rust_via_c, &c_pixels);
+    assert!(
+        max_diff <= 8,
+        "p3_6_3x2_encode: max pixel diff vs cjpeg baseline = {} (tolerance ≤ 8)",
+        max_diff,
+    );
+}
+
+fn pixel_max_diff(a: &[u8], b: &[u8]) -> u8 {
+    assert_eq!(a.len(), b.len());
+    a.iter()
+        .zip(b.iter())
+        .map(|(&x, &y)| (x as i16 - y as i16).unsigned_abs() as u8)
+        .max()
+        .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------------
+// Fixture #3: 3x1 sampling decode — Rust must match djpeg pixel-for-pixel.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn p3_6_3x1_sampling_decode_matches_djpeg() {
+    let (cjpeg, djpeg) = match require_tools_or_skip() {
+        Some(t) => t,
+        None => return,
+    };
+
+    let pixels: Vec<u8> = make_gradient(TEST_W, TEST_H);
+    let ppm: helpers::TempFile = write_ppm_tmp("p3_6_3x1_decode", TEST_W, TEST_H, &pixels);
+
+    let jpeg: Vec<u8> = cjpeg_encode_with_sample(&cjpeg, "3x1,1x1,1x1", ppm.path());
+
+    let rust_img = decompress_to(&jpeg, PixelFormat::Rgb).expect("Rust decode 3x1");
+    assert_eq!(rust_img.width, TEST_W);
+    assert_eq!(rust_img.height, TEST_H);
+
+    let (cw, ch, c_rgb) = helpers::decode_with_c_djpeg(&djpeg, &jpeg, "p3_6_3x1_decode");
+    assert_eq!(cw, TEST_W);
+    assert_eq!(ch, TEST_H);
+
+    helpers::assert_pixels_identical(&rust_img.data, &c_rgb, TEST_W, TEST_H, 3, "p3_6_3x1_decode");
+}
+
+// ---------------------------------------------------------------------------
+// Fixture #4: RGB565 merged-upsample — Rust output (merged path enabled,
+// RGB565 target) must match djpeg -rgb565 byte-for-byte for an S420 input.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn p3_6_rgb565_merged_decode_matches_djpeg_rgb_chain() {
+    let (_cjpeg, djpeg) = match require_tools_or_skip() {
+        Some(t) => t,
+        None => return,
+    };
+
+    // Validate Rust's `merged_upsample + Rgb565` path against the
+    // `djpeg-RGB → 5-6-5 truncate` chain. djpeg's `-rgb565` flag emits a
+    // 24-bpp BMP rather than a 16-bpp file — the in-library RGB565 step
+    // is internal-only — so direct byte-comparison against `djpeg
+    // -rgb565` output isn't possible. Instead, rely on the fact that
+    // `cross_check_rgb565_merged.rs` already pins
+    // (Rust-merged-RGB == djpeg-RGB), then verify that Rust's
+    // `merged + RGB565` matches the same pipeline truncated to 5-6-5.
+    //
+    // S420 + S422 cover both merged kernels (H2V2 and H2V1).
+    let cases: &[(libjpeg_turbo_rs::Subsampling, &str)] = &[
+        (libjpeg_turbo_rs::Subsampling::S420, "S420"),
+        (libjpeg_turbo_rs::Subsampling::S422, "S422"),
+    ];
+
+    for &(subsamp, name) in cases {
+        let pixels: Vec<u8> = make_gradient(TEST_W, TEST_H);
+        let jpeg: Vec<u8> =
+            libjpeg_turbo_rs::compress(&pixels, TEST_W, TEST_H, PixelFormat::Rgb, QUALITY, subsamp)
+                .expect("compress fixture");
+
+        // Rust: merged + RGB565.
+        let mut dec = ScanlineDecoder::new(&jpeg).expect("ScanlineDecoder::new");
+        dec.set_merged_upsample(true);
+        dec.set_output_format(PixelFormat::Rgb565);
+        let rust_565 = dec.finish().expect("merged+RGB565 decode");
+        assert_eq!(rust_565.width, TEST_W, "{}: width", name);
+        assert_eq!(rust_565.height, TEST_H, "{}: height", name);
+        assert_eq!(rust_565.data.len(), TEST_W * TEST_H * 2, "{}: len", name);
+
+        // Rust: merged + RGB (same path before 5-6-5 packing). Used as
+        // the in-library reference: the merged kernel must produce
+        // identical RGB whether the final output is RGB or RGB565.
+        let mut dec_rgb = ScanlineDecoder::new(&jpeg).expect("ScanlineDecoder::new");
+        dec_rgb.set_merged_upsample(true);
+        dec_rgb.set_output_format(PixelFormat::Rgb);
+        let rust_rgb = dec_rgb.finish().expect("merged+RGB decode");
+        let expected_565: Vec<u8> = pack_rgb_to_rgb565_le(&rust_rgb.data);
+        assert_eq!(
+            rust_565.data, expected_565,
+            "{}: merged+RGB565 != pack(merged+RGB) — RGB565 wiring is wrong",
+            name,
+        );
+
+        // C djpeg RGB → 5-6-5 chain. The merged path uses box-filter
+        // upsampling (matching djpeg's `-nosmooth` flag), not the
+        // default fancy-upsample, so the C reference must match.
+        let jpeg_file = helpers::TempFile::new(&format!("p3_6_rgb565_{}.jpg", name));
+        let ppm_file = helpers::TempFile::new(&format!("p3_6_rgb565_{}.ppm", name));
+        jpeg_file.write_bytes(&jpeg);
+        let out = Command::new(&djpeg)
+            .arg("-nosmooth")
+            .arg("-ppm")
+            .arg("-outfile")
+            .arg(ppm_file.path())
+            .arg(jpeg_file.path())
+            .output()
+            .expect("run djpeg -nosmooth");
+        assert!(
+            out.status.success(),
+            "{}: djpeg -nosmooth failed: {}",
+            name,
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let ppm_data = std::fs::read(ppm_file.path()).expect("read PPM");
+        let (cw, ch, c_rgb) = helpers::parse_ppm(&ppm_data).expect("parse PPM");
+        assert_eq!(cw, TEST_W, "{}: width", name);
+        assert_eq!(ch, TEST_H, "{}: height", name);
+        let c_chain_565: Vec<u8> = pack_rgb_to_rgb565_le(&c_rgb);
+        assert_eq!(
+            rust_565.data, c_chain_565,
+            "{}: Rust merged+RGB565 != pack(djpeg -nosmooth RGB) — pixel divergence vs C",
+            name,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes the last Phase 3 OPEN item. P3-6's acceptance bar (per `docs/last_mile/phase3.md`) called for four minimum-coverage fixtures (3x2 decode, 3x2 encode, 3x1 decode, RGB565 merged-upsample) cross-validated against `cjpeg -sample 3x2,1x1,1x1` and `djpeg -rgb565`. Three already passed against the existing decoder/encoder paths; the fourth surfaced a missing shim wiring.

## Shim fix

The merged-upsample gate at `src/decode/pipeline.rs::Decoder::decode` previously bound `out_format == PixelFormat::Rgb`, so `set_merged_upsample(true) + Rgb565` silently fell through to the slow path. Lift the gate to also accept `Rgb565` and route the merged kernel's RGB output through a 5-6-5 little-endian truncation pass. Matches upstream's `jdmrgext-*-565` semantics for the no-dither case; dedicated `_565` SIMD kernels remain a Phase 4 perf task.

**Codex round-1 caught a regression**: the widened gate now intercepted `merged_upsample + dither_565 + Rgb565` requests but the new packing pass did plain truncation, dropping the dither setting silently. Before the gate widened, those requests fell through to the slow path which honored `dither_565`. Fix: `merged_rgb565_ok = (out_format == Rgb565 && !self.dither_565)` so dithered RGB565 keeps falling through to the dithered slow path. The dedicated `_565D` merged kernel (upstream's variant for that combo) remains a Phase 4 follow-up.

A/B probe verifies the dither guard is load-bearing: dropping `&& !self.dither_565` trips the regression branch with "dither_565 + merged produced identical bytes to plain merged — dither setting was silently dropped".

## Test surface

`tests/cross_check_p3_6_nonstandard_rgb565.rs` (4 fixtures):

- `p3_6_3x2_sampling_decode_matches_djpeg` — `cjpeg -sample 3x2,1x1,1x1` → Rust decode pixel-identical to `djpeg`.
- `p3_6_3x2_sampling_encode_round_trips` — Rust encodes at `(3,2)/(1,1)/(1,1)`; `djpeg` decode of Rust output is within `max_diff ≤ 8` of the `cjpeg`+`djpeg` reference (lossy-encode tolerance).
- `p3_6_3x1_sampling_decode_matches_djpeg` — `cjpeg -sample 3x1,1x1,1x1` → Rust decode pixel-identical to `djpeg`.
- `p3_6_rgb565_merged_decode_matches_djpeg_rgb_chain` — for S420 and S422, Rust `merged + RGB565` is byte-identical to `pack5_6_5(merged + RGB)` and `pack5_6_5(djpeg -nosmooth RGB)`. Includes the dither-guard regression branch from codex round-1.

`djpeg -rgb565` itself emits a 24-bpp BMP (the in-library RGB565 step is internal-only), so the comparable form is the `djpeg -nosmooth RGB → 5-6-5 truncate` chain.

## Verification

- `cargo test --release --test cross_check_p3_6_nonstandard_rgb565` → `4 passed, 0 failed, 0 ignored`.
- `cargo test --workspace --release --no-fail-fast` — 2149 product tests pass (4 new), 1 ignored, 1 pre-existing imagemagick failure unaffected.
- `cargo fmt --all -- --check`, `cargo clippy --lib --release -- -D warnings` clean.
- `codex review --commit <head>` (round 2): "no blocking issues were found".

## Closure delta

- `src/decode/pipeline.rs::Decoder::decode` — widen the merged-upsample gate from `Rgb` to `Rgb || (Rgb565 && !dither_565)`; pack RGB → RGB565 LE after the merged kernel runs.
- `tests/cross_check_p3_6_nonstandard_rgb565.rs` — new file with 4 fixtures + dither-guard regression branch.
- `docs/last_mile/phase3.md` — flip P3-6 to **CLOSED 2026-05-08**; refresh status table, suggested-order entry, file header. Phase 3 has zero fully-OPEN items left (P3-1 / P3-2 retain narrow PARTIAL scope).
- `docs/LAST_MILE.md` — drop P3-6 from OPEN-Items table; add a "PARTIAL closures" summary; refresh Phase Map row, suggested-order #6, live-gate table (new row for the P3-6 fixtures, test count 2145 → 2149).
- `docs/FEATURE_PARITY.md` "Merged upsampling" entry now records the RGB+RGB565 wiring and the deferred SIMD `_565` / `_565D` kernel task.

## Test plan

- [x] `cargo test --release --test cross_check_p3_6_nonstandard_rgb565` — 4/4 green locally.
- [x] `cargo test --workspace --release --no-fail-fast` — no new regressions.
- [x] `cargo fmt --check`, `cargo clippy --lib -- -D warnings` clean.
- [x] `codex review --commit <head>` clean (after one round of P2 fix).
- [x] A/B probe verifies the dither guard is load-bearing.
- [ ] CI matrix green on Linux x86_64 / macOS / Windows.

Refs: P3-6 closure (final Phase 3 item).