### PR TITLE
perf(idct): restore SIMD pure-DC pixel-fill shortcut, recover graphic-content regression

### DIFF
--- a/experiments/perf_2026-05-09_x86_64.md
+++ b/experiments/perf_2026-05-09_x86_64.md
@@ -1,0 +1,81 @@
+# Performance Matrix — 2026-05-09 (x86_64 baseline at main b2ef66e)
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Host | `yonghye-pc` (Linux 6.17, Ubuntu 24.04) |
+| CPU | Intel Core i5-10400 (Comet Lake, AVX2) |
+| Governor | `powersave` (sudo not available — variance may be slightly higher) |
+| Turbo | enabled (`no_turbo=0`) |
+| C reference | libjpeg-turbo `2.1.5` (`/usr/lib/x86_64-linux-gnu`) |
+| Rust toolchain | stable (default features = `simd`) |
+| Branch | `fix/encode-bench-float-divisors-fields` (= `main` + bench compile fix) |
+
+## Decode matrix — Rust vs C
+
+All times in microseconds. Rust column is criterion's median; C column is `bench_c_decode_linux` arithmetic mean. Ratio = Rust / C (lower is better; 1.00× means parity).
+
+| Fixture | Size | C (µs) | Rust (µs) | Ratio |
+| --- | --- | ---: | ---: | ---: |
+| photo_64x64_420 | 64×64 | 32.8 | 47.27 | 1.44× |
+| photo_320x240_420 | 320×240 | 524.2 | 514.86 | 0.98× |
+| decode_640x480 (gradient) | 640×480 | 593.8 | 639.33 | 1.08× |
+| photo_1280x720_420 | 1280×720 | 6 156.5 | 5 741.2 | 0.93× |
+| photo_1920x1080_420 | 1920×1080 | 13 857.3 | 12 904 | 0.93× |
+| photo_2560x1440_420 | 2560×1440 | 24 558.8 | 23 161 | 0.94× |
+| photo_3840x2160_420 | 3840×2160 | 55 170.4 | 52 162 | 0.95× |
+| photo_640x480_444 | 640×480 | 3 485.4 | 3 169.5 | 0.91× |
+| photo_640x480_422 | 640×480 | 2 290.5 | 2 153.5 | 0.94× |
+| photo_1920x1080_444 | 1920×1080 | 26 635.4 | 24 524 | 0.92× |
+| photo_1920x1080_422 | 1920×1080 | 17 545.1 | 16 662 | 0.95× |
+| graphic_640x480_420 | 640×480 | 531.2 | 532.28 | 1.00× |
+| checker_640x480_420 | 640×480 | 1 169.4 | 1 108.6 | 0.95× |
+| graphic_1920x1080_420 | 1920×1080 | 2 745.2 | 2 485 | 0.91× |
+| photo_640x480_420_rst (restart) | 640×480 | 565.4 | 514.55 | 0.91× |
+| **prog_640x480_444** | 640×480 | 8 693.7 | 8 468.3 | 0.97× |
+| **prog_640x480_422** | 640×480 | 5 917.2 | 5 800.8 | 0.98× |
+| **prog_1920x1080_420** | 1920×1080 | 37 681.8 | 36 536 | 0.97× |
+| **prog_1920x1080_444** | 1920×1080 | 72 650.7 | 66 785 | 0.92× |
+| **prog_3840x2160_420** | 3840×2160 | 152 921.4 | 148 880 | 0.97× |
+
+**Summary**: Rust decode is **at parity or faster than C** on 19 / 20 cases. The single regression (photo_64x64_420 at 1.44×) is fixed-overhead-dominated — at 47 µs / 33 µs the absolute delta is 14 µs, mostly criterion measurement framing on a tiny image.
+
+Geometric mean ratio (excluding the 64×64 outlier): **0.95×** — Rust is 5% faster than C libjpeg-turbo across the matrix.
+
+## Encode matrix — Rust vs C
+
+| Fixture | Size | Subsampling | C (µs) | Rust (µs) | Ratio |
+| --- | --- | --- | ---: | ---: | ---: |
+| 64x64 | 64×64 | 4:2:0 | 19.8 | — | (no Rust bench at 64×64) |
+| 320x240 | 320×240 | 4:2:0 | 274.7 | 292.13 | 1.06× |
+| 320x240 | 320×240 | 4:2:2 | 342.5 | 360.64 | 1.05× |
+| 320x240 | 320×240 | 4:4:4 | 512.6 | 538.70 | 1.05× |
+| 640x480 | 640×480 | 4:2:0 | 951.9 | — | (no Rust bench; closest 320×240) |
+| 640x480 | 640×480 | 4:2:2 | 1 167.0 | 1 224.7 | 1.05× |
+| 640x480 | 640×480 | 4:4:4 | 1 718.8 | 1 765.5 | 1.03× |
+| 1280x720 | 1280×720 | 4:2:0 | 3 165.5 | — | (no Rust bench) |
+| 1920x1080 | 1920×1080 | 4:2:0 | 7 116.8 | 7 846.5 | 1.10× |
+| 1920x1080 | 1920×1080 | 4:2:2 | 8 851.6 | 9 682.8 | 1.09× |
+| 1920x1080 | 1920×1080 | 4:4:4 | 13 456.3 | 14 440 | 1.07× |
+
+**Summary**: Rust encode runs ~1.05–1.10× of C across resolutions and subsamplings — the existing 7-10% gap to C is consistent with the latest entries in `experiments/encode.tsv` (interior MCU fast-path put 1080p at ~1.03–1.04× under controlled conditions). The `powersave` governor + remaining 64×64 / 640×480 / 1280×720 gaps in the bench matrix likely add a small drift here.
+
+## Microbench fixed-cost
+
+| Operation | Rust (ns) |
+| --- | --- |
+| `idct_8x8` | 27.83 |
+| `ycbcr_to_rgb_row_640` | 253.7 |
+| `fancy_h2v1_320` | 68.7 |
+| `decoder_new_640x480` | 18 621 |
+| `fdct_quantize_8x8` | 48.02 |
+| `rgb_to_ycbcr_row_320` | 150.9 |
+| `rgb_to_ycbcr_row_640` | 295.7 |
+| `rgb_to_ycbcr_row_1920` | 896.8 |
+
+## Notes
+
+1. **Bench file fix**: `benches/encode.rs` was missing the `float_divisors` / `float_divisors_zigzag` fields in the `QuantDivisors` struct literal — would not compile against current `main`. Fixed in branch `fix/encode-bench-float-divisors-fields` (PR pending).
+2. **Encode matrix gaps**: a few sizes appear in the C matrix but not in `benches/encode.rs` (64×64, 640×480 4:2:0, 1280×720 4:2:0). These could be added if the user wants direct ratio coverage at those sizes; current bench coverage is sufficient for the existing experiment-tracking workflow.
+3. **Stable-frequency caveat**: `sudo` was unavailable on the bench host so the governor stayed at `powersave` and turbo remained enabled. Per CLAUDE.md, `performance` governor + `no_turbo=1` would tighten variance; results should still be representative within ~3-5%.

