### PR TITLE
fix(bench): add float_divisors fields to QuantDivisors literal

### DIFF
--- a/benches/encode.rs
+++ b/benches/encode.rs
@@ -33,6 +33,11 @@ fn bench_fdct_quantize_8x8(c: &mut Criterion) {
         shifts_zigzag[i] = shifts[i];
         scales_zigzag[i] = scales[i];
     }
+    // Float divisors mirror `1 / (quant * 8)` — irrelevant for the
+    // integer `fdct_quantize` benchmarked here, but the struct is
+    // shared with the float-FDCT path so all fields must be filled.
+    let float_divisors = [1.0f32 / 128.0f32; 64];
+    let float_divisors_zigzag = float_divisors;
     let quant = QuantDivisors {
         divisors,
         reciprocals,
@@ -44,6 +49,8 @@ fn bench_fdct_quantize_8x8(c: &mut Criterion) {
         corrections_zigzag,
         shifts_zigzag,
         scales_zigzag,
+        float_divisors,
+        float_divisors_zigzag,
     };
     let mut output = [0i16; 64];
 


### PR DESCRIPTION
## Summary

`benches/encode.rs::bench_fdct_quantize_8x8` constructs a `QuantDivisors` struct via a hand-written literal. Two new fields landed on the struct when the float-FDCT path was added (`forward_DCT_float` parity for `cjpeg -dc fa`) — `float_divisors: [f32; 64]` and `float_divisors_zigzag: [f32; 64]` — but the bench was never updated, so it stopped compiling against `main`:

```
error[E0063]: missing fields `float_divisors` and `float_divisors_zigzag` in initializer of `QuantDivisors`
```

`cargo build --bench encode` is not part of CI's clippy / test gate (those use `--lib`), so the regression went un-noticed until the perf matrix re-run today.

## Fix

Pad both fields with `1.0/128.0` (the inverse of the `divisors` constant 128 used by the existing literal). The benchmarked codepath `(enc.fdct_quantize)(...)` is the integer path and doesn't read the float fields, so the values are inert; the struct literal type-checks again.

```rust
let float_divisors = [1.0f32 / 128.0f32; 64];
let float_divisors_zigzag = float_divisors;
let quant = QuantDivisors {
    divisors,
    reciprocals,
    corrections,
    shifts,
    scales,
    divisors_zigzag,
    reciprocals_zigzag,
    corrections_zigzag,
    shifts_zigzag,
    scales_zigzag,
    float_divisors,
    float_divisors_zigzag,
};
```

## Verification

- `cargo build --release --bench encode` clean (was: hard-fail).
- `cargo bench --bench encode` runs the full matrix on x86_64 — `fdct_quantize_8x8` reports 48.02 ns, in line with prior `experiments/encode.tsv` entries.

## Why this lived

`QuantDivisors` is normally constructed by `compute_quant_divisors` (for the encoder pipeline), which always fills every field. The hand-rolled literal in the bench is the only out-of-tree initialiser, and `cargo build --lib` / `cargo clippy --lib` never see it. The pre-commit hook + main-branch CI both gate on `--lib` only, so the bench compile error sat on `main` undetected. A future cleanup could either:
- Constrain CI to also run `cargo build --benches`, or
- Replace the literal with a call to the existing constructor.

This PR ships the minimal fix; the cleanup is left as a follow-up.