### PR TITLE
chore: cut the 0.8.0 changelog section for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and `git log` between tags.
 
 ## [Unreleased]
 
+Nothing yet.
+
+## [0.8.0] - 2026-07-28
+
 ### Added
 - `decompress_from_reader_incremental`: bounded-input-memory decode
   from any `Read` source — interleaved baseline JPEGs decode from a
@@ -170,7 +174,8 @@ First release with the full T1 (Rust crate) + T2 (TurboJPEG 3 cdylib)
 djpeg/cjpeg/jpegtran parity, Pillow/libtiff integration, panic guards
 on all C entry points.
 
-[Unreleased]: https://github.com/developer0hye/libjpeg-turbo-rs/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/developer0hye/libjpeg-turbo-rs/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/developer0hye/libjpeg-turbo-rs/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/developer0hye/libjpeg-turbo-rs/compare/v0.6.3...v0.7.0
 [0.6.3]: https://github.com/developer0hye/libjpeg-turbo-rs/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/developer0hye/libjpeg-turbo-rs/compare/v0.6.1...v0.6.2


### PR DESCRIPTION
Renames `Unreleased` → `0.8.0 - 2026-07-28` (fresh empty Unreleased added, compare links updated) so the `changelog-check` release gate passes when the `v0.8.0` tag is pushed. Release contents: everything in the 0.8.0 section — the #350–#361 and #380–#392 program closures, probe/chainable API, incremental reader, safety-posture phase 1, release/QA hygiene, scalar color tables.

Publishes on tag: root 0.8.0 → capi 0.1.2 → image 0.1.0 (first publish) → npm → GitHub Release, per the sequenced pipeline. Closes the last mechanical gap of #380.

Related: #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)