### PR TITLE
docs(readme): surface x86_64 build-flag recipe in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ libjpeg-turbo-rs = "0.6"
 # libjpeg-turbo-rs = { version = "0.6", features = ["png"] }
 ```
 
+### Build flags (x86_64 only)
+
+For x86_64 production builds, set:
+
+```sh
+RUSTFLAGS="-C target-cpu=native" cargo build --release
+# or, for a portable v3 baseline:
+RUSTFLAGS="-C target-feature=+bmi1,+lzcnt,+bmi2,+fma" cargo build --release
+```
+
+This unlocks BMI1 / LZCNT / BMI2 / FMA in the encoder's scalar
+bitmap-iteration hot path, which the C reference's NASM SIMD already
+embeds. Without these flags `cargo build --release` defaults to the
+SSE2-only `x86_64-v1` baseline and the encoder trails C by 5–10 pp at
+1080p; with them, Rust beats C in every encode benchmark in the
+Performance section above. aarch64 / NEON builds are unaffected.
+
 ### Decompress
 
 ```rust


### PR DESCRIPTION
## Summary

The Performance section already explained that production x86_64 builds need `RUSTFLAGS="-C target-cpu=native"` (or `+bmi1,+lzcnt,+bmi2,+fma`) to close the 5-10pp encoder gap vs C libjpeg-turbo, but the recommendation lived 80+ lines below the install snippet — buried in a paragraph mixed with benchmark commentary. A user who skims Quick Start, runs `cargo add libjpeg-turbo-rs`, and stops there silently inherits the SSE2-only `x86_64-v1` default and ships a noticeably slower encoder than they'd see in the README's headline numbers.

This PR adds a short **Build flags (x86_64 only)** subsection inside Quick Start with both copy-paste recipes:

```sh
RUSTFLAGS="-C target-cpu=native" cargo build --release
# or, for a portable v3 baseline:
RUSTFLAGS="-C target-feature=+bmi1,+lzcnt,+bmi2,+fma" cargo build --release
```

Cross-references the existing Performance section for the why; the section there already has the full data and the LLVM-codegen explanation (`leading_zeros()` → `BSR + correction` without `+lzcnt` vs native single-uop `LZCNT`).

## Why this is doc-only

No code touched. `experiments/encode.tsv` already records both numbers (the "CLOSING measurement" row): `target-cpu=native` ratios are `0.98 / 0.98 / 0.96` at 1080p (Rust beats C in every case); default `x86_64-v1` ratios are `1.10 / 1.09 / 1.07`. Adding the recipe to a discoverable place captures the win for any production user without changing build defaults (which would risk breaking environments that explicitly target older CPUs).

aarch64 / NEON unaffected.

## Verification

- `cargo fmt --check` clean (pre-commit hook).
- `cargo clippy --lib --release -- -D warnings` clean (pre-commit hook).
- No test changes — README-only.

## Closure delta

This is step **(1) Document + tooling** of the catch-up plan I outlined to the user. The follow-up steps:

- **(2) Hand-roll target-featured hot helpers**: apply `#[target_feature(enable = "lzcnt,bmi1")]` to the `encode_ac` / `JPEG_NBITS_CORRECTED` lookup path with runtime CPU detection. Closes the gap on default builds without forcing users to set RUSTFLAGS.
- **(3) Faithful 32-pixel AVX2 RGB→YCbCr port**: deferred until (2) lands and we know what's actually left.