--- a/experiments/perf_2026-05-10_post_idct_shortcut_removal_x86_64.md
+++ b/experiments/perf_2026-05-10_post_idct_shortcut_removal_x86_64.md
@@ -1,0 +1,97 @@
+# Performance Matrix — 2026-05-10 (post-IDCT-shortcut-removal, x86_64 at main 577546a)
+
+## Purpose
+
+Re-measure decode performance after PR #278 (commit `577546a`) removed the pure-DC pixel-fill shortcut from all four SIMD ISLOW IDCTs (NEON / SSE2 / AVX2 / WASM). The pre-fix baseline is `experiments/perf_2026-05-09_x86_64.md` taken at `b2ef66e` — same host, same C reference, same governor.
+
+The PR's review claimed *"aarch64 NEON: geomean 0.998× of pre-fix; no individual case regressed by more than 1.5%"* and *"x86_64 AVX2: geomean 0.997×; same matrix"*. **That claim was wrong on x86_64 graphic content** — see the table below.
+
+## Environment (matches 2026-05-09 baseline for apples-to-apples)
+
+| Item | Value |
+| --- | --- |
+| Host | `yonghye-pc` (Linux 6.17, Ubuntu 24.04) |
+| CPU | Intel Core i5-10400 (Comet Lake, AVX2) |
+| Governor | `powersave` (sudo not available — variance may be slightly higher) |
+| Turbo | enabled (`no_turbo=0`) |
+| C reference | libjpeg-turbo `2.1.5` (`/usr/lib/x86_64-linux-gnu`) |
+| Rust toolchain | stable, default features (`simd`) |
+| Branch | `main` @ `577546a` (= `b2ef66e` + IDCT shortcut removal) |
+
+## Decode matrix — post-fix vs pre-fix
+
+| Fixture | Pre (µs) | Post (µs) | Δ % | Note |
+| --- | ---: | ---: | ---: | --- |
+| photo_64x64_420 | 47.27 | 47.89 | +1.3% | noise |
+| photo_320x240_420 | 514.86 | 512.18 | -0.5% | noise |
+| decode_640x480 (gradient) | 639.33 | 636.82 | -0.4% | noise |
+| photo_1280x720_420 | 5741.2 | 5740.9 | 0% | |
+| photo_1920x1080_420 | 12904 | 12879 | -0.2% | |
+| photo_2560x1440_420 | 23161 | 23044 | -0.5% | |
+| photo_3840x2160_420 | 52162 | 51999 | -0.3% | |
+| photo_640x480_444 | 3169.5 | 3163.7 | -0.2% | |
+| photo_640x480_422 | 2153.5 | 2146.3 | -0.3% | |
+| photo_1920x1080_444 | 24524 | 24378 | -0.6% | |
+| photo_1920x1080_422 | 16662 | 16544 | -0.7% | |
+| **graphic_640x480_420** | **532.28** | **658.22** | **+23.7%** | **REGRESSION** |
+| **checker_640x480_420** | **1108.6** | **1155.8** | **+4.3%** | regression |
+| **graphic_1920x1080_420** | **2485** | **3492.9** | **+40.5%** | **REGRESSION** |
+| photo_640x480_420_rst | 514.55 | 513.35 | -0.2% | |
+| prog_640x480_444 | 8468.3 | 8417.3 | -0.6% | |
+| prog_640x480_422 | 5800.8 | 5783.1 | -0.3% | |
+| prog_1920x1080_420 | 36536 | 36466 | -0.2% | |
+| prog_1920x1080_444 | 66785 | 66619 | -0.2% | |
+| prog_3840x2160_420 | 148880 | 148650 | -0.2% | |
+
+## Diagnosis
+
+The regression localises exactly to the workloads where pure-DC blocks dominate:
+
+- **graphic content** (vector-art-style PNG re-encoded as JPEG; large solid regions): 24-41% slowdown
+- **checker content** (high-contrast 2-colour pattern; many constant-region 8×8 blocks): 4% slowdown
+- **photo content** (natural images, AC-rich blocks): no measurable change
+- **progressive content** (separate scans): no change — progressive's DC scan is non-SIMD path
+
+The pre-fix shortcut path was: `if (AC bitmap == 0) { compute DC scalar pixel value; vst1q_u8 splat to 8 bytes × 8 rows }`. Post-fix, every DC-only block flows through the full 4-column SIMD pass-1 + 4-column SIMD pass-2 pipeline. For a graphic image where ~60% of the 8×8 blocks are DC-only, that's ~60% of MCUs paying for 16 SIMD ops they didn't need before.
+
+## Severity
+
+The regression is real but **bounded to graphic-heavy workloads**:
+
+- Photo (the ~95% case for real-world JPEG): no impact.
+- Progressive (typical web content): no impact.
+- Graphic / banner / icon / chart content: 4-41% slower, but still under C in absolute terms — `graphic_1920x1080_420` was at 0.91× of C pre-fix (2485 vs C's 2745); post-fix it's at 1.27× (3493 vs 2745). C libjpeg-turbo's NEON/AVX2 ISLOW *also* has a pure-DC shortcut, so the comparison is no longer apples-to-apples in C's favour.
+
+## Follow-up: safe-guarded re-introduction
+
+The shortcut formula is bit-exact-equivalent to the full i16-lane pipeline **when `|coeff * quant|` fits in i16** — i.e. `coeff.unsigned_abs() as i32 * quant as i32 <= 0x7FFF`. Real-world JPEGs satisfy this for ~100% of blocks (typical Q-table DC quantizer is in [10,30], so coeff would need |2048+| to overflow — extremely rare in entropy-coded natural content).
+
+A safe re-introduction:
+
+```rust
+if ac_bitmap == 0 {
+    let dc_q_abs = (coeff[0].unsigned_abs() as u32) * (quant[0] as u32);
+    if dc_q_abs <= 0x7FFF {
+        // Safe: shortcut formula matches i16-lane pipeline bit-for-bit.
+        return dc_only_pixel_fill_shortcut(coeff[0], quant[0], output, stride);
+    }
+    // Adversarial input: fall through to full pipeline whose i16 lane
+    // wrap matches libjpeg-turbo's NEON/AVX2 ISLOW.
+}
+// Full pipeline ...
+```
+
+This recovers 100% of the graphic regression on real-world inputs while preserving correctness on the fuzz inputs that motivated the deletion.
+
+The follow-up belongs in a separate PR (one variable at a time per the experiment-tracking workflow). Tracked as a Phase 4 perf gap candidate.
+
+## Microbench fixed-cost (no change)
+
+| Operation | Pre (ns) | Post (ns) | Δ |
+| --- | ---: | ---: | ---: |
+| `idct_8x8` | 27.83 | 27.01 | -3% (noise) |
+| `ycbcr_to_rgb_row_640` | 253.7 | 250.4 | -1.3% |
+| `fancy_h2v1_320` | 68.7 | 68.8 | 0% |
+| `decoder_new_640x480` | 18621 | 18977 | +1.9% |
+
+The `idct_8x8` microbench uses a fixed photo-style coefficient block (no DC-only) so the shortcut never fired in either build. That's why this microbench is flat while end-to-end decode of graphic content regressed — the shortcut's value lives in the *distribution* of block types in real images, not in any single 8×8 block.

--- a/experiments/perf_2026-05-10_post_shortcut_restore_x86_64.md
+++ b/experiments/perf_2026-05-10_post_shortcut_restore_x86_64.md
@@ -1,0 +1,62 @@
+# Performance Matrix — 2026-05-10 (post-shortcut-restore, x86_64 at fix/idct-pure-dc-shortcut-safe-guard bb6ec77)
+
+## Purpose
+
+Verify that re-introducing the pure-DC pixel-fill shortcut with per-backend
+lane semantics recovers the graphic-content regression measured in
+`experiments/perf_2026-05-10_post_idct_shortcut_removal_x86_64.md`.
+
+## Environment
+
+Same as both prior 2026-05-09 / 2026-05-10 runs (Intel i5-10400, AVX2,
+`powersave` governor, libjpeg-turbo 2.1.5).
+
+## Decode matrix — three-way comparison
+
+| Fixture | Pre-PR278 (µs) | Post-PR278 (µs) | Restored (µs) | vs pre-PR278 |
+| --- | ---: | ---: | ---: | ---: |
+| photo_64x64_420 | 47.27 | 47.89 | 47.04 | -0.5% |
+| photo_320x240_420 | 514.86 | 512.18 | 517.87 | +0.6% |
+| decode_640x480 (gradient) | 639.33 | 636.82 | 643.67 | +0.7% |
+| photo_1280x720_420 | 5741 | 5741 | 5793 | +0.9% |
+| photo_1920x1080_420 | 12904 | 12879 | 12987 | +0.6% |
+| photo_2560x1440_420 | 23161 | 23044 | 23294 | +0.6% |
+| photo_3840x2160_420 | 52162 | 51999 | 52484 | +0.6% |
+| photo_640x480_444 | 3170 | 3164 | 3190 | +0.6% |
+| photo_640x480_422 | 2154 | 2146 | 2161 | +0.3% |
+| photo_1920x1080_444 | 24524 | 24378 | 24550 | +0.1% |
+| photo_1920x1080_422 | 16662 | 16544 | 16681 | +0.1% |
+| **graphic_640x480_420** | **532.28** | **658.22** | **534.61** | **+0.4%** ✓ |
+| **checker_640x480_420** | **1108.6** | **1155.8** | **1108.5** | **0.0%** ✓ |
+| **graphic_1920x1080_420** | **2485** | **3493** | **2500** | **+0.6%** ✓ |
+| photo_640x480_420_rst | 514.55 | 513.35 | 516.67 | +0.4% |
+| prog_640x480_444 | 8468 | 8417 | 8521 | +0.6% |
+| prog_640x480_422 | 5801 | 5783 | 5799 | -0.04% |
+| prog_1920x1080_420 | 36536 | 36466 | (full run) | — |
+| prog_1920x1080_444 | 66785 | 66619 | (full run) | — |
+| prog_3840x2160_420 | 148880 | 148650 | (full run) | — |
+
+Photo + progressive: within ±1% of pre-PR278 (run-to-run noise).
+Graphic + checker: **fully recovered** to within ±0.6% of pre-PR278.
+
+## Microbench fixed-cost (no change)
+
+| Operation | Pre-PR278 (ns) | Post-PR278 (ns) | Restored (ns) |
+| --- | ---: | ---: | ---: |
+| `idct_8x8` | 27.83 | 27.01 | 27.99 |
+| `ycbcr_to_rgb_row_640` | 253.7 | 250.4 | 251.5 |
+| `fancy_h2v1_320` | 68.7 | 68.8 | 68.6 |
+| `decoder_new_640x480` | 18621 | 18977 | 18550 |
+
+## Conclusion
+
+The AVX2 i16-wrap shortcut (`wrapping_mul` + `wrapping_shl(2)`) restores the
+PR #278 regression. C-libjpeg-turbo decode parity is maintained on graphic
+content (2.5 ms / 2.7 ms = 0.93× of C, matching pre-PR278). Photo and
+progressive decode unchanged.
+
+The SSE2 + WASM shortcuts in this same commit don't show in the bench
+(Comet Lake runtime dispatches AVX2), but their purpose is correctness for
+the SSE2-only CI matrix and WASM target. Codex review of the first
+restoration attempt caught a missing pass-2 `<< CONST_BITS` wrap in those
+backends; both were fixed before this perf log was published.

--- a/src/simd/aarch64/idct.rs
+++ b/src/simd/aarch64/idct.rs
@@ -102,6 +102,7 @@ unsafe fn neon_idct_islow_core(cptr: *const i16, qptr: *const i16, output: *mut 
 
     // --- Pass 1: columns, left 4×8 half ---
     // Fused load+dequant: vmul_s16(coeff, quant) during load
+    let mut left_dc_only = false;
     let mut ws_l = [0i16; 32];
     let mut ws_r = [0i16; 32];
 
@@ -124,6 +125,15 @@ unsafe fn neon_idct_islow_core(cptr: *const i16, qptr: *const i16, output: *mut 
             let ac_bitmap: i64 = vget_lane_s64(vreinterpret_s64_s16(bitmap_ac), 0);
 
             if ac_bitmap == 0 {
+                // Check if positions 1-3 of row0 are also zero (true DC-only
+                // in left half — only DC coefficient is non-zero). The flag
+                // is consumed by the right-half all-zero branch below to
+                // trigger a pixel-fill shortcut over the whole 8×8 block.
+                let row0_ac_mask = vcreate_s16(0xFFFF_FFFF_FFFF_0000u64);
+                let row0_ac = vand_s16(row0, row0_ac_mask);
+                let row0_ac_bits: i64 = vget_lane_s64(vreinterpret_s64_s16(row0_ac), 0);
+                left_dc_only = row0_ac_bits == 0;
+
                 let dcval = vshl_n_s16::<PASS1_BITS>(row0);
                 let quad: int16x4x4_t = int16x4x4_t(dcval, dcval, dcval, dcval);
                 vst4_s16(ws_l.as_mut_ptr(), quad);
@@ -183,20 +193,30 @@ unsafe fn neon_idct_islow_core(cptr: *const i16, qptr: *const i16, output: *mut 
             let right_all_bitmap: i64 = vget_lane_s64(vreinterpret_s64_s16(bitmap_all), 0);
 
             if right_all_bitmap == 0 {
-                // Entire right half is zero — skip, use sparse pass 2.
-                //
-                // Note: an earlier attempt added a `left_dc_only` pure-DC
-                // pixel-fill shortcut here, but it diverged from the full
-                // pipeline on adversarial inputs where `coeff * quant`
-                // overflows the i16 lane width that `vmul_s16` /
-                // `vshl_n_s16::<PASS1_BITS>` use throughout the rest of
-                // pass 1 + pass 2. Reproducing the wrap semantics in a
-                // scalar shortcut is fragile (codex review of d75924f
-                // caught the PASS1-shift wrap missed by the first round
-                // of fixes), so the shortcut was removed in favour of
-                // letting the full pipeline produce the canonical sample
-                // — its `vqrshrn_n_s16` + wrapping `vadd_u8` final stage
-                // is what libjpeg-turbo's NEON ISLOW does too.
+                if left_dc_only {
+                    // Pure-DC block: entire right half zero + left half
+                    // is DC-only. Skip pass 2 — fill output with the
+                    // single pixel value directly.
+                    //
+                    // i16 wrap throughout pass-1 (mirrors `vmul_s16` +
+                    // `vshl_n_s16::<PASS1_BITS>`), i32 from pass-2 onward.
+                    // The `wrapping_shl(2)` is what PR #278 deleted —
+                    // an earlier `(dq_i16 as i32) << 2` formulation
+                    // diverged from the i16-lane pipeline whenever
+                    // `|dq_i16| > 8191` (e.g. coeff=-2047, quant=17).
+                    let dq_i16: i16 = (*cptr).wrapping_mul(*qptr);
+                    let dq_shifted_i16: i16 = dq_i16.wrapping_shl(PASS1_BITS as u32);
+                    let pass1_i32: i32 = dq_shifted_i16 as i32;
+                    let pass2_i32: i32 =
+                        (pass1_i32 + (1 << (PASS1_BITS + 3 - 1))) >> (PASS1_BITS + 3);
+                    let pixel_val: u8 = (pass2_i32 + 128).clamp(0, 255) as u8;
+                    let fill: uint8x8_t = vdup_n_u8(pixel_val);
+                    for row in 0..8 {
+                        vst1_u8(output.add(row * stride), fill);
+                    }
+                    return;
+                }
+                // Entire right half is zero — skip, use sparse pass 2
                 right_all_zero = true;
             } else {
                 // DC-only in right half

--- a/src/simd/wasm32/idct.rs
+++ b/src/simd/wasm32/idct.rs
@@ -168,9 +168,20 @@ unsafe fn wasm_idct_islow_core(
         let row0_ac = v128_and(row0, ac_mask);
 
         if !v128_any_true(row0_ac) {
+            // Mirror the i32-lane pipeline exactly. WASM uses `i32x4_shl`
+            // for `<< CONST_BITS` in each IDCT pass — this **wraps in i32**
+            // when the input is large enough that `pass1 << 13` exceeds
+            // `i32::MAX`. The simple `dq << PASS1_BITS` collapse would skip
+            // pass-2's wrap. Use `wrapping_shl` + `wrapping_add` to match
+            // `i32x4_shl` + `i32x4_add` semantics. See SSE2 idct.rs for
+            // the same fix and the worked example (coeff=512, quant=255).
             let dq_i32: i32 = (coeffs[0] as i32) * (quant[0] as i32);
-            let pass1_i32: i32 = dq_i32 << PASS1_BITS;
-            let pass2_i32: i32 = (pass1_i32 + (1 << (PASS1_BITS + 3 - 1))) >> (PASS1_BITS + 3);
+            let pass1_pre: i32 = dq_i32.wrapping_shl(CONST_BITS);
+            let pass1_i32: i32 = pass1_pre.wrapping_add(1 << (CONST_BITS - PASS1_BITS - 1))
+                >> (CONST_BITS - PASS1_BITS);
+            let pass2_pre: i32 = pass1_i32.wrapping_shl(CONST_BITS);
+            let pass2_i32: i32 = pass2_pre.wrapping_add(1 << (CONST_BITS + PASS1_BITS + 3 - 1))
+                >> (CONST_BITS + PASS1_BITS + 3);
             let pv: u8 = (pass2_i32 + 128).clamp(0, 255) as u8;
             for r in 0..8 {
                 let row_ptr = output.add(r * stride);

--- a/src/simd/wasm32/idct.rs
+++ b/src/simd/wasm32/idct.rs
@@ -138,13 +138,51 @@ unsafe fn wasm_idct_islow_core(
     output: *mut u8,
     stride: usize,
 ) {
-    // The pure-DC pixel-fill shortcut was intentionally removed —
-    // see `simd/aarch64/idct.rs` for the rationale: every input now
-    // flows through the full pass1 + pass2 pipeline below.
-
-    // --- Full IDCT path ---
     let zero: v128 = i32x4_splat(0);
 
+    // --- Pure-DC pixel-fill shortcut ---
+    //
+    // WASM's full pipeline computes pass-1 in i32 throughout
+    // (`i32x4_mul`, see below), so the scalar shortcut also stays in
+    // i32 to match its own pipeline. AVX2 / NEON instead use i16-lane
+    // multiply + shift and require `wrapping_mul` + `wrapping_shl(2)`
+    // in their shortcut.
+    let cptr_v = coeffs.as_ptr();
+    let row1 = v128_load(cptr_v.add(8) as *const v128);
+    let row2 = v128_load(cptr_v.add(16) as *const v128);
+    let row3 = v128_load(cptr_v.add(24) as *const v128);
+    let row4 = v128_load(cptr_v.add(32) as *const v128);
+    let row5 = v128_load(cptr_v.add(40) as *const v128);
+    let row6 = v128_load(cptr_v.add(48) as *const v128);
+    let row7 = v128_load(cptr_v.add(56) as *const v128);
+
+    let ac_or = v128_or(
+        v128_or(v128_or(row1, row2), v128_or(row3, row4)),
+        v128_or(v128_or(row5, row6), row7),
+    );
+
+    if !v128_any_true(ac_or) {
+        let row0 = v128_load(cptr_v as *const v128);
+        // Mask out lane 0 (DC) using i16x8 mask: [0, -1, -1, -1, -1, -1, -1, -1]
+        let ac_mask = i16x8(0, -1, -1, -1, -1, -1, -1, -1);
+        let row0_ac = v128_and(row0, ac_mask);
+
+        if !v128_any_true(row0_ac) {
+            let dq_i32: i32 = (coeffs[0] as i32) * (quant[0] as i32);
+            let pass1_i32: i32 = dq_i32 << PASS1_BITS;
+            let pass2_i32: i32 = (pass1_i32 + (1 << (PASS1_BITS + 3 - 1))) >> (PASS1_BITS + 3);
+            let pv: u8 = (pass2_i32 + 128).clamp(0, 255) as u8;
+            for r in 0..8 {
+                let row_ptr = output.add(r * stride);
+                for c in 0..8 {
+                    *row_ptr.add(c) = pv;
+                }
+            }
+            return;
+        }
+    }
+
+    // --- Full IDCT path ---
     let mut ws = [0i32; 64];
 
     // ========== Pass 1: columns ==========

--- a/src/simd/x86_64/avx2_idct.rs
+++ b/src/simd/x86_64/avx2_idct.rs
@@ -156,10 +156,51 @@ unsafe fn avx2_idct_islow_core(
 ) {
     let cptr = coeffs.as_ptr();
 
-    // The pure-DC pixel-fill shortcut was intentionally removed —
-    // see `simd/aarch64/idct.rs` for the rationale: every input now
-    // flows through the full pass1 + pass2 pipeline below, whose
-    // i16 lane semantics match libjpeg-turbo's AVX2 ISLOW.
+    // --- Pure-DC pixel-fill shortcut ---
+    //
+    // When every AC coefficient is zero, the entire 8×8 output is a
+    // single constant pixel value derivable in scalar form. PR #278
+    // deleted an earlier version of this shortcut whose pass-1 shift
+    // used i32 arithmetic; for inputs where the dequantized DC times
+    // 4 exceeded i16 range, that diverged from the full pipeline's
+    // `_mm256_slli_epi16(..., 2)` (which wraps in i16). The fix below
+    // is to mirror **both** the i16 dequant multiply and the i16
+    // pass-1 left shift via `wrapping_mul` + `wrapping_shl(2)`, so
+    // the shortcut is bit-exact equivalent to the pipeline on every
+    // input — no runtime guard needed.
+    let row1 = _mm_loadu_si128(cptr.add(8) as *const __m128i);
+    let row2 = _mm_loadu_si128(cptr.add(16) as *const __m128i);
+    let row3 = _mm_loadu_si128(cptr.add(24) as *const __m128i);
+    let row4 = _mm_loadu_si128(cptr.add(32) as *const __m128i);
+    let row5 = _mm_loadu_si128(cptr.add(40) as *const __m128i);
+    let row6 = _mm_loadu_si128(cptr.add(48) as *const __m128i);
+    let row7 = _mm_loadu_si128(cptr.add(56) as *const __m128i);
+
+    let ac_or = _mm_or_si128(
+        _mm_or_si128(_mm_or_si128(row1, row2), _mm_or_si128(row3, row4)),
+        _mm_or_si128(_mm_or_si128(row5, row6), row7),
+    );
+
+    if _mm_testz_si128(ac_or, ac_or) != 0 {
+        let row0 = _mm_loadu_si128(cptr as *const __m128i);
+        let ac_mask = _mm_setr_epi16(0, -1, -1, -1, -1, -1, -1, -1);
+        let row0_ac = _mm_and_si128(row0, ac_mask);
+
+        if _mm_testz_si128(row0_ac, row0_ac) != 0 {
+            // i16 wrap throughout pass-1 (mirrors `_mm256_mullo_epi16`
+            // + `_mm256_slli_epi16(_, 2)`), i32 from pass-2 onward.
+            let dq_i16: i16 = (*cptr).wrapping_mul(*(quant.as_ptr() as *const i16));
+            let dq_shifted_i16: i16 = dq_i16.wrapping_shl(2);
+            let pass1_i32: i32 = dq_shifted_i16 as i32;
+            let pass2_i32: i32 = (pass1_i32 + (1 << 4)) >> 5;
+            let pv: u8 = (pass2_i32 + 128).clamp(0, 255) as u8;
+            let fill = _mm_set1_epi8(pv as i8);
+            for r in 0..8 {
+                _mm_storel_epi64(output.add(r * stride) as *mut __m128i, fill);
+            }
+            return;
+        }
+    }
 
     // --- Load & dequantize: 2 rows per ymm ---
     let qptr = quant.as_ptr() as *const __m256i;

--- a/src/simd/x86_64/idct.rs
+++ b/src/simd/x86_64/idct.rs
@@ -161,17 +161,47 @@ unsafe fn sse2_idct_islow_core(
     output: *mut u8,
     stride: usize,
 ) {
-    // The pure-DC pixel-fill shortcut was intentionally removed —
-    // see `simd/aarch64/idct.rs` for the rationale: the i32 dequant
-    // formula it used diverged from the full pipeline's i16 lane
-    // arithmetic on adversarial inputs where `coeff * quant`
-    // overflows i16. Reproducing the wrap semantics in scalar
-    // shortcut form is fragile (codex review of d75924f flagged a
-    // PASS1-shift wrap missed by the first round of fixes), so
-    // every input now flows through the full pass1 + pass2
-    // pipeline below, whose i16 lane width matches what
-    // libjpeg-turbo's SSE2 ISLOW does.
+    let cptr: *const i16 = coeffs.as_ptr();
     let zero: __m128i = _mm_setzero_si128();
+
+    // --- Pure-DC pixel-fill shortcut ---
+    //
+    // SSE2's full pipeline computes pass-1 in i32 throughout (no
+    // `_mm_mullo_epi16` here — see the `c0 * q0` i32 multiply below),
+    // so the scalar shortcut also stays in i32 to match its own
+    // pipeline. This contrasts with the AVX2 / NEON backends, which
+    // use i16-lane multiply + shift and therefore need
+    // `wrapping_mul` + `wrapping_shl(2)` in their shortcut.
+    let row1 = _mm_loadu_si128(cptr.add(8) as *const __m128i);
+    let row2 = _mm_loadu_si128(cptr.add(16) as *const __m128i);
+    let row3 = _mm_loadu_si128(cptr.add(24) as *const __m128i);
+    let row4 = _mm_loadu_si128(cptr.add(32) as *const __m128i);
+    let row5 = _mm_loadu_si128(cptr.add(40) as *const __m128i);
+    let row6 = _mm_loadu_si128(cptr.add(48) as *const __m128i);
+    let row7 = _mm_loadu_si128(cptr.add(56) as *const __m128i);
+
+    let ac_or = _mm_or_si128(
+        _mm_or_si128(_mm_or_si128(row1, row2), _mm_or_si128(row3, row4)),
+        _mm_or_si128(_mm_or_si128(row5, row6), row7),
+    );
+
+    if _mm_movemask_epi8(_mm_cmpeq_epi8(ac_or, zero)) == 0xFFFF {
+        let row0 = _mm_loadu_si128(cptr as *const __m128i);
+        let ac_mask = _mm_setr_epi16(0, -1, -1, -1, -1, -1, -1, -1);
+        let row0_ac = _mm_and_si128(row0, ac_mask);
+
+        if _mm_movemask_epi8(_mm_cmpeq_epi8(row0_ac, zero)) == 0xFFFF {
+            let dq_i32: i32 = (coeffs[0] as i32) * (quant[0] as i32);
+            let pass1_i32: i32 = dq_i32 << PASS1_BITS;
+            let pass2_i32: i32 = (pass1_i32 + (1 << (PASS1_BITS + 3 - 1))) >> (PASS1_BITS + 3);
+            let pv: u8 = (pass2_i32 + 128).clamp(0, 255) as u8;
+            let fill = _mm_set1_epi8(pv as i8);
+            for r in 0..8 {
+                _mm_storel_epi64(output.add(r * stride) as *mut __m128i, fill);
+            }
+            return;
+        }
+    }
 
     // --- Full IDCT path ---
 

--- a/src/simd/x86_64/idct.rs
+++ b/src/simd/x86_64/idct.rs
@@ -191,9 +191,23 @@ unsafe fn sse2_idct_islow_core(
         let row0_ac = _mm_and_si128(row0, ac_mask);
 
         if _mm_movemask_epi8(_mm_cmpeq_epi8(row0_ac, zero)) == 0xFFFF {
+            // Mirror the i32-lane pipeline exactly. Pass-1 IDCT of
+            // [dq, 0, ..., 0] computes `dq << CONST_BITS` then descales
+            // by `CONST_BITS - PASS1_BITS = 11` with rounding. Pass-2
+            // does the same `<< CONST_BITS` on the pass-1 result —
+            // **this can wrap i32** when the pass-1 value is large
+            // (e.g. `coeff[0]=512, quant[0]=255` → pass1=522240, then
+            // `522240 << 13 = 4278190080` overflows i32 to -16777216,
+            // and the final clamped pixel is 64, not the un-wrapped 255).
+            // Use `wrapping_shl` + `wrapping_add` to match `_mm_slli_epi32`
+            // + `_mm_add_epi32` semantics.
             let dq_i32: i32 = (coeffs[0] as i32) * (quant[0] as i32);
-            let pass1_i32: i32 = dq_i32 << PASS1_BITS;
-            let pass2_i32: i32 = (pass1_i32 + (1 << (PASS1_BITS + 3 - 1))) >> (PASS1_BITS + 3);
+            let pass1_pre: i32 = dq_i32.wrapping_shl(CONST_BITS as u32);
+            let pass1_i32: i32 = pass1_pre.wrapping_add(1 << (CONST_BITS - PASS1_BITS - 1))
+                >> (CONST_BITS - PASS1_BITS);
+            let pass2_pre: i32 = pass1_i32.wrapping_shl(CONST_BITS as u32);
+            let pass2_i32: i32 = pass2_pre.wrapping_add(1 << (CONST_BITS + PASS1_BITS + 3 - 1))
+                >> (CONST_BITS + PASS1_BITS + 3);
             let pv: u8 = (pass2_i32 + 128).clamp(0, 255) as u8;
             let fill = _mm_set1_epi8(pv as i8);
             for r in 0..8 {

--- a/tests/neon_idct.rs
+++ b/tests/neon_idct.rs
@@ -199,3 +199,60 @@ fn neon_idct_full_block() {
     let neon = neon_idct(&coeffs, &quant);
     assert_eq!(neon, scalar, "full block mismatch");
 }
+
+/// Adversarial DC-only block where `coeff[0] * quant[0]` overflows i16.
+///
+/// `2032 * 85 = 172720` — wraps to `-23888` under `vmul_s16`. The full
+/// i16-lane NEON pipeline (and the matching pixel-fill shortcut after
+/// PR #279) produces pixel value `0`. C libjpeg-turbo's NEON ISLOW
+/// agrees because it also operates on i16 lanes.
+///
+/// PR #278's deleted shortcut used `(dq_i16 as i32) << PASS1_BITS`,
+/// which preserves the i16-wrapped multiply result but skips the
+/// pass-1 `<< 2` lane-wrap. For this specific input the bugged
+/// shortcut and the canonical pipeline happened to converge, so the
+/// case here exists to pin the i16-wrap *multiply* leg of the fix.
+/// The companion test below pins the pass-1 *shift* wrap leg.
+///
+/// We compare against a hand-derived expected value (0) rather than
+/// `scalar_idct`, because the scalar fallback uses i32 throughout
+/// and would diverge on this exact input.
+#[test]
+fn neon_idct_dc_only_i16_wrap_multiply() {
+    let mut coeffs = [0i16; 64];
+    coeffs[0] = 2032;
+    let mut quant = [1u16; 64];
+    quant[0] = 85;
+    let neon = neon_idct(&coeffs, &quant);
+    for (i, &val) in neon.iter().enumerate() {
+        assert_eq!(
+            val, 0,
+            "i16-wrap pipeline must produce 0 for coeff=2032 quant=85 (px {i})"
+        );
+    }
+}
+
+/// Adversarial DC-only block where `(coeff[0] * quant[0]) << PASS1_BITS`
+/// overflows i16 even though the multiply fits.
+///
+/// `-2047 * 17 = -34799` wraps to `30737` (positive in i16). Then
+/// `30737 << 2` overflows i16, wrapping to `-8124`. Pipeline pixel: 0.
+///
+/// Codex review of d75924f flagged this exact overflow leg — the
+/// previous round-2 shortcut still wrote `(dq_i16 as i32) << 2`,
+/// which would have produced `255` here. The shortcut after PR #279
+/// uses `dq_i16.wrapping_shl(2)` so it agrees with the pipeline.
+#[test]
+fn neon_idct_dc_only_i16_wrap_pass1_shift() {
+    let mut coeffs = [0i16; 64];
+    coeffs[0] = -2047;
+    let mut quant = [1u16; 64];
+    quant[0] = 17;
+    let neon = neon_idct(&coeffs, &quant);
+    for (i, &val) in neon.iter().enumerate() {
+        assert_eq!(
+            val, 0,
+            "i16-shift wrap must produce 0 for coeff=-2047 quant=17 (px {i})"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

PR #278 deleted the pure-DC pixel-fill shortcut from all four SIMD ISLOWs after a multi-round attempt at fixing its i16-wrap correctness on adversarial fuzz inputs ended up with a third-round PASS1-shift miss codex flagged. The deletion fixed correctness but cost real perf on graphic / banner / chart content. Re-bench on x86_64 i5-10400 measured:

```
graphic_640x480_420   532 µs → 658 µs (+23.7%)
graphic_1920x1080_420 2485 µs → 3493 µs (+40.5%)
checker_640x480_420   1109 µs → 1156 µs ( +4.3%)
```

That puts Rust *above* C libjpeg-turbo in absolute terms for graphic content (was 0.91× of C at 1080p, post-PR278 at 1.27× of C). The project's stated goal is "equivalent or better performance"; this PR closes the gap.

## Approach

The right fix isn't a runtime guard ("if the input would overflow i16, fall through to the full pipeline") — that's clever but fragile. The right fix is to make the shortcut formula compute exactly what the full pipeline computes, in the same lane width. Different SIMD backends use different lane widths, so the shortcut formula differs per backend:

| Backend  | Pass-1 lane | Pass-2 lane | Shortcut form                                              |
| -------- | ----------- | ----------- | ---------------------------------------------------------- |
| AVX2     | i16 (`_mm256_mullo_epi16` + `_mm256_slli_epi16(_, 2)`) | i16→i32 widen | `wrapping_mul` + `wrapping_shl(2)` then i32 |
| NEON     | i16 (`vmul_s16` + `vshl_n_s16::<PASS1_BITS>`) | i16→i32 widen | `wrapping_mul` + `wrapping_shl(2)` then i32 |
| SSE2     | i32 throughout (`c0 * q0` then `_mm_slli_epi32`) | i32 throughout | `wrapping_shl(13)` + `wrapping_add(bias) >> 11` × 2 stages |
| WASM     | i32 throughout (`i32x4_mul` + `i32x4_shl`)       | i32 throughout | same as SSE2                                               |

Both legs of the wrap exist:

- **AVX2 / NEON**: i16 multiply wraps when `|coeff[0] * quant[0]| >= 2^15`; i16 pass-1 shift wraps when `|dq << 2| >= 2^15`. The smoke-crash signature `coeff[0]=2032, quant[0]=85` hits leg 1 (`172720` wraps to `-23888`); codex review of d75924f flagged leg 2 with `coeff[0]=-2047, quant[0]=17` (`-34799` wraps to `30737`, then `30737 << 2` wraps to `-8124`).
- **SSE2 / WASM**: i32 doesn't wrap on multiply (we always have headroom in i32 for `i16 * i16 = i32` results) but **does** wrap on the pass-2 `<< CONST_BITS=13`. Codex review of bb6ec77 flagged this with `coeff[0]=512, quant[0]=255` — pass-1 lands at `522240`, then `522240 << 13 = 4_278_190_080` overflows i32 to `-16_777_216`, and the final pixel is `64` not the un-wrapped `255`.

This PR's shortcut formula on each backend mirrors that backend's pipeline arithmetic exactly. No runtime guard, no formula collapsing.

## Two regression tests pin both i16-wrap legs (NEON)

`tests/neon_idct.rs`:

```
neon_idct_dc_only_i16_wrap_multiply       coeff=2032,  quant=85   → pixel=0
neon_idct_dc_only_i16_wrap_pass1_shift    coeff=-2047, quant=17   → pixel=0
```

Both assert against hand-derived expected values (`0`) rather than `scalar_idct`, because the scalar fallback uses i32 throughout and diverges from the i16-lane SIMD pipeline on these adversarial inputs by design.

## Bench results (post-fix, x86_64 AVX2)

`graphic_1920x1080_420 = 2500 µs` (was 2485 pre-PR278, 3493 post-PR278). All other fixtures within ±1% of pre-PR278. Full table in `experiments/perf_2026-05-10_post_shortcut_restore_x86_64.md`.

## Verification

- `cargo test --workspace --release`:
  - aarch64 macOS: **2161 passed / 0 failed / 0 ignored**.
  - x86_64 Linux (Comet Lake AVX2): **2123 passed / 0 failed / 0 ignored**.
- `cargo clippy --lib --release -- -D warnings` clean on both.
- `cargo check --target wasm32-unknown-unknown` clean.
- Codex review on `bb6ec77` flagged P2 in SSE2 + WASM (pass-2 wrap missing) → fixed in `39f72fc`. Codex review on `39f72fc` clean: *"The SSE2 and WASM shortcut changes mirror the corresponding full i32 SIMD pipeline semantics, including wrapping shifts/adds. I did not identify any introduced correctness, performance, or maintainability issues."*

## Why this lived (the long story)

Pure-DC blocks with `|coeff * quant|` in the wraparound regions are vanishingly rare in real-world JPEG content — typical Q-tables keep DC quantizers in [10, 30], so a coefficient near `±2048` (cat-11 DC differential max) is needed to overflow i16, and a near-max DC differential with all-zero AC describes a near-flat block at extreme luminance, which real encoders rarely emit. `fuzz_decode_diff_c` synthesised the leg-1 case by mutating the entropy-coded DC differential directly. The bench / golden-image suite never tripped it because no fixture in the corpus had the right combination.

PR #278's deletion was the right correctness call given how many rounds the shortcut took to land. The fix in this PR isn't "add a guard, hope for the best" — it's "match the pipeline's arithmetic exactly, prove the equivalence on paper, and pin both wrap legs in TDD." The four backends' lane widths are now documented inline so the next round of optimisation has a concrete model to start from.

## Closure delta

Closes the perf regression flagged in `experiments/perf_2026-05-10_post_idct_shortcut_removal_x86_64.md`. PR #278's correctness gain is preserved — the smoke crash input still decodes Cb=0 on AVX2 + NEON, byte-exact against C libjpeg-turbo NEON / AVX2 ISLOW.