### PR TITLE
docs(claude): mandate LAST_MILE.md read at session start; require mid-work gap filing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,28 +17,37 @@ Rust port of libjpeg-turbo with equivalent or better performance.
 
 # Feature Parity Tracking
 
+- **Read `docs/LAST_MILE.md` first, every session, before any other work.** It is the single source of truth for what is OPEN / PARTIAL / CLOSED across the project. Even for "small" tasks (bug fix, perf tweak, doc edit) — read it. The index is intentionally short (~150 lines).
 - **Read `docs/FEATURE_PARITY.md` before starting any feature work.** It is the checklist of every feature with `[x]`/`[ ]` status.
-- **Read `docs/LAST_MILE.md` for the replacement-readiness gate** — slim index with current status, OPEN items, and the active Suggested Order. Phase detail lives in `docs/last_mile/phase{1,2,3}.md`; open the phase file only for the gap you are working on.
 - **Use `docs/C_API_REFERENCE.md` as the definitive mapping** of every C function → Rust equivalent (✅/❌/🔶).
+- **Discovered mid-work? File it immediately.** If during any task you uncover a bug, missing feature, perf gap, or follow-up that is not already in LAST_MILE.md, add it to the appropriate `docs/last_mile/phaseN.md` (or open `phase4.md` if no existing phase fits) AND register it in the OPEN Items table of `docs/LAST_MILE.md` **before** the PR that surfaced it merges. Don't rely on memory or commit messages — if it isn't tracked in LAST_MILE.md, it doesn't exist for the next session.
 - After implementing a feature, update **all three** docs: checkbox in FEATURE_PARITY.md, status entry in the relevant `docs/last_mile/phaseN.md` when it closes a tracked gap (and the index in `docs/LAST_MILE.md` if the OPEN list changes), and status in C_API_REFERENCE.md.
-- Follow the Suggested Order in the relevant phase file (release gate) over FEATURE_PARITY.md (feature checklist) when choosing what to work on next. Phase 3 has the live OPEN items and its order lives in the index.
+- Follow the Suggested Order in the relevant phase file (release gate) over FEATURE_PARITY.md (feature checklist) when choosing what to work on next.
 
 ## LAST_MILE Management
 
 - **File layout:**
-  - `docs/LAST_MILE.md` — slim index (~100 lines): Cold Assessment, 7-item Replacement Gate, OPEN items table, Phase Map, Phase 3 Suggested Order. Always read first.
+  - `docs/LAST_MILE.md` — slim index (~150 lines): Current Status, 7-item Replacement Gate, OPEN Items table, Phase Map, Suggested Order. **Always read first.**
   - `docs/last_mile/phase1.md` — historical P0-1..4, P1, Phase-1 P2, Tasks 1-7, Definition of Done. All CLOSED.
   - `docs/last_mile/phase2.md` — system-library hardening P2-1..11. All CLOSED.
-  - `docs/last_mile/phase3.md` — long-tail C compatibility P3-1..6. Has live OPEN items.
+  - `docs/last_mile/phase3.md` — long-tail C compatibility P3-1..6. All CLOSED.
+  - `docs/last_mile/phase4.md` — created on demand for new gaps that don't fit existing phases.
   - `docs/last_mile/reference_commands.md` — common verification commands.
 - **Read rule:** open the index first; open exactly one phase file for the gap you are touching. Do not load all phases by default.
-- **Adding a new gap:** append the entry to the appropriate phase file (existing phase if it fits the theme; new phase only if scope is genuinely different). Then add a row to the OPEN Items table in `docs/LAST_MILE.md` with a deep link to the new section anchor. Use kebab-case anchors GitHub generates from the heading.
+- **State machine — every gap lives in exactly one of three states:**
+  - **OPEN** — section heading has no `CLOSED` / `PARTIAL` suffix; OPEN Items row in `docs/LAST_MILE.md` exists.
+  - **PARTIAL: …** — heading has `**PARTIAL: <scope>**`; OPEN Items row still exists with a note on what shrank.
+  - **CLOSED YYYY-MM-DD** — heading has `**CLOSED YYYY-MM-DD**`; section body ends with `**Status (YYYY-MM-DD): closed.**` citing proof; OPEN Items row removed; matching Suggested Order entry struck through (`~~…~~ — CLOSED YYYY-MM-DD`).
+- **Adding a new gap (any state, any source — bug discovered mid-work, missing feature, perf gap, follow-up):**
+  1. Pick the right phase: existing phase if scope fits its theme; otherwise create / append to `docs/last_mile/phase4.md`. **Never silently drop a discovered issue** — file it before merging the PR that surfaced it.
+  2. Append a `## <ID>. <Heading> — **OPEN**` section to the phase file with: motivation, root-cause hypothesis (if any), acceptance criteria, why-deferred note (if applicable).
+  3. Add a row to the OPEN Items table in `docs/LAST_MILE.md` with a deep link to the new section anchor (kebab-case from the heading).
 - **Closing a gap:**
