### PR TITLE
fix(capi): jpeg_read_header supports JPEG_HEADER_TABLES_ONLY (libtiff)

### DIFF
--- a/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
+++ b/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
@@ -1710,60 +1710,22 @@ fn detect_tables_only(bytes: &[u8]) -> Option<Vec<u8>> {
     Some(bytes[..i - 2].to_vec())
 }
 
-/// Walk markers from the SOI and answer whether `bytes` carries its own
-/// DQT or DHT table before the SOF/SOS — i.e. is a self-contained JPEG
-/// rather than a tables-omitting abbreviated image (libjpeg.txt §6).
-/// Used by the splice logic in `jpeg_read_header` to suppress prefixing
-/// when the caller is decoding a fresh standard JPEG on a cinfo that
-/// happens to have a stale `tables_only_prefix` from a prior libtiff
-/// session.
-///
-/// Returns `true` if a DQT (`FF DB`) or DHT (`FF C4`) appears before any
-/// SOF/SOS marker. Returns `false` for tables-omitting streams (libtiff
-/// strip data) — splice should run. Also returns `false` for malformed
-/// inputs; `Decoder::new` then handles the rejection through its normal
-/// error path.
-fn input_has_own_tables(bytes: &[u8]) -> bool {
-    if bytes.len() < 4 || bytes[0] != 0xFF || bytes[1] != 0xD8 {
-        return false;
-    }
-    let mut i: usize = 2;
-    while i + 1 < bytes.len() {
-        while i < bytes.len() && bytes[i] == 0xFF && bytes.get(i + 1) == Some(&0xFF) {
-            i += 1;
-        }
-        if i + 1 >= bytes.len() || bytes[i] != 0xFF {
-            return false;
-        }
-        let marker: u8 = bytes[i + 1];
-        i += 2;
-        match marker {
-            0xDB | 0xC4 => return true, // DQT or DHT — input has own tables
-            0xDA => return false,       // SOS — past header without seeing tables
-            // SOF range: bracketed by C0..CF minus C4 (DHT), C8 (reserved JPG), CC (DAC).
-            0xC0..=0xCF if marker != 0xC4 && marker != 0xC8 && marker != 0xCC => return false,
-            0xD9 => return false, // EOI without tables (degenerate but bounded)
-            0xD0..=0xD7 | 0x01 => continue, // no payload (RST0..RST7, TEM)
-            _ => {
-                if i + 2 > bytes.len() {
-                    return false;
-                }
-                let len: usize = ((bytes[i] as usize) << 8) | (bytes[i + 1] as usize);
-                if len < 2 || i + len > bytes.len() {
-                    return false;
-                }
-                i += len;
-            }
-        }
-    }
-    false
-}
-
 /// Peek at the JPEG header to populate `cinfo.image_width` etc. without
 /// triggering a full decode. Uses the Rust-side `Decoder::new` which
 /// only parses markers up to (but not including) entropy-coded data.
+///
+/// `require_image` mirrors libjpeg's `jpeg_read_header(cinfo, require_image)`
+/// flag (libjpeg.txt §6, jdapimin.c::jpeg_read_header). When the input is
+/// a tables-only abbreviated datastream:
+///   * `require_image == TRUE`  — invoke `error_exit` with `JERR_NO_IMAGE`
+///     so a `setjmp`/`longjmp` consumer recovers cleanly. The classic
+///     contract for callers that don't care about tables: "I asked for
+///     a real image header; you didn't give me one; fail loudly."
+///   * `require_image == FALSE` — return `JPEG_HEADER_TABLES_ONLY` so
+///     the caller can read the tables and use them on a subsequent
+///     image-only datastream (the libtiff `JPEGTables` flow).
 #[no_mangle]
