### PR TITLE
bench: widen the zune-jpeg comparison matrix beyond 4:2:0 baseline (closes #360)

### DIFF
--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -5,11 +5,56 @@ struct CompareCase {
     path: &'static str,
 }
 
+// Every subsampling × {baseline, progressive} × size tier must be
+// represented: the pre-#360 matrix covered only 4:2:0/4:4:4 baseline,
+// which is exactly why the 4:2:2, small-image, and progressive losses
+// to zune-jpeg went unnoticed (issues #350–#353). The wide sweep with
+// allocation metrics lives in `examples/bench_zune_matrix.rs`; this
+// criterion set is the statistically-rigorous subset.
 const COMPARE_CASES: &[CompareCase] = &[
+    // tiny — fixed cost dominates (#351)
+    CompareCase {
+        name: "gray_8x8",
+        path: "tests/fixtures/gray_8x8.jpg",
+    },
+    CompareCase {
+        name: "16x16_420",
+        path: "tests/fixtures/blue_16x16_420.jpg",
+    },
+    CompareCase {
+        name: "64x64_420",
+        path: "tests/fixtures/photo_64x64_420.jpg",
+    },
+    // small / medium, all subsamplings (#350)
+    CompareCase {
+        name: "320x240_422",
+        path: "tests/fixtures/photo_320x240_422.jpg",
+    },
+    CompareCase {
+        name: "320x240_444",
+        path: "tests/fixtures/photo_320x240_444.jpg",
+    },
     CompareCase {
         name: "640x480",
         path: "tests/fixtures/gradient_640x480.jpg",
     },
+    CompareCase {
+        name: "640x480_422",
+        path: "tests/fixtures/photo_640x480_422.jpg",
+    },
+    CompareCase {
+        name: "640x480_444",
+        path: "tests/fixtures/photo_640x480_444.jpg",
+    },
+    CompareCase {
+        name: "640x480_420_rst",
+        path: "tests/fixtures/photo_640x480_420_rst.jpg",
+    },
+    CompareCase {
+        name: "graphic_640x480",
+        path: "tests/fixtures/graphic_640x480_420.jpg",
+    },
+    // HD and up
     CompareCase {
         name: "1280x720",
         path: "tests/fixtures/photo_1280x720_420.jpg",
@@ -19,6 +64,14 @@ const COMPARE_CASES: &[CompareCase] = &[
         path: "tests/fixtures/photo_1920x1080_420.jpg",
     },
     CompareCase {
+        name: "1920x1080_422",
+        path: "tests/fixtures/photo_1920x1080_422.jpg",
+    },
+    CompareCase {
+        name: "1920x1080_444",
+        path: "tests/fixtures/photo_1920x1080_444.jpg",
+    },
+    CompareCase {
         name: "2560x1440",
         path: "tests/fixtures/photo_2560x1440_420.jpg",
     },
@@ -26,13 +79,27 @@ const COMPARE_CASES: &[CompareCase] = &[
         name: "3840x2160",
         path: "tests/fixtures/photo_3840x2160_420.jpg",
     },
+    // progressive (#352)
     CompareCase {
-        name: "320x240_444",
-        path: "tests/fixtures/photo_320x240_444.jpg",
+        name: "320x240_420_prog",
+        path: "tests/fixtures/photo_320x240_420_prog.jpg",
     },
     CompareCase {
-        name: "graphic_640x480",
-        path: "tests/fixtures/graphic_640x480_420.jpg",
+        name: "1920x1080_420_prog",
+        path: "tests/fixtures/photo_1920x1080_420_prog.jpg",
+    },
+    CompareCase {
+        name: "3840x2160_420_prog",
+        path: "tests/fixtures/photo_3840x2160_420_prog.jpg",
+    },
+    // 8K real-world (#352's superlinear-scaling witness)
+    CompareCase {
+        name: "8k_420",
+        path: "tests/fixtures/real_world/derived_7680x4320_8k_420_q75.jpg",
+    },
+    CompareCase {
+        name: "8k_progressive",
+        path: "tests/fixtures/real_world/derived_7680x4320_8k_progressive.jpg",
     },
 ];
 

--- a/examples/bench_zune_matrix.rs
+++ b/examples/bench_zune_matrix.rs
@@ -1,0 +1,325 @@
+//! Wide-matrix decode comparison vs `zune-jpeg` (issue #360).
+//!
+//! Covers every subsampling (4:2:0 / 4:2:2 / 4:4:4 / 4:4:0 / grayscale)
+//! × {baseline, progressive} × resolution tiers from 8×8 to 8K, plus
+//! restart-interval and content-type cases — the categories whose
+//! absence from `benches/compare.rs` hid the #350/#351/#352 losses.
+//!
+//! Per case it reports best-of-N wall clock, allocation count, and
+//! allocated bytes for BOTH decoders, asserts output-length parity
+//! (loudly flagging mismatches instead of reporting them as speed
+//! differences), and ends with a win/loss summary so a single-mode
+//! regression cannot hide in an average.
+//!
+//! Run with: `cargo run --release --example bench_zune_matrix`
+//! (benchmarks must run alone — no parallel builds or tests.)
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::time::Instant;
+
+struct CountingAllocator;
+
+thread_local! {
+    static COUNTING: Cell<bool> = const { Cell::new(false) };
+    static ALLOC_COUNT: Cell<usize> = const { Cell::new(0) };
+    static ALLOC_BYTES: Cell<usize> = const { Cell::new(0) };
+}
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        record(layout.size());
+        System.alloc(layout)
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout)
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        record(new_size);
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+fn record(size: usize) {
+    COUNTING.with(|c| {
+        if c.get() {
+            ALLOC_COUNT.with(|n| n.set(n.get() + 1));
+            ALLOC_BYTES.with(|b| b.set(b.get() + size));
+        }
+    });
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn count_allocs<F: FnOnce()>(f: F) -> (usize, usize) {
+    ALLOC_COUNT.with(|n| n.set(0));
+    ALLOC_BYTES.with(|b| b.set(0));
+    COUNTING.with(|c| c.set(true));
+    f();
+    COUNTING.with(|c| c.set(false));
+    (ALLOC_COUNT.with(|n| n.get()), ALLOC_BYTES.with(|b| b.get()))
+}
+
+/// Best-of-N wall clock with a per-case time budget: keeps tiny images
+/// statistically meaningful (thousands of iterations) without letting
+/// 8K cases run for minutes.
+fn best_of_budget<F: FnMut()>(mut f: F) -> f64 {
+    // Warm-up + single-shot estimate.
+    let t = Instant::now();
+    f();
+    let est_us: f64 = t.elapsed().as_secs_f64() * 1e6;
+    let iters: usize = ((1_500_000.0 / est_us.max(1.0)) as usize).clamp(5, 20_000);
+    for _ in 0..iters / 20 {
+        f();
+    }
+    let mut best = f64::INFINITY;
+    for _ in 0..iters {
+        let t = Instant::now();
+        f();
+        let dt = t.elapsed().as_secs_f64() * 1e6;
+        if dt < best {
+            best = dt;
+        }
+    }
+    best
+}
+
+struct CaseResult {
+    name: &'static str,
+    ours_us: f64,
+    zune_us: f64,
+    ours_allocs: usize,
+    ours_bytes: usize,
+    zune_allocs: usize,
+    zune_bytes: usize,
+    len_ours: usize,
+    len_zune: usize,
+}
+
+const CASES: &[(&str, &str)] = &[
+    // --- tiny (fixed cost dominates) ---
+    ("gray_8x8", "tests/fixtures/gray_8x8.jpg"),
+    ("blue_16x16_420", "tests/fixtures/blue_16x16_420.jpg"),
+    (
+        "blue_16x16_420_prog",
+        "tests/fixtures/blue_16x16_420_prog.jpg",
+    ),
+    ("photo_64x64_420", "tests/fixtures/photo_64x64_420.jpg"),
+    (
+        "photo_64x64_420_prog",
+        "tests/fixtures/photo_64x64_420_prog.jpg",
+    ),
+    (
+        "nonint_440_64x64",
+        "tests/fixtures/real_world/zune_non_interleaved_440_64x64.jpg",
+    ),
+    // --- small ---
+    ("photo_320x240_420", "tests/fixtures/photo_320x240_420.jpg"),
+    ("photo_320x240_422", "tests/fixtures/photo_320x240_422.jpg"),
+    ("photo_320x240_444", "tests/fixtures/photo_320x240_444.jpg"),
+    (
+        "photo_320x240_420_prog",
+        "tests/fixtures/photo_320x240_420_prog.jpg",
+    ),
+    (
+        "gray_227x149",
+        "tests/fixtures/real_world/derived_227x149_grayscale_q90.jpg",
+    ),
+    // --- medium ---
+    ("photo_640x480_420", "tests/fixtures/photo_640x480_420.jpg"),
+    ("photo_640x480_422", "tests/fixtures/photo_640x480_422.jpg"),
+    ("photo_640x480_444", "tests/fixtures/photo_640x480_444.jpg"),
+    (
+        "photo_640x480_420_rst",
+        "tests/fixtures/photo_640x480_420_rst.jpg",
+    ),
+    (
+        "photo_640x480_422_prog",
+        "tests/fixtures/photo_640x480_422_prog.jpg",
+    ),
+    (
+        "photo_640x480_444_prog",
+        "tests/fixtures/photo_640x480_444_prog.jpg",
+    ),
+    ("gradient_640x480", "tests/fixtures/gradient_640x480.jpg"),
+    (
+        "graphic_640x480_420",
+        "tests/fixtures/graphic_640x480_420.jpg",
+    ),
+    (
+        "checker_640x480_420",
+        "tests/fixtures/checker_640x480_420.jpg",
+    ),
+    // --- HD ---
+    (
+        "photo_1280x720_420",
+        "tests/fixtures/photo_1280x720_420.jpg",
+    ),
+    (
+        "photo_1920x1080_420",
+        "tests/fixtures/photo_1920x1080_420.jpg",
+    ),
+    (
+        "photo_1920x1080_422",
+        "tests/fixtures/photo_1920x1080_422.jpg",
+    ),
+    (
+        "photo_1920x1080_444",
+        "tests/fixtures/photo_1920x1080_444.jpg",
+    ),
+    (
+        "graphic_1920x1080_420",
+        "tests/fixtures/graphic_1920x1080_420.jpg",
+    ),
+    (
+        "photo_1920x1080_420_prog",
+        "tests/fixtures/photo_1920x1080_420_prog.jpg",
+    ),
+    (
+        "photo_1920x1080_422_prog",
+        "tests/fixtures/photo_1920x1080_422_prog.jpg",
+    ),
+    (
+        "photo_1920x1080_444_prog",
+        "tests/fixtures/photo_1920x1080_444_prog.jpg",
+    ),
+    (
+        "gray_900x675_prog",
+        "tests/fixtures/real_world/zune_grayscale_progressive_900x675.jpg",
+    ),
+    // --- QHD / 4K / 8K ---
+    (
+        "photo_2560x1440_420",
+        "tests/fixtures/photo_2560x1440_420.jpg",
+    ),
+    (
+        "photo_3840x2160_420",
+        "tests/fixtures/photo_3840x2160_420.jpg",
+    ),
+    (
+        "photo_3840x2160_420_prog",
+        "tests/fixtures/photo_3840x2160_420_prog.jpg",
+    ),
+    (
+        "rw_2048x1536_q90",
+        "tests/fixtures/real_world/derived_2048x1536_baseline_q90.jpg",
+    ),
+    (
+        "rw_4k_420_q85",
+        "tests/fixtures/real_world/derived_3840x2160_4k_420_q85.jpg",
+    ),
+    (
+        "rw_4k_progressive",
+        "tests/fixtures/real_world/derived_3840x2160_4k_progressive.jpg",
+    ),
+    (
+        "rw_8k_420_q75",
+        "tests/fixtures/real_world/derived_7680x4320_8k_420_q75.jpg",
+    ),
+    (
+        "rw_8k_progressive",
+        "tests/fixtures/real_world/derived_7680x4320_8k_progressive.jpg",
+    ),
+];
+
+fn main() {
+    let mut results: Vec<CaseResult> = Vec::new();
+
+    for &(name, path) in CASES {
+        let jpeg = std::fs::read(path).unwrap_or_else(|_| panic!("{path} fixture required"));
+
+        // Allocation profile: one decode per decoder under the counter.
+        let mut len_ours = 0usize;
+        let (ours_allocs, ours_bytes) = count_allocs(|| {
+            let img = libjpeg_turbo_rs::decompress(&jpeg).expect("ours decode");
+            len_ours = img.data.len();
+        });
+        let mut len_zune = 0usize;
+        let (zune_allocs, zune_bytes) = count_allocs(|| {
+            let cursor = std::io::Cursor::new(&jpeg);
+            let mut decoder = zune_jpeg::JpegDecoder::new(cursor);
+            let pixels = decoder.decode().expect("zune decode");
+            len_zune = pixels.len();
+        });
+
+        let ours_us = best_of_budget(|| {
+            let img = libjpeg_turbo_rs::decompress(std::hint::black_box(&jpeg)).unwrap();
+            std::hint::black_box(&img.data);
+        });
+        let zune_us = best_of_budget(|| {
+            let cursor = std::io::Cursor::new(std::hint::black_box(&jpeg));
+            let mut decoder = zune_jpeg::JpegDecoder::new(cursor);
+            let pixels = decoder.decode().unwrap();
+            std::hint::black_box(&pixels);
+        });
+
+        results.push(CaseResult {
+            name,
+            ours_us,
+            zune_us,
+            ours_allocs,
+            ours_bytes,
+            zune_allocs,
+            zune_bytes,
+            len_ours,
+            len_zune,
+        });
+    }
+
+    println!(
+        "{:<26} {:>10} {:>10} {:>6}  {:>7} {:>12}  {:>7} {:>12}  {}",
+        "case", "ours(us)", "zune(us)", "ratio", "allocs", "bytes", "z.allocs", "z.bytes", "parity"
+    );
+    let (mut wins, mut losses, mut ties, mut mismatches) = (0usize, 0usize, 0usize, 0usize);
+    let mut loss_names: Vec<String> = Vec::new();
+    for r in &results {
+        let ratio = r.ours_us / r.zune_us;
+        // Output-length parity: a decoder emitting a different pixel
+        // format must be flagged, not scored (criterion 4 of #360).
+        let parity = if r.len_ours == r.len_zune {
+            "ok".to_string()
+        } else {
+            mismatches += 1;
+            format!("LEN-MISMATCH ours={} zune={}", r.len_ours, r.len_zune)
+        };
+        if r.len_ours == r.len_zune {
+            if ratio <= 0.98 {
+                wins += 1;
+            } else if ratio >= 1.02 {
+                losses += 1;
+                loss_names.push(format!("{} ({ratio:.2}x)", r.name));
+            } else {
+                ties += 1;
+            }
+        }
+        println!(
+            "{:<26} {:>10.1} {:>10.1} {:>6.2}  {:>7} {:>12}  {:>7} {:>12}  {}",
+            r.name,
+            r.ours_us,
+            r.zune_us,
+            ratio,
+            r.ours_allocs,
+            r.ours_bytes,
+            r.zune_allocs,
+            r.zune_bytes,
+            parity
+        );
+    }
+
+    println!(
+        "\nsummary: {wins} wins / {losses} losses / {ties} ties (±2% threshold, \
+         {} scored cases) + {mismatches} format-mismatch cases (unscored)",
+        wins + losses + ties
+    );
+    if !loss_names.is_empty() {
+        println!("losses: {}", loss_names.join(", "));
+    }
+    if mismatches > 0 {
+        println!(
+            "note: LEN-MISMATCH cases compare different output formats \
+             (e.g. zune expands grayscale to RGB); their timings are \
+             printed for reference but excluded from win/loss."
+        );
+    }
+}

--- a/experiments/x86_64_avx2_final_report.md
+++ b/experiments/x86_64_avx2_final_report.md
@@ -65,7 +65,7 @@
 - **4:2:0 baseline**: Rust is now **0.83-0.98x C** across all resolutions (faster than C!)
 - **4:2:2 / 4:4:4**: Rust is **0.83-0.93x C** (significantly faster than C)
 - **Progressive**: Rust is **0.83-0.91x C** (faster than C across the board)
-- **vs zune-jpeg**: Rust is **19-21% faster** at large resolutions
+- **vs zune-jpeg**: Rust is **19-21% faster** on the cases measured here — **4:2:0/4:4:4 baseline at 640x480 and above only**. The 2026-07-26 wide-matrix analysis (issue #361) found the *unmeasured* categories losing to zune at the time: 4:2:2 (1.11-1.24x, #350), tiny images (2-3.6x, #351), and 8K progressive (1.30x, #352). Do not quote this line without the coverage caveat; the wide matrix lives in `examples/bench_zune_matrix.rs` (#360).
 - **Average improvement from baseline**: ~10% on 4:2:0, up to 30% on graphic content
 
 ### Encode

--- a/experiments/zune_matrix_aarch64_2026-07-27.md
+++ b/experiments/zune_matrix_aarch64_2026-07-27.md
@@ -1,0 +1,56 @@
+# zune-jpeg wide-matrix decode baseline — aarch64 (issue #360)
+
+Machine: Apple M-series (aarch64-apple-darwin), macOS, rustc 1.94.1, --release (lto). Ours = libjpeg_turbo_rs::decompress() @ main+#351 (0dcf778); zune = zune-jpeg 0.5.15 with default options. Metric = best-of-N (budgeted), single allocation profile per decoder. Harness: examples/bench_zune_matrix.rs. Date: 2026-07-27.
+
+Run: cargo run --release --example bench_zune_matrix
+
+```
+case                         ours(us)   zune(us)  ratio   allocs        bytes  z.allocs      z.bytes  parity
+gray_8x8                          3.1        2.4   1.32       12        27714        3          816  LEN-MISMATCH ours=64 zune=192
+blue_16x16_420                    6.7        5.6   1.19       19        20070       18         4944  ok
+blue_16x16_420_prog               9.1        8.0   1.14       51        51175       21         5488  ok
+photo_64x64_420                  27.1       31.8   0.85       19        37542       18        24528  ok
+photo_64x64_420_prog             62.3       68.5   0.91       51        80167       21        35920  ok
+nonint_440_64x64                 10.8        8.1   1.33       17        47328       22        42320  ok
+photo_320x240_420               412.5      556.8   0.74       19       365734       18       285648  ok
+photo_320x240_422               516.9      709.4   0.73       17       556454       18       267088  ok
+photo_320x240_444               777.7     1066.6   0.73       15       479654        5       247248  ok
+photo_320x240_420_prog         1182.8     1278.7   0.93       51       626471       21       511568  ok
+gray_227x149                     39.4       65.6   0.60        9        78625        3       105677  LEN-MISMATCH ours=33823 zune=101469
+photo_640x480_420               906.7     1157.3   0.78       19      1403814       18      1030608  ok
+photo_640x480_422              1788.2     2436.2   0.73       17      2169254       18       993488  ok
+photo_640x480_444              2704.5     3672.8   0.74       15      1862054        5       953808  ok
+photo_640x480_420_rst           413.1      558.0   0.74       19       365734       18       285648  ok
+photo_640x480_422_prog         5007.8     5535.1   0.90       49      3428391       21      2213328  ok
+photo_640x480_444_prog         7516.8     8186.6   0.92       47      3735591        8      2797008  ok
+gradient_640x480                415.8      600.5   0.69       19      1403814       18      1030608  ok
+graphic_640x480_420             350.7      410.3   0.85       19      1403814       18      1030608  ok
+checker_640x480_420             823.5     1124.3   0.73       19      1403814       18      1030608  ok
+photo_1280x720_420             4968.2     6680.5   0.74       19      4171174       18      2981328  ok
+photo_1920x1080_420           11207.1    15063.5   0.74       19      9380774       18      6544848  ok
+photo_1920x1080_422           13934.2    19286.8   0.72       17     14534054       18      6433488  ok
+photo_1920x1080_444           21042.0    29058.8   0.72       15     12460454        5      6314448  ok
+graphic_1920x1080_420          1752.8     1866.0   0.94       19      9380774       18      6544848  ok
+photo_1920x1080_420_prog      33612.7    35130.1   0.96       51     15677991       21     12784848  ok
+photo_1920x1080_422_prog      41405.8    43678.1   0.95       49     22858791       21     14701008  ok
+photo_1920x1080_444_prog      61366.9    64080.5   0.96       47     24932391        8     18756048  ok
+gray_900x675_prog              3307.7     3665.8   0.90       27      2514181        4      3066900  LEN-MISMATCH ours=607500 zune=1822500
+photo_2560x1440_420           19878.1    26848.2   0.74       19     16617894       18     11490768  ok
+photo_3840x2160_420           44881.6    60506.8   0.74       19     37359014       18     25529808  ok
+photo_3840x2160_420_prog     134617.0   140301.1   0.96       51     62272551       21     50359248  ok
+rw_2048x1536_q90               9222.2    11574.8   0.80       19     14182822       18      9782736  ok
+rw_4k_420_q85                  8315.8     9586.5   0.87       19     37359014       18     25529808  ok
+rw_4k_progressive             18610.0    17028.8   1.09       51     62272551       21     50359248  ok
+rw_8k_420_q75                 28285.1    30309.3   0.93       19    149348774       18    100824528  ok
+rw_8k_progressive             70683.8    53051.0   1.33       51    248911911       21    200249808  ok
+
+summary: 29 wins / 5 losses / 0 ties (±2% threshold, 34 scored cases) + 3 format-mismatch cases (unscored)
+losses: blue_16x16_420 (1.19x), blue_16x16_420_prog (1.14x), nonint_440_64x64 (1.33x), rw_4k_progressive (1.09x), rw_8k_progressive (1.33x)
+note: LEN-MISMATCH cases compare different output formats (e.g. zune expands grayscale to RGB); their timings are printed for reference but excluded from win/loss.
+```
+
+## Reading
+
+- 4:2:2 wins here (0.72-0.73) predate #350 on this arch — aarch64 never had the x86 4:2:2 regression; #350 removed the 4.2 MB full-res chroma traffic structurally.
+- Remaining losses map to open issues: tiny-image tail (#351 follow-up territory), non-interleaved 4:4:0 (multi-scan path), and the progressive superlinear scaling (#352: 4K prog 1.10x -> 8K prog 1.33x, reproducing the EPYC pattern locally).
+- Grayscale cases are LEN-MISMATCH by design: zune expands grayscale to RGB, we emit 1-channel — flagged, not scored.


### PR DESCRIPTION
Closes #360. Third item of the zune-gap program (#361 / P4-55).

`benches/compare.rs` — our only zune-jpeg comparison — measured seven 4:2:0/4:4:4 baseline photos and nothing else. The 2026-07-26 analysis found every loss (**4:2:2, tiny images, 8K progressive**) sitting exactly in the unmeasured categories, while the harness kept producing the "19–21% faster than zune" line that got quoted as a general claim. A benchmark that only measures where we win is worse than no benchmark.

## What landed

- **`examples/bench_zune_matrix.rs`** — a 37-case sweep: every subsampling (4:2:0/4:2:2/4:4:4/4:4:0/grayscale) × {baseline, progressive} × sizes 8×8 → 8K, plus restart-interval and content-type cases, all from committed fixtures. Per case it reports best-of-N wall clock **and allocation count/bytes for both decoders** (the counting allocator is what found #350's root cause in one run), asserts output-length parity — a decoder emitting a different pixel format is flagged `LEN-MISMATCH` and excluded from scoring instead of being reported as a speed difference — and ends with a win/loss summary so a single-mode regression cannot be averaged away.
- **`benches/compare.rs`** extended 7 → 21 cases with the same category coverage, for criterion-grade local A/Bs.
- **`experiments/zune_matrix_aarch64_2026-07-27.md`** — the new committed baseline: **29 wins / 5 losses / 3 unscored format-mismatches** on aarch64 at main+#351. The five losses map one-to-one onto open issues: tiny-image tail (blue_16x16 1.19×/1.14×), non-interleaved 4:4:0 (1.32×), and #352's progressive scaling — which this matrix **reproduces locally** (4K prog 1.10× → 8K prog 1.33×, the same superlinear pattern as the EPYC box), making #352 debuggable on this machine.
- **`experiments/x86_64_avx2_final_report.md`** — the "19–21% faster" line now carries its coverage caveat and points here.

No library code changes; benches/examples/docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)