### PR TITLE
chore: release 0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "libjpeg-turbo-rs"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "criterion",
  "loom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/libjpeg-turbo-rs-wasm", "crates/libjpeg-turbo-rs-image",
 
 [package]
 name = "libjpeg-turbo-rs"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 rust-version = "1.87"
 description = "Pure Rust reimplementation of libjpeg-turbo with NEON/AVX2 SIMD acceleration"

--- a/docs/superpowers/plans/2026-07-12-release-0.6.3.md
+++ b/docs/superpowers/plans/2026-07-12-release-0.6.3.md
@@ -1,0 +1,58 @@
+# libjpeg-turbo-rs 0.6.3 Release Implementation Plan
+
+> **For Codex:** Execute this plan task-by-task. Do not publish the tag until every pre-release gate is green.
+
+**Goal:** Publish the merged JPEG decoder stability fixes as `libjpeg-turbo-rs` version `0.6.3` on crates.io.
+
+**Architecture:** Use the repository's existing tag-driven release workflow. Land a focused version-bump PR first, wait for PR and post-merge CI, then push `v0.6.3` and verify the release workflow and crates.io index. The C API and WASM package versions remain unchanged, but the `v*` workflow still tests/builds both and exercises their duplicate-version publish handling.
+
+**Tech Stack:** Cargo, GitHub Actions, GitHub CLI, crates.io.
+
+---
+
+### Task 1: Verify release prerequisites
+
+**Files:**
+- Read: `.github/workflows/release.yml`
+- Read: `Cargo.toml`
+- Read: `Cargo.lock`
+
+- [ ] Confirm `main` contains merge commit `5e58f492305aea94addd277f9408d1114817ccb8`.
+- [ ] Wait for all post-merge CI jobs for that commit, including Corpus Test, to pass.
+- [ ] Confirm crates.io currently serves `0.6.2` and does not already contain `0.6.3`.
+- [ ] Confirm prior Rust release tag convention and the release workflow trigger.
+
+### Task 2: Prepare the 0.6.3 version bump
+
+**Files:**
+- Modify: `Cargo.toml:6`
+- Modify: `Cargo.lock:684`
+
+- [ ] Create branch `release/0.6.3` from the verified `main` commit.
+- [ ] Change only the root crate version from `0.6.2` to `0.6.3` and refresh the lockfile.
+- [ ] Run `cargo fmt --all --check`.
+- [ ] Run `cargo publish --dry-run --locked` to validate the package contents and dependency metadata.
+- [ ] Inspect the package file list/archive produced by Cargo; note that CI publishes with `--allow-dirty`.
+- [ ] Inspect the diff and confirm existing untracked fuzz corpus, probe files, and dirty reference submodule are untouched.
+
+### Task 3: Review and open the release PR
+
+- [ ] Obtain an independent review of the version-only change.
+- [ ] Commit with `git commit -s -m "chore: release 0.6.3"`.
+- [ ] Push `release/0.6.3` and open a focused PR describing the published scope and verification.
+- [ ] Wait for every required PR check to pass, including Corpus Test.
+- [ ] Review the final PR diff and confirm it is ready to merge.
+
+### Task 4: Tag and publish
+
+- [ ] Merge with `gh pr merge --merge`, sync with `git pull --ff-only`, and wait for all post-merge checks on that exact release merge SHA.
+- [ ] Create lightweight tag `v0.6.3` to match the latest root tag `v0.6.2`; verify it targets the green release merge SHA before pushing it.
+- [ ] Watch all tag-triggered Release jobs to completion: root publish, C API, and WASM.
+- [ ] Require the root publish job to succeed and verify exact `libjpeg-turbo-rs 0.6.3` availability plus registry/index propagation.
+- [ ] Inspect C API `0.1.0` and WASM `0.2.0` logs to confirm their builds/tests pass and publish attempts end only through expected duplicate-version handling.
+- [ ] Create a clean temporary Cargo consumer pinned to `libjpeg-turbo-rs = "=0.6.3"` and confirm `cargo metadata`/`cargo check` resolve it.
+
+### Task 5: Report release evidence
+
+- [ ] Record the release PR, merge SHA, tag, GitHub Actions run, and crates.io version.
+- [ ] Report intentionally unchanged package versions (`libjpeg-turbo-rs-capi 0.1.0`, WASM/npm `0.2.0`) and their workflow outcomes explicitly.


### PR DESCRIPTION
## Summary
- bump the root `libjpeg-turbo-rs` crate from 0.6.2 to 0.6.3
- publish the merged JPEG decoder stability fixes, including the 12-bit sampling-layout bounds fix
- record the release gates and post-publish verification plan

## Verification
- `cargo fmt --all --check`
- `cargo package --list --locked --allow-dirty` (316 files)
- `cargo publish --dry-run --locked --allow-dirty`
- post-merge CI for decoder fix commit `5e58f492305aea94addd277f9408d1114817ccb8`, including Corpus Test (C parity)

C API remains 0.1.0 and WASM/npm remains 0.2.0; the tag workflow will still test/build both and verify duplicate-version publish handling.