-pub extern "C" fn jpeg_read_header(cinfo: *mut c_void, _require_image: CBoolean) -> c_int {
+pub extern "C" fn jpeg_read_header(cinfo: *mut c_void, require_image: CBoolean) -> c_int {
     let c: &mut JpegDecompressPublic = match unsafe { cinfo_mut(cinfo) } {
         Some(c) => c,
         None => return JPEG_SUSPENDED,
@@ -1813,42 +1775,61 @@ pub extern "C" fn jpeg_read_header(cinfo: *mut c_void, _require_image: CBoolean)
     // the next strip's body so `Decoder::new` sees a single self-contained
     // JPEG.
     //
-    // Detection runs on the freshly-drained bytes *before* any splice
-    // pass to avoid a tables-only stream being re-detected after a
-    // splice (which would loop). After detection we reset
-    // `priv_state.source` to `None` so the next `jpeg_read_header` call
-    // re-drains the caller's source manager and picks up the strip
-    // bytes libtiff has now installed.
-    if priv_state.tables_only_prefix.is_none() {
-        if let Some(prefix) = detect_tables_only(raw_bytes) {
-            priv_state.tables_only_prefix = Some(prefix);
-            priv_state.source = JpegSource::None;
-            priv_state.last_error = CString::new("No error").unwrap_or_default();
-            return JPEG_HEADER_TABLES_ONLY;
+    // Detection runs on every fresh drain (not gated on
+    // `tables_only_prefix.is_none()`) so a cinfo reused across multiple
+    // images can refresh the cached tables on each new tables-only
+    // datastream — stock libjpeg's `jpeg_read_header` accepts repeated
+    // tables-only reads and updates the cached tables in place. After
+    // detection we reset `priv_state.source` to `None` so the next
+    // `jpeg_read_header` call re-drains the caller's source manager and
+    // picks up the strip bytes libtiff has now installed.
+    if let Some(prefix) = detect_tables_only(raw_bytes) {
+        // libjpeg.txt §6 / jdapimin.c::jpeg_read_header: when the
+        // caller passed `require_image = TRUE`, a tables-only blob is
+        // *not* a valid response — invoke `error_exit` with
+        // `JERR_NO_IMAGE` (upstream code 53 at `JPEG_LIB_VERSION=80`,
+        // verified empirically against the submodule's `jerror.h`).
+        // A `setjmp`/`longjmp` consumer recovers; a default handler
+        // aborts. The cached prefix is *not* updated in this branch
+        // because the consumer asked for an image and we're delivering
+        // the documented error.
+        if require_image != 0 {
+            priv_state.last_error = CString::new(
+                "jpeg_read_header: JERR_NO_IMAGE — caller passed require_image=TRUE \
+                 but the input is a tables-only abbreviated datastream",
+            )
+            .unwrap_or_default();
+            invoke_error_exit(cinfo, 53);
+            // Defensive return if a non-conforming handler returns
+            // without longjmp-ing (violates the libjpeg contract).
+            return JPEG_SUSPENDED;
         }
+        priv_state.tables_only_prefix = Some(prefix);
+        priv_state.source = JpegSource::None;
+        priv_state.last_error = CString::new("No error").unwrap_or_default();
+        return JPEG_HEADER_TABLES_ONLY;
     }
 
     // If we have a stashed tables-only prefix and the new input starts
-    // with SOI (the strip data libtiff feeds for each
-    // TIFFReadEncodedStrip), splice them so `Decoder::new` sees the
-    // tables + strip image as one stream. We persist the spliced
+    // with SOI, splice them so `Decoder::new` sees the tables + image
+    // as one stream. The splice is unconditional on prefix presence —
+    // libjpeg's table-replacement contract is "the most recent table
+    // in source order wins for each `(class, destination)` slot", so
+    // an image carrying its own DQT/DHT (a "partial abbreviated"
+    // image, or even a fully self-contained JPEG run on a cinfo with
+    // a stale prefix) simply overrides whatever the cached prefix
+    // installed — no incorrect-decode risk. We persist the spliced
     // bytes back into `priv_state.source` so the rest of the decode
     // path (`jpeg_start_decompress`, `jpeg_read_raw_data`, …) reads
     // from the unified stream.
     let needs_splice: bool = priv_state.tables_only_prefix.is_some()
         && raw_bytes.len() >= 2
         && raw_bytes[0] == 0xFF
-        && raw_bytes[1] == 0xD8
-        // Defensive: a cinfo can be reused for a fresh self-contained
-        // JPEG whose own DQT/DHT make a stale prefix splice incorrect.
-        // Skip the splice when the input already carries its own tables
-        // — `Decoder::new` parses it normally.
-        && !input_has_own_tables(raw_bytes);
+        && raw_bytes[1] == 0xD8;
     if needs_splice {
-        // SAFETY (logical, not unsafe): `raw_bytes` borrows from
-        // `priv_state.source.as_bytes()`. We're about to replace that
-        // backing buffer, so build the combined Vec first via owned
-        // copies; then assign.
+        // `raw_bytes` borrows from `priv_state.source.as_bytes()`. We're
+        // about to replace that backing buffer, so build the combined
+        // Vec first via owned copies; then assign.
         let prefix_clone: Vec<u8> = priv_state.tables_only_prefix.as_deref().unwrap().to_vec();
         let strip_body: Vec<u8> = raw_bytes[2..].to_vec();
         let mut combined: Vec<u8> = Vec::with_capacity(prefix_clone.len() + strip_body.len());

--- a/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
+++ b/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
@@ -628,6 +628,18 @@ struct DecompressPrivate {
     /// Per-component row cursor into `raw_image_cache`. Entry `i` is
     /// the number of rows already delivered for component `i`.
     raw_rows_consumed: Vec<usize>,
+    /// Bytes from a previously-parsed tables-only abbreviated datastream
+    /// (libjpeg.txt §6: SOI + DQT/DHT/DAC + EOI, no SOF/SOS), with the
+    /// trailing `FF D9` (EOI) already stripped so a subsequent strip
+    /// stream can be spliced after these bytes to form a single
+    /// self-contained JPEG. Set by `jpeg_read_header` when it detects a
+    /// tables-only input and returns `JPEG_HEADER_TABLES_ONLY`. Consumed
+    /// (read; never cleared) by subsequent `jpeg_read_header` calls so
+    /// `Decoder::new` sees a complete tables+image stream. The libtiff
+    /// `JPEGTables` field flow needs this — libtiff calls
+    /// `jpeg_read_header` first on the bare tables blob, then on each
+    /// strip's image-without-tables payload.
+    tables_only_prefix: Option<Vec<u8>>,
 }
 
 impl Default for DecompressPrivate {
@@ -650,6 +662,7 @@ impl Default for DecompressPrivate {
             header_parsed_ok: false,
             raw_image_cache: None,
             raw_rows_consumed: Vec::new(),
+            tables_only_prefix: None,
         }
     }
 }
@@ -1616,6 +1629,136 @@ fn colorspace_to_jcs(cs: libjpeg_turbo_rs::ColorSpace) -> c_int {
     }
 }
 
+/// If `bytes` is a tables-only abbreviated JPEG datastream per
+/// libjpeg.txt §6 (SOI + zero or more DQT/DHT/DAC/COM/APPn/DRI markers
+/// + EOI, with no SOF or SOS), return `Some(prefix)` where `prefix` is
+/// the byte run from the SOI through the last marker before EOI — i.e.
+/// the input with the trailing `FF D9` (EOI) stripped. The caller can
+/// splice this prefix in front of a strip stream that starts with `FF D8`
+/// (after dropping its own SOI) to form a single self-contained JPEG
+/// that `Decoder::new` parses normally.
+///
+/// Returns `None` if the input isn't a clean tables-only datastream
+/// (e.g. it has an SOF marker, or it's truncated, or it has a malformed
+/// marker length). The caller falls back to the existing decode path.
+///
+/// JPEG marker bytes recognised here:
+///   * `FF D8` — SOI (start)
+///   * `FF D9` — EOI (end)
+///   * `FF DA` — SOS (rejects: not tables-only)
+///   * `FF C0..FF CF` minus `{C4, C8, CC}` — SOF variants (rejects)
+///   * `FF C4` (DHT), `FF CC` (DAC), `FF DB` (DQT), `FF DD` (DRI),
+///     `FF FE` (COM), `FF E0..FF EF` (APPn) — all valid in tables-only
+///   * `FF D0..FF D7` (RST0..RST7), `FF 01` (TEM) — no length payload,
+///     valid in tables-only (though unusual)
+fn detect_tables_only(bytes: &[u8]) -> Option<Vec<u8>> {
+    if bytes.len() < 4 {
+        return None;
+    }
+    if bytes[0] != 0xFF || bytes[1] != 0xD8 {
+        return None;
+    }
+
+    let mut i: usize = 2;
+    let mut saw_eoi: bool = false;
+    while i + 1 < bytes.len() {
+        // Skip any FF padding the encoder may have inserted between
+        // markers (some libjpeg-turbo encoders write FF FF as filler).
+        while i < bytes.len() && bytes[i] == 0xFF && bytes.get(i + 1) == Some(&0xFF) {
+            i += 1;
+        }
+        if i + 1 >= bytes.len() || bytes[i] != 0xFF {
+            return None;
+        }
+        let marker: u8 = bytes[i + 1];
+        i += 2;
+
+        match marker {
+            0xD9 => {
+                saw_eoi = true;
+                break;
+            }
+            0xD8 => return None, // unexpected duplicate SOI
+            0xDA => return None, // SOS: not tables-only
+            // SOF range: C0..CF minus C4 (DHT), C8 (reserved JPG), CC (DAC).
+            0xC0..=0xCF if marker != 0xC4 && marker != 0xC8 && marker != 0xCC => {
+                return None;
+            }
+            // No-payload markers (RST0..RST7, TEM).
+            0xD0..=0xD7 | 0x01 => {}
+            // Marker with 2-byte big-endian length (covers DQT/DHT/DAC,
+            // DRI, COM, APPn, and any other length-bearing marker).
+            _ => {
+                if i + 2 > bytes.len() {
+                    return None;
+                }
+                let len: usize = ((bytes[i] as usize) << 8) | (bytes[i + 1] as usize);
+                if len < 2 || i + len > bytes.len() {
+                    return None;
+                }
+                i += len;
+            }
+        }
+    }
+
+    if !saw_eoi {
+        return None;
+    }
+    // i now points just past the EOI bytes (FF D9). Strip them so the
+    // returned prefix can be spliced in front of a strip stream's body
+    // (after the strip's leading FF D8) to form a complete JPEG.
+    Some(bytes[..i - 2].to_vec())
+}
+
+/// Walk markers from the SOI and answer whether `bytes` carries its own
+/// DQT or DHT table before the SOF/SOS — i.e. is a self-contained JPEG
+/// rather than a tables-omitting abbreviated image (libjpeg.txt §6).
+/// Used by the splice logic in `jpeg_read_header` to suppress prefixing
+/// when the caller is decoding a fresh standard JPEG on a cinfo that
+/// happens to have a stale `tables_only_prefix` from a prior libtiff
+/// session.
+///
+/// Returns `true` if a DQT (`FF DB`) or DHT (`FF C4`) appears before any
+/// SOF/SOS marker. Returns `false` for tables-omitting streams (libtiff
+/// strip data) — splice should run. Also returns `false` for malformed
+/// inputs; `Decoder::new` then handles the rejection through its normal
+/// error path.
+fn input_has_own_tables(bytes: &[u8]) -> bool {
+    if bytes.len() < 4 || bytes[0] != 0xFF || bytes[1] != 0xD8 {
+        return false;
+    }
+    let mut i: usize = 2;
+    while i + 1 < bytes.len() {
+        while i < bytes.len() && bytes[i] == 0xFF && bytes.get(i + 1) == Some(&0xFF) {
+            i += 1;
+        }
+        if i + 1 >= bytes.len() || bytes[i] != 0xFF {
+            return false;
+        }
+        let marker: u8 = bytes[i + 1];
+        i += 2;
+        match marker {
+            0xDB | 0xC4 => return true, // DQT or DHT — input has own tables
+            0xDA => return false,       // SOS — past header without seeing tables
+            // SOF range: bracketed by C0..CF minus C4 (DHT), C8 (reserved JPG), CC (DAC).
+            0xC0..=0xCF if marker != 0xC4 && marker != 0xC8 && marker != 0xCC => return false,
+            0xD9 => return false, // EOI without tables (degenerate but bounded)
+            0xD0..=0xD7 | 0x01 => continue, // no payload (RST0..RST7, TEM)
+            _ => {
+                if i + 2 > bytes.len() {
+                    return false;
+                }
+                let len: usize = ((bytes[i] as usize) << 8) | (bytes[i + 1] as usize);
+                if len < 2 || i + len > bytes.len() {
+                    return false;
+                }
+                i += len;
+            }
+        }
+    }
+    false
+}
+
 /// Peek at the JPEG header to populate `cinfo.image_width` etc. without
 /// triggering a full decode. Uses the Rust-side `Decoder::new` which
 /// only parses markers up to (but not including) entropy-coded data.
@@ -1649,11 +1792,75 @@ pub extern "C" fn jpeg_read_header(cinfo: *mut c_void, _require_image: CBoolean)
         }
     }
 
-    let bytes: &[u8] = match priv_state.source.as_bytes() {
+    let raw_bytes: &[u8] = match priv_state.source.as_bytes() {
         Some(b) if b.len() >= 2 => b,
         _ => {
             priv_state.last_error =
                 CString::new("jpeg_read_header: no JPEG source attached").unwrap_or_default();
+            return JPEG_SUSPENDED;
+        }
+    };
+
+    // Tables-only abbreviated datastream (libjpeg.txt §6) detection.
+    // libtiff's COMPRESSION_JPEG path calls `jpeg_read_header` on its
+    // `JPEGTables` blob first (SOI + DQT/DHT + EOI, no SOF/SOS), expects
+    // `JPEG_HEADER_TABLES_ONLY` (= 2), and *then* re-points the source
+    // manager at strip data and calls `jpeg_read_header` again to parse
+    // the actual image header — which is missing tables that the strip
+    // data inherits from the cached `JPEGTables`. The shim emulates this
+    // contract by stashing the tables-only bytes (minus the trailing EOI)
+    // in `priv_state.tables_only_prefix` and splicing them in front of
+    // the next strip's body so `Decoder::new` sees a single self-contained
+    // JPEG.
+    //
+    // Detection runs on the freshly-drained bytes *before* any splice
+    // pass to avoid a tables-only stream being re-detected after a
+    // splice (which would loop). After detection we reset
+    // `priv_state.source` to `None` so the next `jpeg_read_header` call
+    // re-drains the caller's source manager and picks up the strip
+    // bytes libtiff has now installed.
+    if priv_state.tables_only_prefix.is_none() {
+        if let Some(prefix) = detect_tables_only(raw_bytes) {
+            priv_state.tables_only_prefix = Some(prefix);
+            priv_state.source = JpegSource::None;
+            priv_state.last_error = CString::new("No error").unwrap_or_default();
+            return JPEG_HEADER_TABLES_ONLY;
+        }
+    }
+
+    // If we have a stashed tables-only prefix and the new input starts
+    // with SOI (the strip data libtiff feeds for each
+    // TIFFReadEncodedStrip), splice them so `Decoder::new` sees the
+    // tables + strip image as one stream. We persist the spliced
+    // bytes back into `priv_state.source` so the rest of the decode
+    // path (`jpeg_start_decompress`, `jpeg_read_raw_data`, …) reads
+    // from the unified stream.
+    let needs_splice: bool = priv_state.tables_only_prefix.is_some()
+        && raw_bytes.len() >= 2
+        && raw_bytes[0] == 0xFF
+        && raw_bytes[1] == 0xD8
+        // Defensive: a cinfo can be reused for a fresh self-contained
+        // JPEG whose own DQT/DHT make a stale prefix splice incorrect.
+        // Skip the splice when the input already carries its own tables
+        // — `Decoder::new` parses it normally.
+        && !input_has_own_tables(raw_bytes);
+    if needs_splice {
+        // SAFETY (logical, not unsafe): `raw_bytes` borrows from
+        // `priv_state.source.as_bytes()`. We're about to replace that
+        // backing buffer, so build the combined Vec first via owned
+        // copies; then assign.
+        let prefix_clone: Vec<u8> = priv_state.tables_only_prefix.as_deref().unwrap().to_vec();
+        let strip_body: Vec<u8> = raw_bytes[2..].to_vec();
+        let mut combined: Vec<u8> = Vec::with_capacity(prefix_clone.len() + strip_body.len());
+        combined.extend_from_slice(&prefix_clone);
+        combined.extend_from_slice(&strip_body);
+        priv_state.source = JpegSource::Owned(combined);
+    }
+    let bytes: &[u8] = match priv_state.source.as_bytes() {
+        Some(b) if b.len() >= 2 => b,
+        _ => {
+            priv_state.last_error =
+                CString::new("jpeg_read_header: no JPEG source after splice").unwrap_or_default();
             return JPEG_SUSPENDED;
         }
     };

--- a/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
+++ b/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
@@ -4066,7 +4066,27 @@ pub extern "C" fn jpeg_consume_input(cinfo: *mut c_void) -> c_int {
                     c2.global_state = DSTATE_SCANNING;
                     JPEG_REACHED_SOS
                 }
-                JPEG_HEADER_TABLES_ONLY => JPEG_REACHED_EOI,
+                JPEG_HEADER_TABLES_ONLY => {
+                    // Mirror stock libjpeg's `inputctl->eoi_reached = TRUE`
+                    // for tables-only inputs by advancing past
+                    // `DSTATE_SCANNING` so `jpeg_input_complete` returns
+                    // `TRUE`. Without this, a documented buffered-image
+                    // polling loop —
+                    //
+                    //     while (!jpeg_input_complete(&cinfo))
+                    //         (void) jpeg_consume_input(&cinfo);
+                    //
+                    // — never terminates on a tables-only datastream
+                    // because the EOI return below isn't observed by
+                    // `jpeg_input_complete`'s `global_state >=
+                    // DSTATE_SCANNING` gate. `jpeg_start_decompress`
+                    // re-asserts `DSTATE_SCANNING` regardless, so
+                    // skipping ahead does not stomp on a real image
+                    // header that arrives later (it can't — we just
+                    // returned EOI).
+                    c2.global_state = DSTATE_SCANNING;
+                    JPEG_REACHED_EOI
+                }
                 _ => JPEG_SUSPENDED,
             }
         }

--- a/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
+++ b/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
@@ -4039,7 +4039,14 @@ pub extern "C" fn jpeg_consume_input(cinfo: *mut c_void) -> c_int {
     }
     match c.global_state {
         DSTATE_START | DSTATE_INHEADER => {
-            let result: c_int = jpeg_read_header(cinfo, /*require_image=*/ 1);
+            // `require_image=FALSE`: stock libjpeg's `jpeg_consume_input`
+            // accepts a tables-only abbreviated datastream as a valid
+            // input — it returns `JPEG_REACHED_EOI` rather than raising
+            // `JERR_NO_IMAGE` (which is the public `jpeg_read_header(…,
+            // require_image=TRUE)` contract). Passing `0` here lets the
+            // tables-only branch return `JPEG_HEADER_TABLES_ONLY`, which
+            // the match arm below maps to `JPEG_REACHED_EOI`.
+            let result: c_int = jpeg_read_header(cinfo, /*require_image=*/ 0);
             // Re-read the state because `jpeg_read_header` mutated it.
             let c2: &mut JpegDecompressPublic = match unsafe { cinfo_mut(cinfo) } {
                 Some(c) => c,

--- a/crates/libjpeg-turbo-rs-capi/tests/capi_jpeg_read_header_tables_only.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/capi_jpeg_read_header_tables_only.rs
@@ -286,6 +286,7 @@ fn jpeg_consume_input_on_tables_only_returns_reached_eoi() {
     type StdErrorFn = unsafe extern "C" fn(*mut JpegErrorMgrLayout) -> *mut JpegErrorMgrLayout;
     type MemSrcFn = unsafe extern "C" fn(*mut c_void, *const u8, usize);
     type ConsumeFn = unsafe extern "C" fn(*mut c_void) -> c_int;
+    type InputCompleteFn = unsafe extern "C" fn(*mut c_void) -> c_int;
 
     let create: libloading::Symbol<CreateFn> =
         unsafe { lib.get(b"jpeg_CreateDecompress").unwrap() };
@@ -295,6 +296,8 @@ fn jpeg_consume_input_on_tables_only_returns_reached_eoi() {
     let mem_src: libloading::Symbol<MemSrcFn> = unsafe { lib.get(b"jpeg_mem_src").unwrap() };
     let consume_input: libloading::Symbol<ConsumeFn> =
         unsafe { lib.get(b"jpeg_consume_input").unwrap() };
+    let input_complete: libloading::Symbol<InputCompleteFn> =
+        unsafe { lib.get(b"jpeg_input_complete").unwrap() };
 
     GOT_CONSUME_ERROR_EXIT.store(0, Ordering::SeqCst);
 
@@ -331,6 +334,24 @@ fn jpeg_consume_input_on_tables_only_returns_reached_eoi() {
         "error_exit must NOT fire from jpeg_consume_input on a tables-only \
          input — got {} invocations",
         GOT_CONSUME_ERROR_EXIT.load(Ordering::SeqCst),
+    );
+
+    // The documented buffered-image polling loop is
+    //     while (!jpeg_input_complete(&cinfo))
+    //         (void) jpeg_consume_input(&cinfo);
+    // After consume_input returns JPEG_REACHED_EOI on a tables-only
+    // stream, the next jpeg_input_complete must return TRUE so the
+    // loop terminates. The shim mirrors stock libjpeg's
+    // `inputctl->eoi_reached = TRUE` by advancing
+    // `cinfo.global_state` past `DSTATE_SCANNING` in the
+    // `JPEG_HEADER_TABLES_ONLY` arm of `jpeg_consume_input`.
+    let complete: c_int = unsafe { input_complete(cinfo_ptr) };
+    assert_ne!(
+        complete, 0,
+        "jpeg_input_complete must return TRUE after a tables-only EOI return \
+         from jpeg_consume_input; otherwise the documented `while \
+         (!jpeg_input_complete) jpeg_consume_input(...)` polling loop \
+         spins forever"
     );
 
     unsafe { destroy(cinfo_ptr) };

--- a/crates/libjpeg-turbo-rs-capi/tests/capi_jpeg_read_header_tables_only.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/capi_jpeg_read_header_tables_only.rs
@@ -1,0 +1,259 @@
+//! P3-shim regression: `jpeg_read_header` must implement libjpeg.txt §6's
+//! tables-only abbreviated-datastream contract.
+//!
+//! Fixture: a hand-crafted SOI + DQT + DHT + EOI blob — the smallest
+//! syntactically-valid tables-only JPEG. The shim's `detect_tables_only`
+//! walks markers without descending into table semantics (it doesn't
+//! validate that DQT precision / destination is sensible, only that the
+//! marker stream contains no SOF/SOS), so a structurally-valid blob is
+//! sufficient to exercise both contract branches:
+//!
+//!   * `jpeg_read_header(cinfo, require_image=FALSE)` returns
+//!     `JPEG_HEADER_TABLES_ONLY` (= 2). The cached prefix can then be
+//!     spliced in front of subsequent strip data.
+//!   * `jpeg_read_header(cinfo, require_image=TRUE)` invokes
+//!     `cinfo->err->error_exit(cinfo)` with `msg_code = JERR_NO_IMAGE`
+//!     (upstream code 53 at `JPEG_LIB_VERSION=80`, verified empirically
+//!     via `cc -DJPEG_LIB_VERSION=80 -I references/libjpeg-turbo/src`)
+//!     and never returns `JPEG_HEADER_TABLES_ONLY`.
+//!
+//! TDD-verified. Removing the `if require_image != 0 { … invoke_error_exit
+//! (cinfo, 53); … }` block in `jpeg_read_header` makes
+//! `tables_only_with_require_image_true_invokes_jerr_no_image`
+//! red-fail with `error_exit fired 0 times, expected 1`.
+
+use std::ffi::c_int;
+use std::os::raw::{c_long, c_void};
+use std::sync::atomic::{AtomicI32, AtomicUsize, Ordering};
+
+use libloading::Library;
+
+const JMSG_STR_PARM_MAX: usize = 80;
+
+#[repr(C)]
+struct JpegErrorMgrLayout {
+    error_exit: Option<unsafe extern "C" fn(*mut c_void)>,
+    emit_message: Option<unsafe extern "C" fn(*mut c_void, c_int)>,
+    output_message: Option<unsafe extern "C" fn(*mut c_void)>,
+    format_message: Option<unsafe extern "C" fn(*mut c_void, *mut u8)>,
+    reset_error_mgr: Option<unsafe extern "C" fn(*mut c_void)>,
+    msg_code: c_int,
+    msg_parm: [u8; JMSG_STR_PARM_MAX],
+    trace_level: c_int,
+    num_warnings: c_long,
+    jpeg_message_table: *const *const u8,
+    last_jpeg_message: c_int,
+    addon_message_table: *const *const u8,
+    first_addon_message: c_int,
+    last_addon_message: c_int,
+}
+
+fn cdylib_path() -> std::path::PathBuf {
+    let workspace_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let candidates = [
+        workspace_root.join("target/release/liblibjpeg_turbo_rs_capi.dylib"),
+        workspace_root.join("target/release/liblibjpeg_turbo_rs_capi.so"),
+        workspace_root.join("target/release/libjpeg_turbo_rs_capi.dll"),
+    ];
+    for c in &candidates {
+        if c.exists() {
+            return c.clone();
+        }
+    }
+    let status = std::process::Command::new(env!("CARGO"))
+        .args(["build", "-p", "libjpeg-turbo-rs-capi", "--release"])
+        .current_dir(&workspace_root)
+        .status()
+        .expect("cargo build");
+    assert!(status.success(), "cargo build failed");
+    for c in &candidates {
+        if c.exists() {
+            return c.clone();
+        }
+    }
+    panic!("cdylib not found after build");
+}
+
+/// Hand-crafted tables-only JPEG: SOI + minimal DQT + minimal DHT + EOI.
+/// The DQT/DHT contents pass `detect_tables_only`'s structural check
+/// (which only walks marker headers, not table semantics).
+fn build_tables_only_blob() -> Vec<u8> {
+    let mut v: Vec<u8> = Vec::new();
+    // SOI.
+    v.extend_from_slice(&[0xFF, 0xD8]);
+    // DQT: 2 (len bytes) + 1 (Pq/Tq) + 64 (8-bit quant values) = 67 = 0x43.
+    v.extend_from_slice(&[0xFF, 0xDB, 0x00, 0x43, 0x00]);
+    v.extend(std::iter::repeat(16u8).take(64));
+    // DHT: 2 (len bytes) + 1 (Tc/Th) + 16 (bits[1..17]) + 12 (huffvals) = 31 = 0x1F.
+    v.extend_from_slice(&[0xFF, 0xC4, 0x00, 0x1F, 0x00]);
+    // bits[1..17] sums to 12 (one DC code at length 1, six at length 3,
+    // five at length 4 = 12). Any layout summing < 256 works for the
+    // structural walker.
+    v.extend_from_slice(&[
+        0x00, 0x01, 0x05, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00,
+    ]);
+    // 12 huffval entries (one per total bits-count above).
+    v.extend_from_slice(&[
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
+    ]);
+    // EOI.
+    v.extend_from_slice(&[0xFF, 0xD9]);
+    v
+}
+
+// Per-test atomics + per-test callbacks so cargo test's parallel runner
+// cannot race the two test paths through a shared callback.
+static GOT_FALSE_ERROR_EXIT: AtomicUsize = AtomicUsize::new(0);
+static GOT_FALSE_MSG_CODE: AtomicI32 = AtomicI32::new(0);
+static GOT_TRUE_ERROR_EXIT: AtomicUsize = AtomicUsize::new(0);
+static GOT_TRUE_MSG_CODE: AtomicI32 = AtomicI32::new(0);
+
+unsafe extern "C" fn track_false_error_exit(cinfo: *mut c_void) {
+    GOT_FALSE_ERROR_EXIT.fetch_add(1, Ordering::SeqCst);
+    if !cinfo.is_null() {
+        let err_pp: *const *mut JpegErrorMgrLayout = cinfo as *const *mut JpegErrorMgrLayout;
+        let err_ptr: *mut JpegErrorMgrLayout = err_pp.read();
+        if !err_ptr.is_null() {
+            GOT_FALSE_MSG_CODE.store((*err_ptr).msg_code, Ordering::SeqCst);
+        }
+    }
+}
+
+unsafe extern "C" fn track_true_error_exit(cinfo: *mut c_void) {
+    GOT_TRUE_ERROR_EXIT.fetch_add(1, Ordering::SeqCst);
+    if !cinfo.is_null() {
+        let err_pp: *const *mut JpegErrorMgrLayout = cinfo as *const *mut JpegErrorMgrLayout;
+        let err_ptr: *mut JpegErrorMgrLayout = err_pp.read();
+        if !err_ptr.is_null() {
+            GOT_TRUE_MSG_CODE.store((*err_ptr).msg_code, Ordering::SeqCst);
+        }
+    }
+}
+
+#[test]
+fn tables_only_with_require_image_false_returns_header_tables_only() {
+    let lib: Library = unsafe { Library::new(cdylib_path()).expect("dlopen cdylib") };
+
+    type CreateFn = unsafe extern "C" fn(*mut c_void, c_int, usize);
+    type DestroyFn = unsafe extern "C" fn(*mut c_void);
+    type StdErrorFn = unsafe extern "C" fn(*mut JpegErrorMgrLayout) -> *mut JpegErrorMgrLayout;
+    type MemSrcFn = unsafe extern "C" fn(*mut c_void, *const u8, usize);
+    type ReadHeaderFn = unsafe extern "C" fn(*mut c_void, c_int) -> c_int;
+
+    let create: libloading::Symbol<CreateFn> =
+        unsafe { lib.get(b"jpeg_CreateDecompress").unwrap() };
+    let destroy: libloading::Symbol<DestroyFn> =
+        unsafe { lib.get(b"jpeg_destroy_decompress").unwrap() };
+    let std_error: libloading::Symbol<StdErrorFn> = unsafe { lib.get(b"jpeg_std_error").unwrap() };
+    let mem_src: libloading::Symbol<MemSrcFn> = unsafe { lib.get(b"jpeg_mem_src").unwrap() };
+    let read_header: libloading::Symbol<ReadHeaderFn> =
+        unsafe { lib.get(b"jpeg_read_header").unwrap() };
+
+    GOT_FALSE_ERROR_EXIT.store(0, Ordering::SeqCst);
+    GOT_FALSE_MSG_CODE.store(0, Ordering::SeqCst);
+
+    let mut err: JpegErrorMgrLayout = unsafe { std::mem::zeroed() };
+    unsafe { std_error(&mut err as *mut _) };
+    err.error_exit = Some(track_false_error_exit);
+
+    // Allocate cinfo as a 4 KiB buffer (well above the JpegDecompressPublic
+    // size). Initialize the err slot at offset 0; the rest is initialised
+    // by jpeg_CreateDecompress.
+    let mut cinfo_buf: [u8; 4096] = [0u8; 4096];
+    unsafe {
+        let err_slot: *mut *mut JpegErrorMgrLayout =
+            cinfo_buf.as_mut_ptr() as *mut *mut JpegErrorMgrLayout;
+        err_slot.write(&mut err as *mut _);
+    }
+    let cinfo_ptr: *mut c_void = cinfo_buf.as_mut_ptr() as *mut c_void;
+
+    // JPEG_LIB_VERSION = 80, struct size: pass actual JpegDecompressPublic size.
+    // 4096 is conservative — any value >= the real struct size is accepted.
+    unsafe { create(cinfo_ptr, 80, 4096) };
+
+    let blob: Vec<u8> = build_tables_only_blob();
+    unsafe { mem_src(cinfo_ptr, blob.as_ptr(), blob.len()) };
+
+    // require_image = FALSE (= 0).
+    let ret: c_int = unsafe { read_header(cinfo_ptr, 0) };
+
+    assert_eq!(
+        ret, 2,
+        "expected JPEG_HEADER_TABLES_ONLY (= 2), got {}",
+        ret
+    );
+    assert_eq!(
+        GOT_FALSE_ERROR_EXIT.load(Ordering::SeqCst),
+        0,
+        "error_exit must NOT fire on require_image=FALSE — got {} invocations",
+        GOT_FALSE_ERROR_EXIT.load(Ordering::SeqCst),
+    );
+
+    unsafe { destroy(cinfo_ptr) };
+}
+
+#[test]
+fn tables_only_with_require_image_true_invokes_jerr_no_image() {
+    let lib: Library = unsafe { Library::new(cdylib_path()).expect("dlopen cdylib") };
+
+    type CreateFn = unsafe extern "C" fn(*mut c_void, c_int, usize);
+    type DestroyFn = unsafe extern "C" fn(*mut c_void);
+    type StdErrorFn = unsafe extern "C" fn(*mut JpegErrorMgrLayout) -> *mut JpegErrorMgrLayout;
+    type MemSrcFn = unsafe extern "C" fn(*mut c_void, *const u8, usize);
+    type ReadHeaderFn = unsafe extern "C" fn(*mut c_void, c_int) -> c_int;
+
+    let create: libloading::Symbol<CreateFn> =
+        unsafe { lib.get(b"jpeg_CreateDecompress").unwrap() };
+    let destroy: libloading::Symbol<DestroyFn> =
+        unsafe { lib.get(b"jpeg_destroy_decompress").unwrap() };
+    let std_error: libloading::Symbol<StdErrorFn> = unsafe { lib.get(b"jpeg_std_error").unwrap() };
+    let mem_src: libloading::Symbol<MemSrcFn> = unsafe { lib.get(b"jpeg_mem_src").unwrap() };
+    let read_header: libloading::Symbol<ReadHeaderFn> =
+        unsafe { lib.get(b"jpeg_read_header").unwrap() };
+
+    GOT_TRUE_ERROR_EXIT.store(0, Ordering::SeqCst);
+    GOT_TRUE_MSG_CODE.store(0, Ordering::SeqCst);
+
+    let mut err: JpegErrorMgrLayout = unsafe { std::mem::zeroed() };
+    unsafe { std_error(&mut err as *mut _) };
+    err.error_exit = Some(track_true_error_exit);
+
+    let mut cinfo_buf: [u8; 4096] = [0u8; 4096];
+    unsafe {
+        let err_slot: *mut *mut JpegErrorMgrLayout =
+            cinfo_buf.as_mut_ptr() as *mut *mut JpegErrorMgrLayout;
+        err_slot.write(&mut err as *mut _);
+    }
+    let cinfo_ptr: *mut c_void = cinfo_buf.as_mut_ptr() as *mut c_void;
+
+    unsafe { create(cinfo_ptr, 80, 4096) };
+
+    let blob: Vec<u8> = build_tables_only_blob();
+    unsafe { mem_src(cinfo_ptr, blob.as_ptr(), blob.len()) };
+
+    // require_image = TRUE (= 1).
+    let _ret: c_int = unsafe { read_header(cinfo_ptr, 1) };
+
+    assert_eq!(
+        GOT_TRUE_ERROR_EXIT.load(Ordering::SeqCst),
+        1,
+        "error_exit must be invoked exactly once on require_image=TRUE + tables-only \
+         input — got {} invocations",
+        GOT_TRUE_ERROR_EXIT.load(Ordering::SeqCst),
+    );
+    assert_eq!(
+        GOT_TRUE_MSG_CODE.load(Ordering::SeqCst),
+        53,
+        "msg_code = {}, expected upstream JERR_NO_IMAGE (= 53 at JPEG_LIB_VERSION=80, \
+         verified empirically via cc -DJPEG_LIB_VERSION=80 against jerror.h)",
+        GOT_TRUE_MSG_CODE.load(Ordering::SeqCst),
+    );
+
+    unsafe { destroy(cinfo_ptr) };
+}

--- a/crates/libjpeg-turbo-rs-capi/tests/capi_jpeg_read_header_tables_only.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/capi_jpeg_read_header_tables_only.rs
@@ -108,11 +108,12 @@ fn build_tables_only_blob() -> Vec<u8> {
 }
 
 // Per-test atomics + per-test callbacks so cargo test's parallel runner
-// cannot race the two test paths through a shared callback.
+// cannot race the test paths through a shared callback.
 static GOT_FALSE_ERROR_EXIT: AtomicUsize = AtomicUsize::new(0);
 static GOT_FALSE_MSG_CODE: AtomicI32 = AtomicI32::new(0);
 static GOT_TRUE_ERROR_EXIT: AtomicUsize = AtomicUsize::new(0);
 static GOT_TRUE_MSG_CODE: AtomicI32 = AtomicI32::new(0);
+static GOT_CONSUME_ERROR_EXIT: AtomicUsize = AtomicUsize::new(0);
 
 unsafe extern "C" fn track_false_error_exit(cinfo: *mut c_void) {
     GOT_FALSE_ERROR_EXIT.fetch_add(1, Ordering::SeqCst);
@@ -134,6 +135,10 @@ unsafe extern "C" fn track_true_error_exit(cinfo: *mut c_void) {
             GOT_TRUE_MSG_CODE.store((*err_ptr).msg_code, Ordering::SeqCst);
         }
     }
+}
+
+unsafe extern "C" fn track_consume_error_exit(_cinfo: *mut c_void) {
+    GOT_CONSUME_ERROR_EXIT.fetch_add(1, Ordering::SeqCst);
 }
 
 #[test]
@@ -253,6 +258,79 @@ fn tables_only_with_require_image_true_invokes_jerr_no_image() {
         "msg_code = {}, expected upstream JERR_NO_IMAGE (= 53 at JPEG_LIB_VERSION=80, \
          verified empirically via cc -DJPEG_LIB_VERSION=80 against jerror.h)",
         GOT_TRUE_MSG_CODE.load(Ordering::SeqCst),
+    );
+
+    unsafe { destroy(cinfo_ptr) };
+}
+
+/// Direct `jpeg_consume_input` on a tables-only stream must return
+/// `JPEG_REACHED_EOI` (= 2), NOT invoke `error_exit` with `JERR_NO_IMAGE`.
+/// Stock libjpeg's `jpeg_consume_input` (jdapimin.c) accepts a tables-only
+/// abbreviated datastream as a valid input — the `require_image` semantics
+/// only apply when the *public* `jpeg_read_header` is called by the
+/// consumer. The shim's internal call from `jpeg_consume_input` to
+/// `jpeg_read_header` must therefore pass `require_image=FALSE` so the
+/// tables-only branch returns `JPEG_HEADER_TABLES_ONLY`, which the
+/// `jpeg_consume_input` match arm maps to `JPEG_REACHED_EOI`.
+///
+/// Pre-fix history: codex stop-time review on the initial public-API
+/// `require_image=TRUE` wiring caught this regression because the
+/// internal call had been hard-coded to `require_image=1`. The fix
+/// rewrites that call to pass `0`.
+#[test]
+fn jpeg_consume_input_on_tables_only_returns_reached_eoi() {
+    let lib: Library = unsafe { Library::new(cdylib_path()).expect("dlopen cdylib") };
+
+    type CreateFn = unsafe extern "C" fn(*mut c_void, c_int, usize);
+    type DestroyFn = unsafe extern "C" fn(*mut c_void);
+    type StdErrorFn = unsafe extern "C" fn(*mut JpegErrorMgrLayout) -> *mut JpegErrorMgrLayout;
+    type MemSrcFn = unsafe extern "C" fn(*mut c_void, *const u8, usize);
+    type ConsumeFn = unsafe extern "C" fn(*mut c_void) -> c_int;
+
+    let create: libloading::Symbol<CreateFn> =
+        unsafe { lib.get(b"jpeg_CreateDecompress").unwrap() };
+    let destroy: libloading::Symbol<DestroyFn> =
+        unsafe { lib.get(b"jpeg_destroy_decompress").unwrap() };
+    let std_error: libloading::Symbol<StdErrorFn> = unsafe { lib.get(b"jpeg_std_error").unwrap() };
+    let mem_src: libloading::Symbol<MemSrcFn> = unsafe { lib.get(b"jpeg_mem_src").unwrap() };
+    let consume_input: libloading::Symbol<ConsumeFn> =
+        unsafe { lib.get(b"jpeg_consume_input").unwrap() };
+
+    GOT_CONSUME_ERROR_EXIT.store(0, Ordering::SeqCst);
+
+    let mut err: JpegErrorMgrLayout = unsafe { std::mem::zeroed() };
+    unsafe { std_error(&mut err as *mut _) };
+    err.error_exit = Some(track_consume_error_exit);
+
+    let mut cinfo_buf: [u8; 4096] = [0u8; 4096];
+    unsafe {
+        let err_slot: *mut *mut JpegErrorMgrLayout =
+            cinfo_buf.as_mut_ptr() as *mut *mut JpegErrorMgrLayout;
+        err_slot.write(&mut err as *mut _);
+    }
+    let cinfo_ptr: *mut c_void = cinfo_buf.as_mut_ptr() as *mut c_void;
+
+    unsafe { create(cinfo_ptr, 80, 4096) };
+
+    let blob: Vec<u8> = build_tables_only_blob();
+    unsafe { mem_src(cinfo_ptr, blob.as_ptr(), blob.len()) };
+
+    let ret: c_int = unsafe { consume_input(cinfo_ptr) };
+
+    // JPEG_REACHED_EOI = 2.
+    assert_eq!(
+        ret, 2,
+        "expected JPEG_REACHED_EOI (= 2), got {} — the internal jpeg_read_header \
+         call from jpeg_consume_input must pass require_image=FALSE so a \
+         tables-only blob does not trigger JERR_NO_IMAGE",
+        ret,
+    );
+    assert_eq!(
+        GOT_CONSUME_ERROR_EXIT.load(Ordering::SeqCst),
+        0,
+        "error_exit must NOT fire from jpeg_consume_input on a tables-only \
+         input — got {} invocations",
+        GOT_CONSUME_ERROR_EXIT.load(Ordering::SeqCst),
     );
 
     unsafe { destroy(cinfo_ptr) };

--- a/crates/libjpeg-turbo-rs-capi/tests/libtiff_integration.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/libtiff_integration.rs
@@ -78,28 +78,21 @@ fn cdylib_path() -> PathBuf {
 /// Builds `examples/libtiff_integration/main.c`, runs it with our cdylib
 /// as the JPEG provider, and asserts exit 0.
 ///
-/// # Known failure (tracked)
-///
-/// When libtiff reads a COMPRESSION_JPEG TIFF it first calls
-/// `jpeg_read_header` on the `JPEGTables` tag (an abbreviated tables-only
-/// datastream: SOI + DQT + DHT + EOI, no SOF/SOS).  Our shim's
-/// `jpeg_read_header` passes this blob to `libjpeg_turbo_rs::Decoder::new`,
-/// which fails with "no SOF marker" because it requires a full image header.
-/// libtiff then reports "Bogus JPEGTables field" and aborts the decode.
-///
-/// The fix requires `jpeg_read_header` to detect a tables-only abbreviated
-/// datastream and return `JPEG_HEADER_TABLES_ONLY` (2) while stashing the
-/// parsed DQT/DHT tables in the decompressor's private state for later reuse.
-/// This is tracked as a follow-up bug; it is NOT a `jpeg_write_raw_data` /
-/// `jpeg_read_raw_data` correctness issue — both iMCU-row entry points are
-/// exercised correctly once libtiff reaches the actual strip data.
-///
-/// Run with `--include-ignored` to see the current failure output.
+/// libtiff's COMPRESSION_JPEG read path calls `jpeg_read_header` first on
+/// the TIFF `JPEGTables` tag (an abbreviated tables-only datastream:
+/// SOI + DQT + DHT + EOI, no SOF/SOS) and expects
+/// `JPEG_HEADER_TABLES_ONLY` (= 2). The shim's `jpeg_read_header` walks
+/// markers manually to detect the absence of SOF/SOS, stashes the
+/// (EOI-stripped) bytes in `priv_state.tables_only_prefix`, resets the
+/// drained source so the next call re-reads from the caller's source
+/// manager, and returns `JPEG_HEADER_TABLES_ONLY`. On the subsequent
+/// per-strip `jpeg_read_header` call the prefix is spliced in front of
+/// the strip body (after dropping the strip's own SOI) so
+/// `Decoder::new` sees a complete tables+image stream — see the
+/// implementation in `crates/libjpeg-turbo-rs-capi/src/jpeglib.rs`'s
+/// `detect_tables_only` helper plus the splice block in
+/// `jpeg_read_header`.
 #[test]
-#[ignore = "known shim gap: jpeg_read_header does not handle JPEG_HEADER_TABLES_ONLY \
-            (abbreviated tables-only datastream); libtiff JPEG decode fails with \
-            'Bogus JPEGTables field' — tracked as follow-up; \
-            run with --include-ignored to verify the failure mode"]
 fn libtiff_jpeg_roundtrip_via_shim() {
     // Skip on Windows — the SONAME / loader-path scheme is POSIX-only.
     if cfg!(target_os = "windows") {

--- a/docs/LAST_MILE.md
+++ b/docs/LAST_MILE.md
@@ -16,7 +16,7 @@ Project is **replacement-ready** for the Rust-application + stock-tool drop-in s
 
 | Check | Result |
 | --- | --- |
-| `cargo test --workspace --release` | **Passes** — 2158 tests, 0 failures, 0 ignored. |
+| `cargo test --workspace --release` | **Passes** — 2160 tests, 0 failures, 0 ignored. |
 | `cargo test -p libjpeg-turbo-rs --test cross_product_transform` | **Passes** all 12 cases. P0-1 closed. |
 | `cargo test -p libjpeg-turbo-rs --test regression_progressive_4pixel_chroma_transform` | **Passes** 256 cases byte-exact vs `jpegtran -progressive -copy all <op>`. P3-4 closed. |
 | `cargo test --test cross_check_p3_6_nonstandard_rgb565` | **Passes** 4 fixtures: 3x2 decode (vs `djpeg`), 3x2 encode (vs `cjpeg -sample 3x2,1x1,1x1` + `djpeg`), 3x1 decode, RGB565 merged-upsample (vs `djpeg -nosmooth` + 5-6-5 truncate chain). P3-6 closed. |

--- a/docs/LAST_MILE.md
+++ b/docs/LAST_MILE.md
@@ -16,7 +16,7 @@ Project is **replacement-ready** for the Rust-application + stock-tool drop-in s
 
 | Check | Result |
 | --- | --- |
-| `cargo test --workspace --release` | **Passes** — 2157 tests, 0 failures, 1 ignored (one slow release-only stress test). |
+| `cargo test --workspace --release` | **Passes** — 2158 tests, 0 failures, 0 ignored. |
 | `cargo test -p libjpeg-turbo-rs --test cross_product_transform` | **Passes** all 12 cases. P0-1 closed. |
 | `cargo test -p libjpeg-turbo-rs --test regression_progressive_4pixel_chroma_transform` | **Passes** 256 cases byte-exact vs `jpegtran -progressive -copy all <op>`. P3-4 closed. |
 | `cargo test --test cross_check_p3_6_nonstandard_rgb565` | **Passes** 4 fixtures: 3x2 decode (vs `djpeg`), 3x2 encode (vs `cjpeg -sample 3x2,1x1,1x1` + `djpeg`), 3x1 decode, RGB565 merged-upsample (vs `djpeg -nosmooth` + 5-6-5 truncate chain). P3-6 closed. |
@@ -26,6 +26,7 @@ Project is **replacement-ready** for the Rust-application + stock-tool drop-in s
 | `cargo test --test capi_pillow_compat` | **Passes** — Pillow round-trip @ q=90 PSNR 49.49 dB. P0-3 closed. |
 | `cargo test -p libjpeg-turbo-rs-capi --test tjunittest_link` | **Passes** without `--include-ignored`. |
 | `cargo test -p libjpeg-turbo-rs-capi --test abi_offsets --release` | **Passes** all 6 cross-checks: `jpeg_decompress_struct` (P2-4) + `jpeg_marker_struct` + `jpeg_compress_struct` + `jpeg_error_mgr` + `jpeg_source_mgr` + `jpeg_destination_mgr` against upstream `jpeglib.h` at `JPEG_LIB_VERSION=80`. P3-1 closed. |
+| `cargo test -p libjpeg-turbo-rs-capi --test libtiff_integration --release` | **Passes** end-to-end libtiff COMPRESSION_JPEG round-trip via the cdylib (skips with reason if libtiff/cc are absent). The shim's `jpeg_read_header` walks markers manually to detect tables-only abbreviated datastreams (libjpeg.txt §6) and splices the cached prefix in front of each strip's body so `Decoder::new` parses the unified stream. Previously `#[ignore]`d as a known shim gap; un-ignored 2026-05-09. |
 
 ---
 

--- a/docs/LAST_MILE.md
+++ b/docs/LAST_MILE.md
@@ -16,7 +16,7 @@ Project is **replacement-ready** for the Rust-application + stock-tool drop-in s
 
 | Check | Result |
 | --- | --- |
-| `cargo test --workspace --release` | **Passes** — 2160 tests, 0 failures, 0 ignored. |
+| `cargo test --workspace --release` | **Passes** — 2161 tests, 0 failures, 0 ignored. |
 | `cargo test -p libjpeg-turbo-rs --test cross_product_transform` | **Passes** all 12 cases. P0-1 closed. |
 | `cargo test -p libjpeg-turbo-rs --test regression_progressive_4pixel_chroma_transform` | **Passes** 256 cases byte-exact vs `jpegtran -progressive -copy all <op>`. P3-4 closed. |
 | `cargo test --test cross_check_p3_6_nonstandard_rgb565` | **Passes** 4 fixtures: 3x2 decode (vs `djpeg`), 3x2 encode (vs `cjpeg -sample 3x2,1x1,1x1` + `djpeg`), 3x1 decode, RGB565 merged-upsample (vs `djpeg -nosmooth` + 5-6-5 truncate chain). P3-6 closed. |


### PR DESCRIPTION
## Summary

Wires libjpeg.txt §6's tables-only abbreviated-datastream contract into the shim's `jpeg_read_header`, un-ignoring the `libtiff_jpeg_roundtrip_via_shim` test and bringing the workspace gate to **2161 passed / 0 failed / 0 ignored** (was: 2157 / 0 / 1; the lone ignored test was this libtiff shim gap, mis-described in `LAST_MILE.md` as a "slow stress test").

libtiff's COMPRESSION_JPEG read path calls `jpeg_read_header` first on the TIFF `JPEGTables` tag (an SOI + DQT/DHT + EOI blob, no SOF/SOS) and expects `JPEG_HEADER_TABLES_ONLY` (= 2). Pre-fix the shim passed the bare blob to `libjpeg_turbo_rs::Decoder::new`, which rejected it as "no SOF marker" → libtiff reported "Bogus JPEGTables field" and aborted strip decode.

## Implementation

* `detect_tables_only(bytes)` — walks markers from SOI, accepts DQT/DHT/DAC/COM/APPn/DRI + RST0..RST7/TEM (no payload), rejects SOF (`FF C0..FF CF` minus DHT/DAC/JPG) / SOS (`FF DA`) / malformed lengths / truncated input. Skips `FF FF` filler. Returns the input minus the trailing `FF D9` (EOI) so the prefix can be spliced in front of a strip body that drops its own SOI.
* New `DecompressPrivate.tables_only_prefix: Option<Vec<u8>>` (default `None`) holds the stripped prefix between calls. Persists across per-strip `jpeg_finish_decompress` / `jpeg_abort_decompress` so each subsequent strip splices against the same cached tables — the abort path already resets `priv_state.source = None`, which drives the next `jpeg_read_header` to re-drain the source manager.
* `jpeg_read_header`:
  - `require_image == TRUE` + tables-only input → invoke `error_exit` with `JERR_NO_IMAGE` (upstream code 53 at `JPEG_LIB_VERSION=80`, verified empirically via `cc -DJPEG_LIB_VERSION=80 -I references/libjpeg-turbo/src` against `jerror.h`). Mirrors stock libjpeg's `jdapimin.c::jpeg_read_header` contract.
  - `require_image == FALSE` + tables-only input → stash the prefix (replacing any prior cached prefix on a reused cinfo), reset `priv_state.source = JpegSource::None` so the next call re-drains the (now strip-pointing) source manager, return `JPEG_HEADER_TABLES_ONLY`.
  - Cached prefix + bytes start with `FF D8` → splice prefix + `raw_bytes[2..]` into a fresh owned `Vec<u8>` and persist as `priv_state.source = JpegSource::Owned(...)` so the rest of the decode path reads the unified stream. Splice is unconditional on prefix-presence per libjpeg's "most recent table in source order wins" contract — partial abbreviated images (some tables present, some inherited) and even fully self-contained reuse are handled correctly because the image's own tables override their counterparts.
* `jpeg_consume_input` internal call to `jpeg_read_header` now passes `require_image=FALSE` so a tables-only input returns `JPEG_HEADER_TABLES_ONLY` (mapped to `JPEG_REACHED_EOI`) rather than raising `JERR_NO_IMAGE`. The `JPEG_HEADER_TABLES_ONLY` arm advances `cinfo.global_state` past `DSTATE_SCANNING` so `jpeg_input_complete` returns TRUE — the documented `while (!jpeg_input_complete) jpeg_consume_input(...)` polling loop now terminates on tables-only inputs (mirrors stock `inputctl->eoi_reached = TRUE`).

## Codex iteration

The first commit shipped only the libtiff path. Codex stop-time review then flagged:

1. `require_image=TRUE` not honored on tables-only → added `JERR_NO_IMAGE` branch.
2. `is_none()` gate suppressed re-detection on a reused cinfo → removed.
3. Defensive `input_has_own_tables` guard broke partial abbreviated images → removed; splice unconditionally.
4. After (1), `jpeg_consume_input`'s internal `jpeg_read_header(cinfo, 1)` started raising `JERR_NO_IMAGE` on tables-only → changed to `(cinfo, 0)`.
5. After (4), `jpeg_consume_input → JPEG_REACHED_EOI` left `global_state` below `DSTATE_SCANNING` → polling loops spun forever; added `c2.global_state = DSTATE_SCANNING` in the tables-only arm.

Final round: codex review reports **no actionable regressions**.

## Tests

`crates/libjpeg-turbo-rs-capi/tests/capi_jpeg_read_header_tables_only.rs` (new):

* `tables_only_with_require_image_false_returns_header_tables_only` — hand-crafted SOI + minimal DQT + minimal DHT + EOI blob via `jpeg_mem_src`; asserts return = 2 and `error_exit` not invoked.
* `tables_only_with_require_image_true_invokes_jerr_no_image` — same fixture + `require_image=TRUE`; asserts `error_exit` fires once with `msg_code = 53`.
* `jpeg_consume_input_on_tables_only_returns_reached_eoi` — same fixture; asserts `jpeg_consume_input` returns 2 (`JPEG_REACHED_EOI`), `error_exit` not invoked, and post-call `jpeg_input_complete` returns TRUE.

`crates/libjpeg-turbo-rs-capi/tests/libtiff_integration.rs` — un-ignored. End-to-end TIFF round-trip (TIFFWriteEncodedStrip + TIFFReadEncodedStrip on a 64x64 RGB / Q=75 / 8-row-strip image) now passes through the cdylib with `max_diff` well under the 32-LSB tolerance.

TDD-verified each codex fix via mutation A/B (revert the fix → corresponding test red-fails; restore → green).

## Verification

- `cargo test -p libjpeg-turbo-rs-capi --test capi_jpeg_read_header_tables_only --release` → 3/3 green.
- `cargo test -p libjpeg-turbo-rs-capi --test libtiff_integration --release` → 1/1 green (was: red-fail with `Bogus JPEGTables field`).
- `cargo test -p libjpeg-turbo-rs-capi --test abi_offsets --release` → 6/6 green (no struct layout regression).
- `cargo test --workspace --release --no-fail-fast` → `passed=2161 failed=0 ignored=0`.
- `cargo fmt --all --check`, `cargo clippy --lib --release -- -D warnings` clean.

## Doc updates

- `docs/LAST_MILE.md` live gate: `2157 tests, 0 failures, 1 ignored (one slow release-only stress test)` → `2161 tests, 0 failures, 0 ignored`. The "slow stress test" caveat was wrong text — the actual ignored test was this libtiff shim gap. New live-gate row added for `cargo test ... libtiff_integration` (skips with reason if libtiff/cc absent; passes when present).

## Test plan

- [x] Three new unit tests pin the contract corners (require_image false/true, consume_input loop termination).
- [x] libtiff integration test un-ignored and green.
- [x] Mutation A/B verified teeth on each codex-flagged path.
- [x] Workspace gate at 2161/0/0 — first time the shim has zero ignored tests.
- [ ] CI matrix green on Linux x86_64 / macOS / Windows (libtiff test skips with reason on platforms without libtiff/cc; structural tests run everywhere).

Refs: closes the historical `libtiff_jpeg_roundtrip_via_shim #[ignore]` (was tracked as a known shim gap in libjpeg.txt §6 abbreviated datastream support); brings workspace gate to a clean zero-ignored state.