### PR TITLE
ci: bound the mutation job instead of letting it time out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,25 @@ jobs:
         run: |
           git diff "origin/${{ github.base_ref || 'main' }}"...HEAD > /tmp/pr.diff
           wc -l /tmp/pr.diff
+      # Bounded on purpose. A large diff can produce hundreds of mutants, each
+      # rebuilding and re-running three test binaries, and the first PR to
+      # touch `compress_cmyk` blew straight through the 30-minute step limit —
+      # a job that times out reports "fail" and tells the reader nothing. So
+      # the work is capped at what fits, and whatever is skipped is announced
+      # rather than quietly dropped.
       - name: Mutate only the changed lines
         run: |
-          cargo mutants --in-diff /tmp/pr.diff -j 4 --timeout 300 \
+          set -uo pipefail
+          TOTAL=$(cargo mutants --in-diff /tmp/pr.diff --list 2>/dev/null | wc -l)
+          echo "$TOTAL mutants in the changed lines"
+          # ~90 mutants is what this job gets through inside its step timeout.
+          BUDGET=90
+          SHARDS=$(( (TOTAL + BUDGET - 1) / BUDGET ))
+          if [ "$SHARDS" -lt 1 ]; then SHARDS=1; fi
+          if [ "$SHARDS" -gt 1 ]; then
+            echo "::warning::$TOTAL mutants exceed this job's budget; testing shard 0/$SHARDS (~$BUDGET) and skipping the other $(( TOTAL - TOTAL / SHARDS )). A clean result here does NOT mean the whole diff was checked."
+          fi
+          cargo mutants --in-diff /tmp/pr.diff --shard "0/$SHARDS" -j 4 --timeout 300 \
             --cargo-test-arg --test --cargo-test-arg encode_pipeline_golden \
             --cargo-test-arg --test --cargo-test-arg encode_option_matrix \
             --cargo-test-arg --test --cargo-test-arg encode_input_validation \

--- a/docs/last_mile/phase4.md
+++ b/docs/last_mile/phase4.md
@@ -888,6 +888,8 @@ Two real gaps were found and closed on the way:
 
 **Criterion 3 — `--in-diff` in CI.** A non-blocking `Mutation test (changed lines)` job mutates only what a PR touches. Non-blocking on purpose: a surviving mutant is sometimes an equivalent mutant, a judgement call rather than a defect, and failing the build on it would train people to ignore the job.
 
+The job is also **time-bounded**, which the first large PR through it proved necessary: P4-39's CMYK diff produced enough mutants to run past the 30-minute step limit, and a timed-out job reports `fail` while telling the reader nothing. It now counts the mutants first and shards down to what fits, emitting a `::warning::` naming how many it skipped — a clean result on a large diff means "the sampled shard was clean", not "the diff was checked".
+
 ## P4-49. `smoothing_factor` Is A Silent No-Op For Grayscale — **CLOSED 2026-07-26**
 
 **Motivation.** Found 2026-07-26 by the metamorphic option matrix while closing the baseline half of P4-46. GitHub [#327](https://github.com/developer0hye/libjpeg-turbo-rs/issues/327).


### PR DESCRIPTION
The first large PR through `Mutation test (changed lines)` — #341's CMYK diff — produced enough mutants to run past the 30-minute step limit.

A timed-out job reports `fail` and tells the reader nothing, which is worse than not running it at all: the signal it exists to give is absent, and the red mark says something untrue about the code.

## Change

Count the mutants first, shard down to roughly what fits in the budget, and emit a `::warning::` naming how many were skipped:

```
::warning::412 mutants exceed this job's budget; testing shard 0/5 (~90) and
skipping the other 330. A clean result here does NOT mean the whole diff was checked.
```

A clean result on a large diff means "the sampled shard was clean", not "the diff was checked" — the job now says so rather than leaving the reader to assume.

Shard indices are 0-based (`--shard k/n` rejects `k == n`), confirmed against the installed cargo-mutants rather than assumed.

CI-only; no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)