### PR TITLE
Add fuzz smoke repro metadata artifacts

### DIFF
--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -23,6 +23,9 @@ jobs:
   fuzz:
     name: Fuzz ${{ matrix.target }}
     runs-on: ubuntu-latest
+    env:
+      FUZZ_TARGET: ${{ matrix.target }}
+      MAX_TOTAL_TIME: ${{ github.event.inputs.max_total_time || '600' }}
     strategy:
       fail-fast: false
       matrix:
@@ -81,8 +84,6 @@ jobs:
         run: cargo test --test generate_fuzz_seeds
 
       - name: Run fuzzer
-        env:
-          MAX_TOTAL_TIME: ${{ github.event.inputs.max_total_time || '600' }}
         # `--target x86_64-unknown-linux-gnu` is mandatory: the prebuilt
         # cargo-fuzz binary we install above is musl-linked, so without
         # an explicit target it defaults to its host triple
@@ -94,8 +95,83 @@ jobs:
         run: |
           cargo +nightly fuzz run \
             --target x86_64-unknown-linux-gnu \
-            "${{ matrix.target }}" \
+            "${FUZZ_TARGET}" \
             -- -max_total_time="${MAX_TOTAL_TIME}" -print_final_stats=1
+
+      - name: Write repro metadata
+        if: failure()
+        run: |
+          mkdir -p "fuzz/repro/${FUZZ_TARGET}"
+
+          {
+            echo "Fuzz Smoke repro"
+            echo
+            echo "target: ${FUZZ_TARGET}"
+            echo "workflow: ${GITHUB_WORKFLOW}"
+            echo "run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}"
+            echo "commit: ${GITHUB_SHA}"
+            echo "runner: ${RUNNER_OS} ${RUNNER_ARCH}"
+            echo "max_total_time: ${MAX_TOTAL_TIME}"
+            echo
+            echo "Rebuild the seed corpus first:"
+            echo "  cargo test --test generate_fuzz_seeds"
+            echo
+            echo "Re-run the same smoke budget:"
+            echo "  cargo +nightly fuzz run --target x86_64-unknown-linux-gnu ${FUZZ_TARGET} -- -max_total_time=${MAX_TOTAL_TIME} -print_final_stats=1"
+            echo
+            echo "Download crash artifacts from this run:"
+            echo "  gh run download ${GITHUB_RUN_ID} -n fuzz-artifacts-${FUZZ_TARGET} -D fuzz/artifacts/${FUZZ_TARGET}"
+            echo
+            echo "Reproduce a downloaded crash artifact:"
+            echo "  cargo +nightly fuzz run --target x86_64-unknown-linux-gnu ${FUZZ_TARGET} fuzz/artifacts/${FUZZ_TARGET}/<crash-file> -- -runs=1"
+            echo
+            echo "Differential target note:"
+            case "${FUZZ_TARGET}" in
+              fuzz_decode_diff_c|fuzz_encode_diff_c|fuzz_transform_diff_c)
+                echo "  Install libjpeg-turbo 3.1.4.1 C tools and put /opt/libjpeg-turbo/bin first on PATH."
+                echo "  ARCH=\$(dpkg --print-architecture)"
+                echo "  VERSION=3.1.4.1"
+                echo "  curl -fL -o /tmp/ljt.deb \"https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/\${VERSION}/libjpeg-turbo-official_\${VERSION}_\${ARCH}.deb\""
+                echo "  sudo apt-get install -y /tmp/ljt.deb"
+                echo "  export PATH=/opt/libjpeg-turbo/bin:\${PATH}"
+                ;;
+              *)
+                echo "  No C tool dependency for this target."
+                ;;
+            esac
+          } > "fuzz/repro/${FUZZ_TARGET}/repro.txt"
+
+          {
+            echo "rustc"
+            rustc -Vv || true
+            echo
+            echo "cargo"
+            cargo -V || true
+            echo
+            echo "cargo-fuzz"
+            cargo fuzz --version || true
+            echo
+            echo "C tools"
+            for tool in djpeg cjpeg jpegtran; do
+              echo "${tool}"
+              if command -v "${tool}" >/dev/null 2>&1; then
+                command -v "${tool}"
+                "${tool}" -version || true
+              else
+                echo "not found"
+              fi
+              echo
+            done
+          } > "fuzz/repro/${FUZZ_TARGET}/versions.txt" 2>&1
+
+      - name: Upload repro metadata
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-repro-${{ matrix.target }}
+          path: fuzz/repro/${{ matrix.target }}
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Upload crash artifacts
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # /references
 fuzz/target
 fuzz/artifacts
