### PR TITLE
test(capi): fix imagemagick smoke fixture — luma-shared checker

### DIFF
--- a/crates/libjpeg-turbo-rs-capi/tests/capi_imagemagick_compat.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/capi_imagemagick_compat.rs
@@ -83,6 +83,23 @@ fn imagemagick_binary() -> Option<(&'static str, PathBuf)> {
 /// Synthesise a deterministic PPM that covers smooth gradients + high
 /// frequency checker. Big enough (160x120) that quality-75 DCT loss is
 /// measurable but still well above the 30 dB PSNR floor.
+///
+/// **Luma-shared checker.** The previous fixture put an 8-pixel checker
+/// directly on the B channel (values 32 / 224, ±96 amplitude). That
+/// signal sits at the chroma Nyquist limit, so 4:2:0 subsampling — the
+/// ImageMagick default at quality=75 — could not recover it: stock
+/// `cjpeg -quality 75` + `djpeg` themselves got PSNR=22.47 dB on that
+/// fixture, below the 30 dB threshold this test asserts. The fixture
+/// was inherently incompatible with the threshold.
+///
+/// Fix: route the high-frequency modulation through luma instead of
+/// chroma. Adding the same `±32` offset to all three channels shifts
+/// `Y = 0.299·R + 0.587·G + 0.114·B` by `±32` while leaving Cb / Cr
+/// unchanged (the BT.601 chroma matrix coefficients sum to zero across
+/// `R,G,B`). Luma keeps its full bandwidth at 4:2:0, so the 8-pixel
+/// checker is a real mid-frequency Huffman / DCT stressor on the Y
+/// plane without aliasing through chroma. Stock cjpeg + djpeg now
+/// reaches ~41.7 dB on this fixture; cdylib parity targets the same.
 fn write_fixture_ppm(path: &Path) {
     const W: usize = 160;
     const H: usize = 120;
@@ -92,16 +109,21 @@ fn write_fixture_ppm(path: &Path) {
         for x in 0..W {
             // Smooth horizontal/vertical gradients on R/G so chroma
             // subsampling has real signal to lose and recover.
-            let r: u8 = ((x * 255) / (W - 1)) as u8;
-            let g: u8 = ((y * 255) / (H - 1)) as u8;
-            // Checker on B forces the encoder to keep some mid-frequency
-            // energy — if our Huffman tables are wrong we'll see blocks
-            // here and PSNR will crater.
-            let b: u8 = if ((x / 8) + (y / 8)) % 2 == 0 {
-                32
+            let r_grad: i16 = ((x * 255) / (W - 1)) as i16;
+            let g_grad: i16 = ((y * 255) / (H - 1)) as i16;
+            // Luma-shared checker: ±32 offset applied uniformly to
+            // R/G/B → ±32 modulation on Y, zero on Cb/Cr (the BT.601
+            // chroma coefficients sum to zero). Forces the encoder to
+            // keep mid-frequency luma energy without aliasing the
+            // 4:2:0 chroma planes.
+            let checker: i16 = if ((x / 8) + (y / 8)) % 2 == 0 {
+                -32
             } else {
-                224
+                32
             };
+            let r: u8 = (r_grad + checker).clamp(0, 255) as u8;
+            let g: u8 = (g_grad + checker).clamp(0, 255) as u8;
+            let b: u8 = (128 + checker).clamp(0, 255) as u8;
             buf.extend_from_slice(&[r, g, b]);
         }
     }

--- a/docs/LAST_MILE.md
+++ b/docs/LAST_MILE.md
@@ -16,7 +16,7 @@ Project is **replacement-ready** for the Rust-application + stock-tool drop-in s
 
 | Check | Result |
 | --- | --- |
-| `cargo test --workspace --release` | **Passes** product-path — 2149 tests, 0 product failures, 1 ignored (one pre-existing capi `imagemagick_roundtrips_through_our_cdylib` PSNR regression tracked under `docs/fix-arith-contradiction`). |
+| `cargo test --workspace --release` | **Passes** — 2150 tests, 0 failures, 1 ignored (one slow release-only stress test). |
 | `cargo test -p libjpeg-turbo-rs --test cross_product_transform` | **Passes** all 12 cases. P0-1 closed. |
 | `cargo test -p libjpeg-turbo-rs --test regression_progressive_4pixel_chroma_transform` | **Passes** 256 cases byte-exact vs `jpegtran -progressive -copy all <op>`. P3-4 closed. |
 | `cargo test --test cross_check_p3_6_nonstandard_rgb565` | **Passes** 4 fixtures: 3x2 decode (vs `djpeg`), 3x2 encode (vs `cjpeg -sample 3x2,1x1,1x1` + `djpeg`), 3x1 decode, RGB565 merged-upsample (vs `djpeg -nosmooth` + 5-6-5 truncate chain). P3-6 closed. |


### PR DESCRIPTION
## Summary

Closes the last failing test in `cargo test --workspace`. The
`imagemagick_roundtrips_through_our_cdylib` smoke had been failing with
`PSNR=22.621 dB (min=30.000)` since before the start of the Phase 3
closure work; Phase 3 commits noted it as "pre-existing, tracked
separately under `docs/fix-arith-contradiction`". Turns out that
`docs/fix-arith-contradiction` is a git *branch* covering an unrelated
arith-fuzz issue (closed in #264). The imagemagick failure was never
actually tracked — just deferred.

## Root cause: fixture / threshold mismatch, not a codec bug

A/B against stock libjpeg-turbo with no cdylib injection:

| Pipeline | PSNR | MSE |
| --- | --- | --- |
| stock `cjpeg -quality 75` + stock `djpeg` | **22.466 dB** | 368.6 |
| cdylib-injected ImageMagick @ q=75 | 22.621 dB | 355.6 |

Stock libjpeg-turbo itself can't reach 30 dB on this fixture either.
The 8-pixel B-channel checker (values 32 / 224, ±96 amplitude) sits at
the chroma Nyquist limit; ImageMagick's default 4:2:0 chroma
subsampling cannot recover it at quality=75. The threshold was
incompatible with the fixture content from the day the test was
written.

## Fix: luma-shared checker (preserves test intent)

Apply the same `±32` offset to all three R/G/B channels uniformly.
That shifts `Y = 0.299·R + 0.587·G + 0.114·B` by `±32` while leaving
Cb / Cr unchanged — the BT.601 chroma coefficients sum to zero across
R, G, B. Luma keeps its full bandwidth at 4:2:0, so the 8-pixel
checker remains a real mid-frequency Huffman / DCT stressor on the Y
plane without aliasing through chroma. The author's stated intent
("forces the encoder to keep some mid-frequency energy — if our
Huffman tables are wrong we'll see blocks here and PSNR will crater")
is preserved; only the channel routing changes.

## Round-trip results post-fix

| Pipeline | PSNR | MSE |
| --- | --- | --- |
| stock `cjpeg -quality 75` + stock `djpeg` | 41.730 dB | 4.4 |
| cdylib-injected ImageMagick @ q=75 | **41.559 dB** | 4.5 |

Both well above the 30 dB floor, and within 0.2 dB of each other — the
cdylib-injection path tracks stock libjpeg-turbo as designed.

## Verification

- `cargo test --release -p libjpeg-turbo-rs-capi --test capi_imagemagick_compat` → 1 passed.
- `cargo test --workspace --release --no-fail-fast` → 2150 product tests pass, **0 failures**, 1 ignored (the slow release-only stress test, unchanged).
- `cargo fmt --all -- --check`, `cargo clippy --lib --release -- -D warnings` clean.

## Closure delta

- `crates/libjpeg-turbo-rs-capi/tests/capi_imagemagick_compat.rs::write_fixture_ppm` — replace the B-channel-only checker with a luma-shared checker. Long-form comment captures the BT.601 derivation + why the previous fixture was incompatible with the threshold.
- `docs/LAST_MILE.md` live-gate row updated: drop the "pre-existing imagemagick PSNR regression" caveat now that the workspace is fully green.

## Test plan

- [x] `cargo test --release -p libjpeg-turbo-rs-capi --test capi_imagemagick_compat` → 1/1 green locally.
- [x] `cargo test --workspace --release --no-fail-fast` → 2150 / 0-failed locally.
- [x] `cargo fmt --check`, `cargo clippy --lib -- -D warnings` clean.
- [x] A/B verified: stock libjpeg-turbo also clears the 30 dB floor on the new fixture (41.73 dB), proving the threshold is now reachable rather than aspirational.
- [ ] CI matrix green on Linux x86_64 / macOS / Windows.

Refs: workspace-test cleanliness — last failure caveat eliminated.