-  1. In the phase file: change the heading suffix to `— **CLOSED YYYY-MM-DD**` (or `**PARTIAL: …**` when scope shrank but didn't fully close). Add a `**Status (YYYY-MM-DD): closed.**` line citing the test/command that proves it. Strike-through the matching Suggested Order entry with `~~…~~` and append the same date.
-  2. In `docs/LAST_MILE.md`: remove the row from OPEN Items if fully closed; refresh the live-checks table if the gate output changed.
+  1. In the phase file: change heading suffix to `— **CLOSED YYYY-MM-DD**` (or `**PARTIAL: …**`). Add `**Status (YYYY-MM-DD): closed.**` citing the test/command that proves it. Strike-through the matching Suggested Order entry.
+  2. In `docs/LAST_MILE.md`: remove the row from OPEN Items if fully closed; refresh the live-gate table if the gate output changed.
   3. Update `docs/FEATURE_PARITY.md` checkbox and `docs/C_API_REFERENCE.md` status if a canonical mapping changed.
-- **No archive churn:** CLOSED entries stay in their phase file as institutional memory (root cause + fix + verification). Don't move them to a separate archive — searching `git log` for the SHA that closed an entry is more useful than a flat archive.
-- **Index discipline:** the slim index must stay under ~150 lines. If it grows, that's a signal to push detail back into the phase files, not to expand the index.
+- **No archive churn:** CLOSED entries stay in their phase file as institutional memory. Don't move them to a separate archive — `git log --grep=<ID>` finds the closing SHA.
+- **Index discipline:** the slim index must stay under ~150 lines. If it grows, push detail back into the phase files; don't expand the index.
 
 # Project Rules
 


### PR DESCRIPTION
## Motivation

Today's session surfaced a coordination gap in our existing CLAUDE.md rules. Two specific failure modes:

1. **PR #278's graphic-content perf regression went undocumented as it merged.** The smoke-crash fix in #278 had a known-but-unmeasured perf cost. The post-merge re-bench measured it (24-41% slowdown on graphic content), and a follow-up PR #279 recovered the regression — but only because the perf log lived in the same conversation. A fresh session next morning would have read main, seen no OPEN entry, and assumed the perf side was settled.
2. **Phase 4 was a placeholder reference, not a real file.** `docs/LAST_MILE.md:51` literally said *"Future phases live in `docs/last_mile/phase4.md` or later"* — but no such file existed and no rule said to create it on demand. So discovered gaps that didn't fit phase 1/2/3 had nowhere obvious to go.

This PR hardens two rules in the **Feature Parity Tracking** section to close both holes:

### 1. LAST_MILE.md becomes the first read every session

Was: *"Read `docs/LAST_MILE.md` for the replacement-readiness gate"* (implied — for feature work).
Is now: *"Read `docs/LAST_MILE.md` first, every session, before any other work."* (unconditional — bug fixes, perf tweaks, doc edits all touch the gap inventory).

The index is intentionally short (~150 lines) for exactly this reason.

### 2. Discovered-mid-work gaps must be filed before the surfacing PR merges

New rule:

> **Discovered mid-work? File it immediately.** If during any task you uncover a bug, missing feature, perf gap, or follow-up that is not already in LAST_MILE.md, add it to the appropriate `docs/last_mile/phaseN.md` (or open `phase4.md` if no existing phase fits) AND register it in the OPEN Items table of `docs/LAST_MILE.md` **before** the PR that surfaced it merges. Don't rely on memory or commit messages — if it isn't tracked in LAST_MILE.md, it doesn't exist for the next session.

This is the rule that would have caught PR #278's regression: when the post-merge bench showed a 40% slowdown, the rule says open a row in LAST_MILE.md before the next PR closes. Even if the row says "OPEN — perf regression on graphic content, recovery PR coming", the next session has the inventory.

## Other tightenings (same section)

- **Explicit three-state machine** for every gap: `OPEN` / `PARTIAL: <scope>` / `CLOSED YYYY-MM-DD`. Each state has a precise definition of where the heading suffix, OPEN Items row, Suggested Order strike-through, and Status line should be.
- **"Adding a new gap" is now numbered with explicit phase fallback**: existing phase if scope fits theme; otherwise create or append to `docs/last_mile/phase4.md`. Removes the ambiguity that left phase 4 as a placeholder.
- **Phase Map updated**: phase3 is fully CLOSED as of 2026-05-09 (was "Has live OPEN items"); phase4 documented as a create-on-demand container.
- **"No archive churn" rule references `git log --grep=<ID>`** since that's the realistic recovery path for closed entries.

## Verification

This is a process / documentation PR — no test impact. The rules apply prospectively to future sessions. To verify the new wording is unambiguous, the test is whether a fresh agent reading the updated section can:

- Decide whether to read LAST_MILE.md (yes — always).
- Tell which state a gap is in from the heading alone (OPEN / PARTIAL / CLOSED).
- Know what to do when they find a bug mid-PR (file it before merging).
- Know where to put a discovery that doesn't fit phase 1/2/3 (phase4.md, create on demand).

Pre-commit hook (`cargo fmt --check`, `cargo clippy --lib --release -- -D warnings`) passes; the change touches only CLAUDE.md.