+fuzz/repro
 .DS_Store
 bench_c_decode_linux
 crates/libjpeg-turbo-rs-wasm/pkg/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ Rust port of libjpeg-turbo with equivalent or better performance.
 - After completing each planned task, run `cargo test` and commit before moving to the next task. **Skip tests if the change has no impact on runtime behavior** (e.g., docs, comments, CI config). Changes to runtime config files (YAML, JSON, etc. read by code) must still trigger tests.
 - **A task is not "done" until CI/CD is green.** Local `cargo test` / `cargo clippy` / `cargo fmt --check` are necessary but not sufficient — they only cover the host platform (typically aarch64-darwin) while CI runs on `ubuntu-latest`, `macos-latest`, and `windows-latest`. Push the commits, then verify all jobs in `.github/workflows/*.yml` pass with `gh pr checks --watch <PR#>` (or `gh run watch <run-id>` for a direct push). Only after every required job is green may you tell the user the task is complete. If CI fails, fix the failure and re-verify; do **not** report completion based on local results alone.
 - **After any code change (feature addition, bug fix, refactoring, PR merge), check if `README.md` needs updating.** If project description, usage, setup, architecture, or API changed, update `README.md` with clear, concise language. Keep it minimal — only document what users need to know.
+- When debugging Fuzz Smoke failures, inspect `fuzz-repro-<target>` (`repro.txt`, `versions.txt`) alongside `fuzz-artifacts-<target>` before local reproduction or fixes.
 
 ## Testing (TDD)
 

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -88,6 +88,14 @@ cargo +nightly fuzz list
 cargo +nightly fuzz run fuzz_decompress fuzz/artifacts/fuzz_decompress/<crash-file>
 ```
 
+## CI smoke failure artifacts
+
+The Fuzz Smoke workflow uploads two artifact groups when a target fails:
+
+- `fuzz-artifacts-<target>`: libFuzzer crash inputs from `fuzz/artifacts/<target>/`.
+- `fuzz-repro-<target>`: `repro.txt` with the exact rerun commands and `versions.txt` with
+  Rust, cargo-fuzz, and C tool versions from the failing runner.
+
 ## Coverage
 
 ```bash
@@ -103,4 +111,5 @@ fuzz/
   fuzz_targets/           # One .rs file per fuzz target
   corpus/<target>/        # Seed corpus per target (populated by generate_fuzz_seeds test)
   artifacts/<target>/     # Crash-reproducing inputs (gitignored, created by fuzzer)
+  repro/<target>/         # CI-only repro metadata artifacts (gitignored, created on failure)
 ```


### PR DESCRIPTION
## Summary
- add failure-only Fuzz Smoke repro metadata generation
- upload a separate fuzz-repro-<target> artifact containing repro.txt and versions.txt
- document the new artifact pair and ignore local fuzz/repro output
- add a CLAUDE.md rule requiring future Fuzz Smoke debugging to inspect repro metadata before local reproduction or fixes

## Verification
- cargo fmt --all
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/fuzz-smoke.yml
- local shell simulation generated non-empty repro.txt and versions.txt
- codex review --uncommitted
- pre-commit hook: cargo fmt --check; cargo clippy --lib -- -D warnings