### PR TITLE
docs(abi-compat): retitle T4 roadmap section to reference P2-A by ID

### DIFF
--- a/docs/ABI_COMPATIBILITY.md
+++ b/docs/ABI_COMPATIBILITY.md
@@ -105,12 +105,16 @@ For the full enumeration of v6b → v7 → v8 differences, see the `#if JPEG_LIB
 
 Symmetric to the decompress side — refer to `crates/libjpeg-turbo-rs-capi/src/jpeglib.rs` and `references/libjpeg-turbo/src/jpeglib.h:300+` for the per-version field list.
 
-## Roadmap (not blocking P2-9 closure)
+## Roadmap — T4 (v6b/v7 drop-in) is tracked as P2-A
 
-If a Phase 3 demands real v6b drop-in, the path is:
+T4 ("System v6b/v7 drop-in") is an explicit non-goal under the current
+default. The only honest path to closing it is the per-ABI cdylib
+matrix tracked as **P2-A** in the master plan
+(`/Users/yhkwon/.claude/plans/dreamy-moseying-swing.md`). When triggered
+the work is:
 
 1. Add a `CAPI_LIB_VERSION = 62 | 70 | 80` cfg gate.
-2. Generate per-version `JpegDecompressPublic` / `JpegCompressPublic` types with conditional fields.
+2. Generate per-version `JpegDecompressPublic` / `JpegCompressPublic` types with conditional fields (likely via `bindgen` or a small build-time code-gen step — hand-maintaining three ~200-field mirrors is known-fragile).
 3. Pin per-version offset assertions for each.
 4. Build per-version cdylibs (`libjpeg.so.62.cdylib`, `libjpeg.so.7.cdylib`, `libjpeg.so.8.cdylib`).
 5. Add a CI matrix entry per version.


### PR DESCRIPTION
## Summary

`docs/ABI_COMPATIBILITY.md` had two stale references that pre-dated the current P0→P1→P2 plan structure:

- Section heading said \`Roadmap (not blocking P2-9 closure)\` — Phase 2 is closed.
- Body said \"If a Phase 3 demands real v6b drop-in...\" — Phase 3 is closed.

The actual tracker for the per-ABI cdylib matrix that unblocks T4 is **P2-A** in the master plan (\`/Users/yhkwon/.claude/plans/dreamy-moseying-swing.md\`). A reader who follows README's T4 \"non-goal\" link to this section should immediately see the live tracker ID.

This PR retitles the section, replaces the stale Phase-3 sentence with a direct reference to P2-A, and adds a brief mention of bindgen / build-time code-gen (which the plan already calls out as the practical avoidance of hand-maintaining three ~200-field struct mirrors). No behavioural change.

## Test plan

- [x] Doc-only change — pre-commit hook (fmt + clippy) passes; nothing to test at runtime.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)