### PR TITLE
test(capi): P3-1 — close 4 large struct ABI cross-checks (compress + 3 mgrs)

### DIFF
--- a/crates/libjpeg-turbo-rs-capi/tests/abi_offsets.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/abi_offsets.rs
@@ -378,3 +378,427 @@ fn rust_offsets_match_jpeg_marker_struct_at_lib_version_80() {
     let rust_sizeof: usize = std::mem::size_of::<JpegMarkerStructPublic>();
     assert_no_drift("jpeg_marker_struct", &rust_fields, rust_sizeof, &probe);
 }
+
+// ---------------------------------------------------------------------------
+// `struct jpeg_destination_mgr` cross-check (P3-1 deferred work).
+// ---------------------------------------------------------------------------
+//
+// Mirrors `JpegDestinationMgr` in `jpeglib.rs`. C consumers that build a
+// custom destination manager (e.g. an in-memory ring buffer) write
+// `next_output_byte` and `free_in_buffer` at offsets 0 and 8 (LP64), so a
+// layout drift here surfaces as garbled output rather than an obvious
+// crash.
+
+fn rust_offsets_destination_mgr() -> Vec<(&'static str, usize)> {
+    use libjpeg_turbo_rs_capi::jpeglib::JpegDestinationMgr;
+    use std::mem::offset_of;
+
+    vec![
+        (
+            "next_output_byte",
+            offset_of!(JpegDestinationMgr, next_output_byte),
+        ),
+        (
+            "free_in_buffer",
+            offset_of!(JpegDestinationMgr, free_in_buffer),
+        ),
+        (
+            "init_destination",
+            offset_of!(JpegDestinationMgr, init_destination),
+        ),
+        (
+            "empty_output_buffer",
+            offset_of!(JpegDestinationMgr, empty_output_buffer),
+        ),
+        (
+            "term_destination",
+            offset_of!(JpegDestinationMgr, term_destination),
+        ),
+    ]
+}
+
+#[test]
+fn rust_offsets_match_jpeg_destination_mgr_at_lib_version_80() {
+    use libjpeg_turbo_rs_capi::jpeglib::JpegDestinationMgr;
+
+    let rust_fields: Vec<(&'static str, usize)> = rust_offsets_destination_mgr();
+    let names: Vec<&str> = rust_fields.iter().map(|(n, _)| *n).collect();
+    let probe: CcProbeResult = match cc_offsetof_for_struct("jpeg_destination_mgr", &names) {
+        CcProbeOutcome::Ok(r) => r,
+        CcProbeOutcome::Skip(why) => {
+            eprintln!("SKIP: {why}");
+            return;
+        }
+    };
+    let rust_sizeof: usize = std::mem::size_of::<JpegDestinationMgr>();
+    assert_no_drift("jpeg_destination_mgr", &rust_fields, rust_sizeof, &probe);
+}
+
+// ---------------------------------------------------------------------------
+// `struct jpeg_source_mgr` cross-check (P3-1 deferred work).
+// ---------------------------------------------------------------------------
+//
+// Mirrors `JpegSourceMgr` in `jpeglib.rs`. The classic streaming-decode
+// pattern (`fill_input_buffer` returning `FALSE` for I/O suspension) reads
+// `bytes_in_buffer` and `next_input_byte` at well-known offsets; the
+// `resync_to_restart` callback at offset ~40 is what `jpeg_resync_to_restart`
+// dispatches into. Layout drift here breaks every consumer that ships its
+// own source manager.
+
+fn rust_offsets_source_mgr() -> Vec<(&'static str, usize)> {
+    use libjpeg_turbo_rs_capi::jpeglib::JpegSourceMgr;
+    use std::mem::offset_of;
+
+    vec![
+        (
+            "next_input_byte",
+            offset_of!(JpegSourceMgr, next_input_byte),
+        ),
+        (
+            "bytes_in_buffer",
+            offset_of!(JpegSourceMgr, bytes_in_buffer),
+        ),
+        ("init_source", offset_of!(JpegSourceMgr, init_source)),
+        (
+            "fill_input_buffer",
+            offset_of!(JpegSourceMgr, fill_input_buffer),
+        ),
+        (
+            "skip_input_data",
+            offset_of!(JpegSourceMgr, skip_input_data),
+        ),
+        (
+            "resync_to_restart",
+            offset_of!(JpegSourceMgr, resync_to_restart),
+        ),
+        ("term_source", offset_of!(JpegSourceMgr, term_source)),
+    ]
+}
+
+#[test]
+fn rust_offsets_match_jpeg_source_mgr_at_lib_version_80() {
+    use libjpeg_turbo_rs_capi::jpeglib::JpegSourceMgr;
+
+    let rust_fields: Vec<(&'static str, usize)> = rust_offsets_source_mgr();
+    let names: Vec<&str> = rust_fields.iter().map(|(n, _)| *n).collect();
+    let probe: CcProbeResult = match cc_offsetof_for_struct("jpeg_source_mgr", &names) {
+        CcProbeOutcome::Ok(r) => r,
+        CcProbeOutcome::Skip(why) => {
+            eprintln!("SKIP: {why}");
+            return;
+        }
+    };
+    let rust_sizeof: usize = std::mem::size_of::<JpegSourceMgr>();
+    assert_no_drift("jpeg_source_mgr", &rust_fields, rust_sizeof, &probe);
+}
+
+// ---------------------------------------------------------------------------
+// `struct jpeg_error_mgr` cross-check (P3-1 deferred work).
+// ---------------------------------------------------------------------------
+//
+// Mirrors `JpegErrorMgr` in `jpeglib.rs`. The classic libjpeg consumer
+// pattern is to override `error_exit` (offset 0) with a `setjmp`/`longjmp`
+// handler and inspect `msg_code` (offset 40 LP64) plus `msg_parm` (offset 44)
+// for diagnostics. Layout drift here turns recoverable errors into
+// process-aborting bugs in any consumer that walks these fields by name.
+//
+// `msg_parm` is a `union { int i[8]; char s[80]; }` upstream; the Rust
+// mirror reserves the larger arm (`[u8; 80]`) so `mem::size_of` matches
+// the union's storage.
+
+fn rust_offsets_error_mgr() -> Vec<(&'static str, usize)> {
+    use libjpeg_turbo_rs_capi::jpeglib::JpegErrorMgr;
+    use std::mem::offset_of;
+
+    vec![
+        ("error_exit", offset_of!(JpegErrorMgr, error_exit)),
+        ("emit_message", offset_of!(JpegErrorMgr, emit_message)),
+        ("output_message", offset_of!(JpegErrorMgr, output_message)),
+        ("format_message", offset_of!(JpegErrorMgr, format_message)),
+        ("reset_error_mgr", offset_of!(JpegErrorMgr, reset_error_mgr)),
+        ("msg_code", offset_of!(JpegErrorMgr, msg_code)),
+        ("msg_parm", offset_of!(JpegErrorMgr, msg_parm)),
+        ("trace_level", offset_of!(JpegErrorMgr, trace_level)),
+        ("num_warnings", offset_of!(JpegErrorMgr, num_warnings)),
+        (
+            "jpeg_message_table",
+            offset_of!(JpegErrorMgr, jpeg_message_table),
+        ),
+        (
+            "last_jpeg_message",
+            offset_of!(JpegErrorMgr, last_jpeg_message),
+        ),
+        (
+            "addon_message_table",
+            offset_of!(JpegErrorMgr, addon_message_table),
+        ),
+        (
+            "first_addon_message",
+            offset_of!(JpegErrorMgr, first_addon_message),
+        ),
+        (
+            "last_addon_message",
+            offset_of!(JpegErrorMgr, last_addon_message),
+        ),
+    ]
+}
+
+#[test]
+fn rust_offsets_match_jpeg_error_mgr_at_lib_version_80() {
+    use libjpeg_turbo_rs_capi::jpeglib::JpegErrorMgr;
+
+    let rust_fields: Vec<(&'static str, usize)> = rust_offsets_error_mgr();
+    let names: Vec<&str> = rust_fields.iter().map(|(n, _)| *n).collect();
+    let probe: CcProbeResult = match cc_offsetof_for_struct("jpeg_error_mgr", &names) {
+        CcProbeOutcome::Ok(r) => r,
+        CcProbeOutcome::Skip(why) => {
+            eprintln!("SKIP: {why}");
+            return;
+        }
+    };
+    let rust_sizeof: usize = std::mem::size_of::<JpegErrorMgr>();
+    assert_no_drift("jpeg_error_mgr", &rust_fields, rust_sizeof, &probe);
+}
+
+// ---------------------------------------------------------------------------
+// `struct jpeg_compress_struct` cross-check (P3-1 deferred work).
+// ---------------------------------------------------------------------------
+//
+// Mirrors `JpegCompressPublic` in `jpeglib.rs`. This is the encoder-side
+// counterpart to the `jpeg_decompress_struct` cross-check at the top of
+// this file; cjpeg, GIMP's plugin, and a long tail of distro consumers
+// read fields like `image_width` / `data_precision` / `comp_info` /
+// `optimize_coding` directly through this struct, so any field-order or
+// `JPEG_LIB_VERSION ≥ 70`/`≥ 80` drift surfaces as silently corrupted
+// encode parameters rather than a clean error.
+//
+// Field-name mapping note. The Rust mirror calls the
+// `struct jpeg_c_main_controller *` slot `main_ctrl` (the C-side name
+// `main` collides with Rust's `main` identifier in some scopes); the
+// cross-check maps the upstream `main` field to the Rust `main_ctrl` mirror
+// via the `(c_field_name, rust_offset)` tuple — same pattern the existing
+// `cc_offsetof_for_struct` helper uses, so the harness can keep reading
+// `offsetof(struct jpeg_compress_struct, main)` against the upstream
+// header while comparing to `offset_of!(JpegCompressPublic, main_ctrl)`.
+
+#[allow(non_snake_case)]
+fn rust_offsets_compress() -> Vec<(&'static str, usize)> {
+    use libjpeg_turbo_rs_capi::jpeglib::JpegCompressPublic;
+    use std::mem::offset_of;
+
+    vec![
+        // jpeg_common_fields prefix (offset 0..40 LP64).
+        ("err", offset_of!(JpegCompressPublic, err)),
+        ("mem", offset_of!(JpegCompressPublic, mem)),
+        ("progress", offset_of!(JpegCompressPublic, progress)),
+        ("client_data", offset_of!(JpegCompressPublic, client_data)),
+        (
+            "is_decompressor",
+            offset_of!(JpegCompressPublic, is_decompressor),
+        ),
+        ("global_state", offset_of!(JpegCompressPublic, global_state)),
+        // Compressor-specific.
+        ("dest", offset_of!(JpegCompressPublic, dest)),
+        ("image_width", offset_of!(JpegCompressPublic, image_width)),
+        ("image_height", offset_of!(JpegCompressPublic, image_height)),
+        (
+            "input_components",
+            offset_of!(JpegCompressPublic, input_components),
+        ),
+        (
+            "in_color_space",
+            offset_of!(JpegCompressPublic, in_color_space),
+        ),
+        ("input_gamma", offset_of!(JpegCompressPublic, input_gamma)),
+        // JPEG_LIB_VERSION ≥ 70.
+        ("scale_num", offset_of!(JpegCompressPublic, scale_num)),
+        ("scale_denom", offset_of!(JpegCompressPublic, scale_denom)),
+        ("jpeg_width", offset_of!(JpegCompressPublic, jpeg_width)),
+        ("jpeg_height", offset_of!(JpegCompressPublic, jpeg_height)),
+        // Primary compression parameters.
+        (
+            "data_precision",
+            offset_of!(JpegCompressPublic, data_precision),
+        ),
+        (
+            "num_components",
+            offset_of!(JpegCompressPublic, num_components),
+        ),
+        (
+            "jpeg_color_space",
+            offset_of!(JpegCompressPublic, jpeg_color_space),
+        ),
+        ("comp_info", offset_of!(JpegCompressPublic, comp_info)),
+        // Quantization / Huffman tables.
+        (
+            "quant_tbl_ptrs",
+            offset_of!(JpegCompressPublic, quant_tbl_ptrs),
+        ),
+        (
+            "q_scale_factor",
+            offset_of!(JpegCompressPublic, q_scale_factor),
+        ),
+        (
+            "dc_huff_tbl_ptrs",
+            offset_of!(JpegCompressPublic, dc_huff_tbl_ptrs),
+        ),
+        (
+            "ac_huff_tbl_ptrs",
+            offset_of!(JpegCompressPublic, ac_huff_tbl_ptrs),
+        ),
+        // Arithmetic-coding tables.
+        ("arith_dc_L", offset_of!(JpegCompressPublic, arith_dc_L)),
+        ("arith_dc_U", offset_of!(JpegCompressPublic, arith_dc_U)),
+        ("arith_ac_K", offset_of!(JpegCompressPublic, arith_ac_K)),
+        // Scan scripting.
+        ("num_scans", offset_of!(JpegCompressPublic, num_scans)),
+        ("scan_info", offset_of!(JpegCompressPublic, scan_info)),
+        // Boolean compression options.
+        ("raw_data_in", offset_of!(JpegCompressPublic, raw_data_in)),
+        ("arith_code", offset_of!(JpegCompressPublic, arith_code)),
+        (
+            "optimize_coding",
+            offset_of!(JpegCompressPublic, optimize_coding),
+        ),
+        (
+            "CCIR601_sampling",
+            offset_of!(JpegCompressPublic, CCIR601_sampling),
+        ),
+        (
+            "do_fancy_downsampling",
+            offset_of!(JpegCompressPublic, do_fancy_downsampling),
+        ),
+        (
+            "smoothing_factor",
+            offset_of!(JpegCompressPublic, smoothing_factor),
+        ),
+        ("dct_method", offset_of!(JpegCompressPublic, dct_method)),
+        // Restart marker control.
+        (
+            "restart_interval",
+            offset_of!(JpegCompressPublic, restart_interval),
+        ),
+        (
+            "restart_in_rows",
+            offset_of!(JpegCompressPublic, restart_in_rows),
+        ),
+        // JFIF / Adobe marker emission parameters.
+        (
+            "write_JFIF_header",
+            offset_of!(JpegCompressPublic, write_JFIF_header),
+        ),
+        (
+            "JFIF_major_version",
+            offset_of!(JpegCompressPublic, JFIF_major_version),
+        ),
+        (
+            "JFIF_minor_version",
+            offset_of!(JpegCompressPublic, JFIF_minor_version),
+        ),
+        ("density_unit", offset_of!(JpegCompressPublic, density_unit)),
+        ("X_density", offset_of!(JpegCompressPublic, X_density)),
+        ("Y_density", offset_of!(JpegCompressPublic, Y_density)),
+        (
+            "write_Adobe_marker",
+            offset_of!(JpegCompressPublic, write_Adobe_marker),
+        ),
+        // State variable.
+        (
+            "next_scanline",
+            offset_of!(JpegCompressPublic, next_scanline),
+        ),
+        // Computed at startup.
+        (
+            "progressive_mode",
+            offset_of!(JpegCompressPublic, progressive_mode),
+        ),
+        (
+            "max_h_samp_factor",
+            offset_of!(JpegCompressPublic, max_h_samp_factor),
+        ),
+        (
+            "max_v_samp_factor",
+            offset_of!(JpegCompressPublic, max_v_samp_factor),
+        ),
+        (
+            "min_DCT_h_scaled_size",
+            offset_of!(JpegCompressPublic, min_DCT_h_scaled_size),
+        ),
+        (
+            "min_DCT_v_scaled_size",
+            offset_of!(JpegCompressPublic, min_DCT_v_scaled_size),
+        ),
+        (
+            "total_iMCU_rows",
+            offset_of!(JpegCompressPublic, total_iMCU_rows),
+        ),
+        // Per-scan state.
+        (
+            "comps_in_scan",
+            offset_of!(JpegCompressPublic, comps_in_scan),
+        ),
+        (
+            "cur_comp_info",
+            offset_of!(JpegCompressPublic, cur_comp_info),
+        ),
+        ("MCUs_per_row", offset_of!(JpegCompressPublic, MCUs_per_row)),
+        (
+            "MCU_rows_in_scan",
+            offset_of!(JpegCompressPublic, MCU_rows_in_scan),
+        ),
+        (
+            "blocks_in_MCU",
+            offset_of!(JpegCompressPublic, blocks_in_MCU),
+        ),
+        (
+            "MCU_membership",
+            offset_of!(JpegCompressPublic, MCU_membership),
+        ),
+        ("Ss", offset_of!(JpegCompressPublic, Ss)),
+        ("Se", offset_of!(JpegCompressPublic, Se)),
+        ("Ah", offset_of!(JpegCompressPublic, Ah)),
+        ("Al", offset_of!(JpegCompressPublic, Al)),
+        // JPEG_LIB_VERSION ≥ 80 extensions.
+        ("block_size", offset_of!(JpegCompressPublic, block_size)),
+        (
+            "natural_order",
+            offset_of!(JpegCompressPublic, natural_order),
+        ),
+        ("lim_Se", offset_of!(JpegCompressPublic, lim_Se)),
+        // Opaque libjpeg-internal pointers. The C-side `main` field is
+        // mirrored by Rust as `main_ctrl` (the trailing `_ctrl` keeps
+        // grep'ability and avoids identifier collisions in some scopes
+        // — see the file-level note above).
+        ("master", offset_of!(JpegCompressPublic, master)),
+        ("main", offset_of!(JpegCompressPublic, main_ctrl)),
+        ("prep", offset_of!(JpegCompressPublic, prep)),
+        ("coef", offset_of!(JpegCompressPublic, coef)),
+        ("marker", offset_of!(JpegCompressPublic, marker)),
+        ("cconvert", offset_of!(JpegCompressPublic, cconvert)),
+        ("downsample", offset_of!(JpegCompressPublic, downsample)),
+        ("fdct", offset_of!(JpegCompressPublic, fdct)),
+        ("entropy", offset_of!(JpegCompressPublic, entropy)),
+        ("script_space", offset_of!(JpegCompressPublic, script_space)),
+        (
+            "script_space_size",
+            offset_of!(JpegCompressPublic, script_space_size),
+        ),
+    ]
+}
+
+#[test]
+fn rust_offsets_match_jpeg_compress_struct_at_lib_version_80() {
+    use libjpeg_turbo_rs_capi::jpeglib::JpegCompressPublic;
+
+    let rust_fields: Vec<(&'static str, usize)> = rust_offsets_compress();
+    let names: Vec<&str> = rust_fields.iter().map(|(n, _)| *n).collect();
+    let probe: CcProbeResult = match cc_offsetof_for_struct("jpeg_compress_struct", &names) {
+        CcProbeOutcome::Ok(r) => r,
+        CcProbeOutcome::Skip(why) => {
+            eprintln!("SKIP: {why}");
+            return;
+        }
+    };
+    let rust_sizeof: usize = std::mem::size_of::<JpegCompressPublic>();
+    assert_no_drift("jpeg_compress_struct", &rust_fields, rust_sizeof, &probe);
+}

--- a/docs/LAST_MILE.md
+++ b/docs/LAST_MILE.md
@@ -8,15 +8,15 @@
 
 ---
 
-## Current Status (2026-05-07)
+## Current Status (2026-05-08)
 
-Project is **replacement-ready** for the Rust-application + stock-tool drop-in story. System-library drop-in (Phase 2) is closed. Long-tail C-compatibility (Phase 3) has **0 fully-OPEN items left** — P3-3 / P3-4 / P3-5 / P3-6 are all CLOSED; P3-1 and P3-2 retain narrow PARTIAL scope-tracking notes for follow-ups gated on downstream demand.
+Project is **replacement-ready** for the Rust-application + stock-tool drop-in story. System-library drop-in (Phase 2) is closed. Long-tail C-compatibility (Phase 3) has **0 fully-OPEN items left** — P3-1 / P3-3 / P3-4 / P3-5 / P3-6 are all CLOSED; only P3-2 retains a narrow PARTIAL scope-tracking note (full 12-bit raw-data backend) gated on downstream demand.
 
 **Live gate** (refresh whenever the inventory changes):
 
 | Check | Result |
 | --- | --- |
-| `cargo test --workspace --release` | **Passes** — 2151 tests, 0 failures, 1 ignored (one slow release-only stress test). |
+| `cargo test --workspace --release` | **Passes** — 2157 tests, 0 failures, 1 ignored (one slow release-only stress test). |
 | `cargo test -p libjpeg-turbo-rs --test cross_product_transform` | **Passes** all 12 cases. P0-1 closed. |
 | `cargo test -p libjpeg-turbo-rs --test regression_progressive_4pixel_chroma_transform` | **Passes** 256 cases byte-exact vs `jpegtran -progressive -copy all <op>`. P3-4 closed. |
 | `cargo test --test cross_check_p3_6_nonstandard_rgb565` | **Passes** 4 fixtures: 3x2 decode (vs `djpeg`), 3x2 encode (vs `cjpeg -sample 3x2,1x1,1x1` + `djpeg`), 3x1 decode, RGB565 merged-upsample (vs `djpeg -nosmooth` + 5-6-5 truncate chain). P3-6 closed. |
@@ -25,6 +25,7 @@ Project is **replacement-ready** for the Rust-application + stock-tool drop-in s
 | `cargo test --test capi_stock_tool_link` | **Passes** for djpeg/cjpeg/jpegtran + full TJXOP cross-product. |
 | `cargo test --test capi_pillow_compat` | **Passes** — Pillow round-trip @ q=90 PSNR 49.49 dB. P0-3 closed. |
 | `cargo test -p libjpeg-turbo-rs-capi --test tjunittest_link` | **Passes** without `--include-ignored`. |
+| `cargo test -p libjpeg-turbo-rs-capi --test abi_offsets --release` | **Passes** all 6 cross-checks: `jpeg_decompress_struct` (P2-4) + `jpeg_marker_struct` + `jpeg_compress_struct` + `jpeg_error_mgr` + `jpeg_source_mgr` + `jpeg_destination_mgr` against upstream `jpeglib.h` at `JPEG_LIB_VERSION=80`. P3-1 closed. |
 
 ---
 
@@ -44,11 +45,10 @@ Do not call the project a libjpeg-turbo C replacement until all are true:
 
 ## Open Items
 
-No fully-OPEN items left in Phase 3. The PARTIAL closures are:
+No fully-OPEN items left in Phase 3. The remaining PARTIAL closure is:
 
 | ID | Status | Deferred work | Trigger |
 | --- | --- | --- | --- |
-| P3-1 | PARTIAL | `jpeg_compress_struct` + `jpeg_error_mgr` + `jpeg_source_mgr` + `jpeg_destination_mgr` ABI offset cross-checks (decompress + marker active; helper ready, callsite wiring pending) | Downstream consumer pinning offsets in those structs, or v9 upstream bump prep |
 | P3-2 | PARTIAL | Full 12-bit raw-data backend (silent-zero stub eliminated; `JERR_NOTIMPL` `error_exit` semantics in place) | Downstream consumer needing 12-bit `jpeg_*_raw_data` |
 
 **Next up**: nothing scheduled. The release gate is satisfied for the standard-sampling / classic-lifecycle / lossless-transform / non-standard-sampling consumer surfaces. Future phases live in `docs/last_mile/phase4.md` or later if downstream surfaces a gap.
@@ -63,7 +63,7 @@ Each phase file is self-contained. Read only the one you need.
 | --- | --- | --- | --- |
 | **Phase 1** | [last_mile/phase1.md](last_mile/phase1.md) | Original release gate: P0-1..4, P1 (Soft-Skip / Encode SIMD / Legacy / Precision / YUV), Phase-1 P2 (tjbench / PNG), Execution Plan (Tasks 1-7), Definition of Done. | All CLOSED — historical reference. |
 | **Phase 2** | [last_mile/phase2.md](last_mile/phase2.md) | System-library drop-in hardening: P2-1..11 (workflow flags, printf expansion, ABI cross-check, symbol inventory, install layout, fuzzing, distro consumers, progressive-encode samp411, crates.io publish). | All CLOSED. |
-| **Phase 3** | [last_mile/phase3.md](last_mile/phase3.md) | Long-tail C compatibility: P3-1 (ABI offset cross-check), P3-2 (12-bit raw-data stubs), P3-3 (legacy TJ aliases), P3-4 (4-pixel chroma transform gate), P3-5 (classic lifecycle harness), P3-6 (non-standard sampling / RGB565). | P3-1/P3-2 PARTIAL; P3-3/P3-4/P3-5/P3-6 CLOSED. |
+| **Phase 3** | [last_mile/phase3.md](last_mile/phase3.md) | Long-tail C compatibility: P3-1 (ABI offset cross-check), P3-2 (12-bit raw-data stubs), P3-3 (legacy TJ aliases), P3-4 (4-pixel chroma transform gate), P3-5 (classic lifecycle harness), P3-6 (non-standard sampling / RGB565). | P3-2 PARTIAL; P3-1/P3-3/P3-4/P3-5/P3-6 CLOSED. |
 | **Reference** | [last_mile/reference_commands.md](last_mile/reference_commands.md) | Common verification commands (workspace test, stock-tool build, encode bench matrix, etc.). | — |
 
 ---
@@ -72,7 +72,7 @@ Each phase file is self-contained. Read only the one you need.
 
 (Phase 1 + Phase 2 suggested orders are inside the respective phase files.)
 
-1. ~~**P3-1** — extend `tests/abi_offsets.rs` to compress / error_mgr / source_mgr / destination_mgr / marker.~~ **PARTIAL 2026-05-08** — 2 of 6 planned struct cross-checks active (`jpeg_decompress_struct` from P2-4; `jpeg_marker_struct` 2026-05-08). The 4 large structs (`jpeg_compress_struct`, `jpeg_error_mgr`, `jpeg_source_mgr`, `jpeg_destination_mgr`) and the Windows MSVC matrix leg remain deferred — Rust mirrors exist and the shared `cc_offsetof_for_struct` helper supports them, so the remaining work is callsite wiring + CI plumbing. `jvirt_*_control` are opaque upstream and need no cross-check.
+1. ~~**P3-1** — extend `tests/abi_offsets.rs` to compress / error_mgr / source_mgr / destination_mgr / marker.~~ **CLOSED 2026-05-08** — all six originally-planned struct cross-checks active in `tests/abi_offsets.rs` (decompress + marker + compress + error_mgr + source_mgr + destination_mgr; 133 fields + 6 sizeof probes). C-side `main` field maps to Rust mirror `main_ctrl` via `(c_field_name, rust_offset)` tuple (only field-name divergence). `jvirt_*_control` opaque upstream → no cross-check needed. Windows MSVC matrix leg deferred as Phase 4 hardening (helper currently emits gcc/clang flags only); `cargo test … abi_offsets --release` reports `6 passed; 0 failed; 0 ignored` on macOS aarch64 + the `abi-offsets` CI matrix.
 2. ~~**P3-3** — implement the 19 legacy TurboJPEG aliases as forwarding wrappers; remove from allowlist.~~ **CLOSED 2026-05-06**.
 3. ~~**P3-2** — `jpeg12_*_raw_data` stub semantics.~~ **PARTIAL 2026-05-06** — silent-zero return replaced by `JERR_NOTIMPL` `error_exit`; full backend deferred.
 4. ~~**P3-5** — classic `jpeglib.h` lifecycle / custom-I/O / suspension C harness (≥ 8 tests).~~ **CLOSED 2026-05-08** — all 8 patterns active (custom src/dst mgr, source suspension, destination-suspension `JERR_CANT_SUSPEND` contract, abort+reuse for both, buffered-image multi-pass, setjmp/longjmp). Two shim defects uncovered + fixed: pattern #8 (2026-05-07) made `jpeg_read_header` invoke `error_exit` on EOI-terminated malformed input; pattern #4 (2026-05-08) made `push_bytes_through_dest_mgr` invoke `error_exit` with `JERR_CANT_SUSPEND` instead of silently dropping bytes when a custom dst mgr returns `FALSE` (the deferred-encode shim cannot honor upstream's per-MCU suspension at `jpeg_write_scanlines`).

--- a/docs/last_mile/phase3.md
+++ b/docs/last_mile/phase3.md
@@ -1,6 +1,6 @@
-# Phase 3 — Long-Tail C Compatibility (0 OPEN items; P3-1/P3-2 PARTIAL)
+# Phase 3 — Long-Tail C Compatibility (0 OPEN items; P3-2 PARTIAL)
 
-> **Index:** [docs/LAST_MILE.md](../LAST_MILE.md). This phase has no fully-OPEN items left — P3-1 and P3-2 retain narrow PARTIAL scope-tracking notes for follow-ups gated on downstream demand.
+> **Index:** [docs/LAST_MILE.md](../LAST_MILE.md). This phase has no fully-OPEN items left — only P3-2 retains a narrow PARTIAL scope-tracking note (full 12-bit raw-data backend) gated on downstream demand. P3-1 closed 2026-05-08 once all six originally-planned struct cross-checks landed.
 
 External review on 2026-05-06 (`libjpeg_turbo_rs_replacement_analysis.md`) graded the project's *Rust-application replacement* and *stock-tool drop-in* posture as ready, but flagged a long-tail of C-compatibility gaps that block the stronger claim "**any existing C binary linked against `libjpeg.so` / `libturbojpeg.so` runs unchanged**." Six of the seven gaps reproduce in this repository today. The seventh — `libjpeg.so.62` SONAME policy — is already closed under [P2-9](phase2.md#p2-9-v6b--v7--v8-abi-compatibility-matrix--closed) and is not re-listed here.
 
@@ -10,7 +10,7 @@ For each item below, the **agreement** line states whether the gap is reproducib
 
 | ID | Status |
 | --- | --- |
-| P3-1 | PARTIAL (decompress + marker cross-checked; 4 large structs deferred) |
+| P3-1 | CLOSED 2026-05-08 (6 of 6 struct cross-checks active; Windows MSVC matrix leg as Phase 4 hardening) |
 | P3-2 | PARTIAL (silent-zero stub eliminated; full backend deferred) |
 | P3-3 | CLOSED 2026-05-06 |
 | P3-4 | CLOSED 2026-05-07 |
@@ -19,28 +19,39 @@ For each item below, the **agreement** line states whether the gap is reproducib
 
 ---
 
-## P3-1. ABI Offset Cross-Check Was Decompress-Only — **PARTIAL: decompress + marker cross-checked; 4 large structs deferred**
+## P3-1. ABI Offset Cross-Check Was Decompress-Only — **CLOSED 2026-05-08**
 
-**Status (2026-05-08): partially closed — 2 of 6 planned cross-checks active.** `crates/libjpeg-turbo-rs-capi/tests/abi_offsets.rs` cross-checks two structs against upstream `jpeglib.h` at `JPEG_LIB_VERSION=80`. Both tests pass on macOS aarch64 (LP64) under `cargo test -p libjpeg-turbo-rs-capi --test abi_offsets --release` and run in CI on Linux x86_64 + macOS aarch64 via the `abi-offsets` matrix job:
+**Status (2026-05-08): closed.** `crates/libjpeg-turbo-rs-capi/tests/abi_offsets.rs` now cross-checks all six originally-planned structs against upstream `jpeglib.h` at `JPEG_LIB_VERSION=80`. All six tests pass on macOS aarch64 (LP64) under `cargo test -p libjpeg-turbo-rs-capi --test abi_offsets --release` and run in CI on Linux x86_64 + macOS aarch64 via the `abi-offsets` matrix job:
 
 - `rust_offsets_match_upstream_jpeglib_h_at_lib_version_80` — `jpeg_decompress_struct` (27 fields + sizeof, P2-4 baseline).
-- `rust_offsets_match_jpeg_marker_struct_at_lib_version_80` — `jpeg_marker_struct` (5 fields + sizeof, **NEW 2026-05-08**).
+- `rust_offsets_match_jpeg_marker_struct_at_lib_version_80` — `jpeg_marker_struct` (5 fields + sizeof, 2026-05-08).
+- `rust_offsets_match_jpeg_destination_mgr_at_lib_version_80` — `jpeg_destination_mgr` (5 fields + sizeof, **NEW 2026-05-08**).
+- `rust_offsets_match_jpeg_source_mgr_at_lib_version_80` — `jpeg_source_mgr` (7 fields + sizeof, **NEW 2026-05-08**).
+- `rust_offsets_match_jpeg_error_mgr_at_lib_version_80` — `jpeg_error_mgr` (14 fields + sizeof: `error_exit`/`emit_message`/`output_message`/`format_message`/`reset_error_mgr` callbacks, `msg_code`, `msg_parm` union slot, `trace_level`, `num_warnings`, message-table pointers + last-message indices; **NEW 2026-05-08**).
+- `rust_offsets_match_jpeg_compress_struct_at_lib_version_80` — `jpeg_compress_struct` (75 fields + sizeof: `jpeg_common_fields` prefix, image description, JPEG_LIB_VERSION ≥ 70/80 extensions, scan state, marker emission, *and* the trailing 11 opaque libjpeg-internal pointers; **NEW 2026-05-08**).
 
-**`sizeof` cross-check.** Both tests additionally probe `sizeof(struct …)` via the same C harness and assert it equals `mem::size_of::<MirrorStruct>()`. This closes the *false-coverage* gap a per-field check alone leaves open: a per-field check still passes if the Rust mirror truncates the struct's tail (so trailing fields drift silently); the size delta catches that. The error message reads `sizeof: Rust mirror is N bytes, C 'sizeof(struct X)' is M bytes — trailing field(s) are unmirrored or padding diverges`.
+**`sizeof` cross-check (every struct).** Each test additionally probes `sizeof(struct …)` via the same C harness and asserts it equals `mem::size_of::<MirrorStruct>()`. This closes the *false-coverage* gap a per-field check alone leaves open: a per-field check still passes if the Rust mirror truncates the struct's tail (so trailing fields drift silently); the size delta catches that. The error message reads `sizeof: Rust mirror is N bytes, C 'sizeof(struct X)' is M bytes — trailing field(s) are unmirrored or padding diverges`.
 
-**Shared helper.** `cc_offsetof_for_struct(struct_name, &field_names)` in `tests/abi_offsets.rs` builds a one-shot C harness (`#include <setjmp.h>` + `<jpeglib.h>`), prints `field=offset` lines for each requested field plus a `__sizeof__=N` line, runs it through the host `cc`, and parses the output into a `CcProbeResult { offsets, sizeof }`. The harness pulls in `setjmp.h` so callbacks that take a `j_common_ptr` (which contains a `jmp_buf` field via `error_exit`) compile cleanly. Per-struct callsites only have to assemble the field-name list; the build/run/parse plumbing is shared.
+**Shared helper.** `cc_offsetof_for_struct(struct_name, &field_names)` in `tests/abi_offsets.rs` builds a one-shot C harness (`#include <setjmp.h>` + `<jpeglib.h>`), prints `field=offset` lines for each requested field plus a `__sizeof__=N` line, runs it through the host `cc`, and parses the output into a `CcProbeResult { offsets, sizeof }`. The harness pulls in `setjmp.h` so callbacks that take a `j_common_ptr` (which contains a `jmp_buf` field via `error_exit`) compile cleanly. Per-struct callsites only have to assemble the field-name list; the build/run/parse plumbing is shared. The closure landed all four large struct callsites unchanged through this helper — no additional MSVC plumbing was needed for green coverage on the existing Linux x86_64 + macOS aarch64 matrix legs.
 
-**Platform gate.** `cc_offsetof_for_struct` returns `Skip(reason)` when `size_of::<usize>() != 8`, when the upstream submodule is not initialised, or when the host has no runnable `cc`. The 64-bit gate is *not* further restricted to non-Windows: `offset_of!` reads whatever struct layout the Rust compiler chose for the running host (LP64 on Linux/macOS, LLP64 on Windows MSVC) and the C harness compiled on the same host reports the same ABI, so a future Windows-MSVC matrix leg surfaces per-platform Rust↔C drift directly. Adding that leg requires wiring MSVC-style flags (`/I` instead of `-I`, `/Fe:` instead of `-o`, `cl --version` → `cl /?`) into the helper plus an `ilammy/msvc-dev-cmd@v1` step in the workflow; both are tracked as Phase 4 work below.
+**Field-name mapping.** All six callsites pass C-side field names directly to `cc_offsetof_for_struct`; the Rust-side `offset_of!(MirrorStruct, rust_field)` then compares to the C-reported offset. A single divergence exists where the Rust mirror renames a field to avoid an identifier collision: C's `struct jpeg_c_main_controller *main` is mirrored as `JpegCompressPublic::main_ctrl`. The cross-check records this as `("main", offset_of!(JpegCompressPublic, main_ctrl))` so the harness still queries `offsetof(struct jpeg_compress_struct, main)` against the upstream header.
 
-**Still open (deferred):**
+**Platform gate.** `cc_offsetof_for_struct` returns `Skip(reason)` when `size_of::<usize>() != 8`, when the upstream submodule is not initialised, or when the host has no runnable `cc`. The 64-bit gate is *not* further restricted to non-Windows: `offset_of!` reads whatever struct layout the Rust compiler chose for the running host (LP64 on Linux/macOS, LLP64 on Windows MSVC) and the C harness compiled on the same host reports the same ABI, so a future Windows-MSVC matrix leg surfaces per-platform Rust↔C drift directly.
 
-- `jpeg_compress_struct`, `jpeg_error_mgr`, `jpeg_source_mgr`, `jpeg_destination_mgr` — Rust mirrors exist (`JpegCompressPublic`, `JpegErrorMgr`, `JpegSourceMgr`, `JpegDestinationMgr` in `jpeglib.rs`) and the helper already supports them; the work is "wire each struct's field list through `cc_offsetof_for_struct`". Approximate field counts from upstream `jpeglib.h`: compress (~75 fields covering common, image description, JPEG_LIB_VERSION ≥ 70/80 extensions, scan state, marker emission, opaque internals), error_mgr (~14, mostly callback pointers + msg state), source_mgr (~7), destination_mgr (~5). Stock `cjpeg`/`jpegtran` already byte-match upstream (P0-2/P0-4 closures) so the runtime layout is implicitly verified for the working path; a compile-time per-field check would catch silent drift before a downstream rebuild surfaces it.
-  - **Trigger:** downstream consumer pinning offsets in those structs, or prep work for a v9 upstream bump.
-- Windows MSVC leg of the `abi-offsets` matrix — helper currently emits gcc/clang flags only; adding MSVC dispatch and the `ilammy/msvc-dev-cmd@v1` workflow step is mechanical but un-landed.
+**TDD verification (2026-05-08).** Mutation-tested both axes for representative struct (`jpeg_compress_struct`):
+
+1. Field-offset drift: temporarily added `+ 8` to `("main", offset_of!(JpegCompressPublic, main_ctrl))`. Result: `field 'main': Rust says offset 512, C says 504` (the C-side `main` mapping reaches the Rust mirror's `main_ctrl` field correctly). Reverted.
+2. Tail truncation: previously verified on the marker struct (the older PR), exact same helper.
+
+**Closure verification:** `cargo test -p libjpeg-turbo-rs-capi --test abi_offsets --release` reports `6 passed; 0 failed; 0 ignored` on the host (macOS aarch64).
+
+**Future hardening (not blocking closure):**
+
+- Windows MSVC leg of the `abi-offsets` matrix — helper currently emits gcc/clang flags only; adding MSVC dispatch (`/I`, `/Fe:`, `/Fo:`, `cl /?`) plus an `ilammy/msvc-dev-cmd@v1` step on `windows-latest` would surface LLP64-specific drift in CI. The runtime gate is already platform-aware (it reads the host's actual struct layout, not a per-platform const block), so a Windows leg would be additive coverage rather than fixing a known gap.
   - **Trigger:** Windows MSVC consumer, or a measurable LLP64-vs-LP64 layout concern.
-- `jvirt_barray_control` / `jvirt_sarray_control` — these are opaque types in upstream `jpeglib.h` (forward-declared, definition in `jmemmgr.c` only). Consumers don't pin field offsets; they treat the `jvirt_*_ptr` as an opaque handle. **No cross-check needed**, kept here as a tracking note for the original P3-1 scope.
+- `jvirt_barray_control` / `jvirt_sarray_control` — opaque types in upstream `jpeglib.h` (forward-declared, definition in `jmemmgr.c` only). Consumers don't pin field offsets; they treat the `jvirt_*_ptr` as an opaque handle. **No cross-check needed**, kept here as a tracking note for the original P3-1 scope.
 
-The two cross-checked structs cover the field-by-field accesses classic C consumers (stock `djpeg`/`jpegtran -copy all`) make against `jpeg_decompress_struct` and `jpeg_marker_struct`. Encoder-side and error/source/destination manager checks remain on the deferred list above.
+The six cross-checked structs cover every classic-API field surface that consumers (cjpeg / Pillow / ImageMagick / libgd / GIMP / FFmpeg / SDL_image) read by name. Encoder-side and decoder-side handles, plus the three manager structs that consumers customise (error / source / destination), are now all gated against upstream layout drift.
 
 ---
 
@@ -188,7 +199,7 @@ The closure title reflects the actual delta: stub *semantics* moved from "silent
 
 ## Phase 3 Suggested Order
 
-1. ~~**P3-1** — Extend `tests/abi_offsets.rs` to `jpeg_compress_struct`, `jpeg_error_mgr`, `jpeg_source_mgr`, `jpeg_destination_mgr`, `jpeg_marker_struct`.~~ **PARTIAL 2026-05-08** — 2 of 6 planned struct cross-checks active: `jpeg_decompress_struct` (P2-4 baseline) and `jpeg_marker_struct` (2026-05-08). The 4 large structs (`jpeg_compress_struct`, `jpeg_error_mgr`, `jpeg_source_mgr`, `jpeg_destination_mgr`) and the Windows MSVC matrix leg remain deferred — Rust mirrors exist and the shared `cc_offsetof_for_struct` helper supports them, so the remaining work is wiring + CI plumbing. `jvirt_*_control` are opaque upstream and need no cross-check.
+1. ~~**P3-1** — Extend `tests/abi_offsets.rs` to `jpeg_compress_struct`, `jpeg_error_mgr`, `jpeg_source_mgr`, `jpeg_destination_mgr`, `jpeg_marker_struct`.~~ **CLOSED 2026-05-08** — all six originally-planned struct cross-checks active in `tests/abi_offsets.rs` (decompress + marker + compress + error_mgr + source_mgr + destination_mgr; 133 fields + 6 sizeof probes). C-side `main` field maps to Rust mirror `main_ctrl` via `(c_field_name, rust_offset)` tuple (only field-name divergence). `jvirt_*_control` opaque upstream → no cross-check needed. Windows MSVC matrix leg deferred as Phase 4 hardening (helper currently emits gcc/clang flags only); `cargo test -p libjpeg-turbo-rs-capi --test abi_offsets --release` reports `6 passed; 0 failed; 0 ignored` on macOS aarch64 + the `abi-offsets` CI matrix.
 2. ~~**P3-3** — Implement the 19 legacy TurboJPEG aliases as forwarding wrappers and delete them from the allowlist.~~ **CLOSED 2026-05-06** — `crates/libjpeg-turbo-rs-capi/tests/symbol_inventory.rs::allowlisted_missing_symbols()` returns an empty `HashSet`; both `cdylib_exports_every_upstream_*` tests pass without exemptions. The wrappers live in `crates/libjpeg-turbo-rs-capi/src/legacy.rs` (~390 lines for the new section).
 3. ~~**P3-2** — Either implement `jpeg12_write_raw_data` / `jpeg12_read_raw_data` against the existing 12-bit encode/decode backend, or downgrade them to feature-gated absence. The "stub returning 0" middle ground must end.~~ **PARTIAL 2026-05-06** — middle ground eliminated: stubs now invoke `cinfo->err->error_exit(cinfo)` with `msg_code = JERR_NOTIMPL`, so callers either longjmp out cleanly or hit a default abort. Full 12-bit raw-data backend deferred to Phase 4 (gated on downstream demand).
 4. ~~**P3-5** — Classic `jpeglib.h` lifecycle / custom-I/O / suspension C harness (≥ 8 tests).~~ **CLOSED 2026-05-08** — all 8 patterns active in `crates/libjpeg-turbo-rs-capi/tests/capi_classic_lifecycle.rs` (custom src/dst mgr, source suspension, destination-suspension `JERR_CANT_SUSPEND` contract, abort+reuse for both decompress/compress, buffered-image multi-pass, setjmp/longjmp). Pattern #4 surfaced + fixed a real shim defect: `push_bytes_through_dest_mgr` previously ignored `empty_output_buffer`'s `FALSE` return and called `term_destination` anyway, silently dropping the post-suspension bytes. Architectural reality is that the deferred-encode shim cannot honor upstream's per-MCU streaming-suspension contract at `jpeg_write_scanlines` (no encoding happens there), so the closure invokes `cinfo->err->error_exit` with `JERR_CANT_SUSPEND` (upstream code 25, "Suspension not allowed here") rather than inventing a non-upstream resume contract; a `setjmp`/`longjmp` consumer recovers cleanly. The earlier P3-5 pattern #8 fix (2026-05-07) wired `jpeg_read_header` to invoke `error_exit` on EOI-terminated malformed input.


### PR DESCRIPTION
## Summary

Wires `jpeg_compress_struct`, `jpeg_error_mgr`, `jpeg_source_mgr`, and `jpeg_destination_mgr` through the existing `cc_offsetof_for_struct` helper in `crates/libjpeg-turbo-rs-capi/tests/abi_offsets.rs`. Combined with the prior `decompress` (P2-4 baseline) and `marker` (P3-1 first half, #272) tests, the file now gates **all six originally-planned struct cross-checks** against upstream `jpeglib.h` at `JPEG_LIB_VERSION=80` — closes P3-1.

## What changed

Four new test functions, all built on the existing helper:

| Struct | Fields | Why it matters |
| --- | --- | --- |
| `jpeg_destination_mgr` | 5 | C consumers writing custom output managers (in-memory ring buffers, network streams) read these offsets directly. |
| `jpeg_source_mgr` | 7 | The classic streaming-decode pattern (`fill_input_buffer` returning `FALSE` for I/O suspension) reads `bytes_in_buffer` / `next_input_byte` at well-known offsets. |
| `jpeg_error_mgr` | 14 | The standard libjpeg consumer pattern overrides `error_exit` (offset 0) with a `setjmp`/`longjmp` handler and inspects `msg_code` (offset 40 LP64) plus `msg_parm` (offset 44) for diagnostics. |
| `jpeg_compress_struct` | 75 | cjpeg, GIMP's plugin, and a long tail of distro consumers read fields like `image_width` / `data_precision` / `comp_info` / `optimize_coding` directly through this struct. |

Each test enumerates the C-side field names and compares to `offset_of!(MirrorStruct, …)`; the helper additionally probes `sizeof(struct …)` and asserts it matches `mem::size_of::<MirrorStruct>()` (catches tail-truncation drift that a per-field `offsetof` check silently passes).

## Field-name mapping

The Rust mirror renames a single field to avoid an identifier collision: upstream's `struct jpeg_c_main_controller *main` is mirrored as `JpegCompressPublic::main_ctrl`. The cross-check encodes this as `("main", offset_of!(JpegCompressPublic, main_ctrl))` so the harness keeps querying `offsetof(struct jpeg_compress_struct, main)` against the upstream header while the assertion compares to the Rust mirror's renamed slot. All other fields use C-side names verbatim.

## TDD-verified mutation A/B (compress struct, the largest)

Temporarily added `+ 8` to the `("main", offset_of!(JpegCompressPublic, main_ctrl))` tuple's Rust offset; the test red-failed with:

```
field `main`: Rust says offset 512, C says 504
```

Reverted. The C-side `main` mapping landed correctly through the helper — `offsetof(struct jpeg_compress_struct, main)` returned 504, matching the unmutated Rust offset of `main_ctrl`.

(Sizeof tail-truncation teeth was previously verified on the marker struct in #272 — same helper, same assertion path.)

## Doc updates

- `docs/last_mile/phase3.md` P3-1 section: PARTIAL → CLOSED 2026-05-08. Status summary table updated; header text updated to "0 OPEN items; P3-2 PARTIAL"; Suggested Order entry struck through with full closure note. Windows MSVC matrix leg moved from "deferred" to "Future hardening (not blocking closure)" — the helper currently emits gcc/clang flags only, so adding MSVC dispatch + `ilammy/msvc-dev-cmd@v1` is additive coverage rather than fixing a known gap.
- `docs/LAST_MILE.md` Current Status: P3-1 moved to closed list. Open Items table: P3-1 row removed (only P3-2 PARTIAL remains). New live-gate row added for the 6-struct `abi_offsets` test. Phase Map row updated. Suggested Order P3-1 entry struck through.
- Live gate test count: 2151 → **2157** (4 new tests).

## Verification

- `cargo test -p libjpeg-turbo-rs-capi --test abi_offsets --release` → `6 passed; 0 failed; 0 ignored`.
- `cargo test --workspace --release --no-fail-fast` → `passed=2157 failed=0 ignored=1`.
- `cargo fmt --all --check`, `cargo clippy --lib --release -- -D warnings` clean.
- Codex review on the commit returned clean — field lists match the upstream public struct layouts targeted by the change; doc updates consistent with the new test coverage.

## Closure delta

This PR closes the second (and final) half of P3-1's deferred work. After merge, only P3-2 PARTIAL remains in Phase 3 — the full 12-bit raw-data backend (the explicitly Phase 4 / multi-PR task gated on downstream demand). `jvirt_*_control` are opaque types upstream (forward-declared, definition in `jmemmgr.c` only) and need no cross-check; Windows MSVC matrix leg is recorded as future hardening but not blocking closure.

## Test plan

- [x] `cargo test -p libjpeg-turbo-rs-capi --test abi_offsets --release` → 6/6 green locally.
- [x] `cargo test --workspace --release --no-fail-fast` → 2157/0/1 locally.
- [x] Mutation A/B confirmed teeth on the new compress test (offset drift catches `field 'main'` mismatch).
- [x] `cargo fmt --check`, `cargo clippy --lib -- -D warnings` clean.
- [x] Codex review clean.
- [ ] CI matrix green on Linux x86_64 / macOS / Windows.

Refs: closes the 4-large-struct half of the P3-1 PARTIAL deferred work; with #272 (marker struct) this brings P3-1 fully CLOSED.