### PR TITLE
fix: stop 4:4:1 trim from rejecting short images

### DIFF
--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -294,7 +294,7 @@
 
 ### Options (TJXOPT flags)
 - [x] TJXOPT_PERFECT (1) — Fail if transform is not perfect (partial iMCU) (`TransformOptions.perfect`)
-- [x] TJXOPT_TRIM (2) — Discard partial iMCU edges (`TransformOptions.trim`)
+- [x] TJXOPT_TRIM (2) — Discard partial iMCU edges (`TransformOptions.trim`); an axis holding less than one whole iMCU is left untrimmed rather than rejected, matching `trim_right_edge`/`trim_bottom_edge` (P4-117)
 - [x] TJXOPT_CROP (4) — Enable lossless cropping region (`TransformOptions.crop`)
 - [x] TJXOPT_GRAY (8) — Convert to grayscale during transform (`TransformOptions.grayscale`)
 - [x] TJXOPT_NOOUTPUT (16) — Dry run (no output image) (`TransformOptions.no_output`)

--- a/docs/last_mile/phase4.md
+++ b/docs/last_mile/phase4.md
@@ -75,6 +75,7 @@
 | P4-114 | OPEN (`jpeg_has_multiple_scans` equates multi-scan with progressive) |
 | P4-115 | OPEN (native 12-bit coverage claims include modes and sampling layouts that are not tested) |
 | P4-116 | OPEN (C-parity tests can convert Rust/oracle failures or missing comparisons into a pass) |
+| P4-117 | CLOSED 2026-08-08 (4:4:1 trim rejected images shorter than one iMCU row) |
 | P4-120 | OPEN (classic-shim allocation-failure paths are unreachable from tests) |
 
 ---
@@ -2296,3 +2297,47 @@ allocation.
 **Why deferred.** P4-108 delivers the behaviour; this is test reachability for
 one error path. It belongs with the wider test-integrity work in **P4-116**
 rather than blocking the destination-ownership fix.
+
+## P4-117. 4:4:1 Trim Rejected Images Shorter Than One iMCU Row — **CLOSED 2026-08-08**
+
+**Motivation.** Filed 2026-08-02 as GitHub [#439](https://github.com/developer0hye/libjpeg-turbo-rs/issues/439)
+while making the P4-116 transform matrices fail closed; this phase-file entry
+was missed at filing time and is added here with its closure. The 35x27
+non-MCU-aligned 4:4:1 fixture reported 78 attempted trim cases and only 70
+completions — `VFlip`, `Rot90`, `Rot180` and `Transverse`, in both baseline and
+progressive output, returned `trim would remove all image data`.
+
+**Root cause.** 4:4:1 is `h_samp=1, v_samp=4`, so its iMCU is 8 wide by **32
+tall**. A 27-row image therefore contains zero whole iMCU rows, and
+`transform_coefficients` computed `(27 / 32) * 32 == 0` and rejected the
+transform outright.
+
+Upstream has no such error path. `trim_right_edge` and `trim_bottom_edge`
+(transupp.c:1570-1592) each open with `if (MCU_cols > 0 && …)` /
+`if (MCU_rows > 0 && …)`: an axis holding less than one whole iMCU is simply
+left untrimmed. Measured against stock `jpegtran -trim` on exactly this input:
+
+| op | C output | reason |
+| --- | --- | --- |
+| hflip | 32x27 | width 35 → 32; height not trimmed by this op |
+| vflip | **35x27** | height 27 holds no whole iMCU — guard fires |
+| transpose | 27x35 | transpose never trims (transupp.c:1873) |
+| rot90 | **27x35** | output width comes from source height — guard fires |
+| rot180 | 32x27 | width trims; height guarded |
+| rot270 | 27x32 | output height comes from source width → 32 |
+| transverse | 27x32 | width → 32; height guarded |
+
+**Fix.** `src/api/coefficient.rs` routes both axes through
+`trim_to_whole_imcus`, which returns the extent unchanged when fewer than one
+iMCU fits, mirroring upstream's guard. The `trim would remove all image data`
+error is gone — as in C, trimming can no longer fail.
+
+**Status (2026-08-08): closed.** `tests/regression_s441_trim.rs` pins all seven
+operations: the geometry table above, a pixel-for-pixel cross-check against
+stock `jpegtran -trim` (both sides transforming the *same* source JPEG, decoded
+through the same `djpeg`, `max_diff == 0`), and a 4:2:0 control proving the
+guard does not weaken trimming where a whole iMCU does fit (35x27 → 32x16).
+Verified red before the fix: `vflip` and three others were rejected, 2 of 3
+tests failing. `cargo test --workspace --no-fail-fast`: 2458 passed, 0 failed,
+1 ignored. Once this merges, `cross_product_transform`'s trim carve-out
+assertion fires and directs the next session to delete it, restoring 78/78.

--- a/src/api/coefficient.rs
+++ b/src/api/coefficient.rs
@@ -568,6 +568,25 @@ pub fn write_coefficients(coeffs: &JpegCoefficients) -> Result<Vec<u8>> {
 /// and C TurboJPEG's `tjTransform` without `TJXOPT_COPYNONE`). Pass
 /// [`MarkerCopyMode::None`](crate::MarkerCopyMode::None) via [`transform_jpeg_with_options`] to strip
 /// markers instead.
+/// One axis of upstream's edge trimming.
+///
+/// Returns the largest whole number of iMCUs that fits in `extent`, or `extent`
+/// unchanged when fewer than one iMCU fits — mirroring the `MCU_cols > 0` /
+/// `MCU_rows > 0` guards in `trim_right_edge` / `trim_bottom_edge`
+/// (transupp.c:1570-1592). Dropping the guard turns "there is nothing to trim"
+/// into "trim everything", which is how P4-117 rejected valid 4:4:1 images.
+fn trim_to_whole_imcus(extent: usize, imcu: usize, trim: bool) -> usize {
+    if !trim || imcu == 0 {
+        return extent;
+    }
+    let whole_imcus: usize = extent / imcu;
+    if whole_imcus > 0 {
+        whole_imcus * imcu
+    } else {
+        extent
+    }
+}
+
 pub fn transform_jpeg(data: &[u8], op: TransformOp) -> Result<Vec<u8>> {
     transform_jpeg_with_options(
         data,
@@ -681,22 +700,19 @@ pub fn transform_jpeg_with_options(data: &[u8], options: &TransformOptions) -> R
             _ => has_partial_height,
         };
 
-        let trimmed_w: usize = if trim_width {
-            (coeffs.width as usize / imcu_w) * imcu_w
-        } else {
-            coeffs.width as usize
-        };
-        let trimmed_h: usize = if trim_height {
-            (coeffs.height as usize / imcu_h) * imcu_h
-        } else {
-            coeffs.height as usize
-        };
-
-        if trimmed_w == 0 || trimmed_h == 0 {
-            return Err(JpegError::CorruptData(
-                "trim would remove all image data".to_string(),
-            ));
-        }
+        // Trim to whole iMCUs, but only when at least one whole iMCU exists on
+        // that axis. Upstream guards each edge the same way — `trim_right_edge`
+        // and `trim_bottom_edge` (transupp.c:1570-1592) both begin
+        // `if (MCU_cols > 0 && ...)` / `if (MCU_rows > 0 && ...)`, so an image
+        // narrower or shorter than one iMCU is simply left alone.
+        //
+        // P4-117: without the guard, a 4:4:1 (h=1, v=4) image only 27 rows tall
+        // computes `(27 / 32) * 32 == 0` and the whole transform was rejected
+        // with "trim would remove all image data". C returns the untrimmed
+        // 35x27 for `-trim -flip vertical` on exactly that input, and there is
+        // no error path in upstream's trim at all.
+        let trimmed_w: usize = trim_to_whole_imcus(coeffs.width as usize, imcu_w, trim_width);
+        let trimmed_h: usize = trim_to_whole_imcus(coeffs.height as usize, imcu_h, trim_height);
 
         coeffs.width = trimmed_w as u16;
         coeffs.height = trimmed_h as u16;

--- a/tests/regression_s441_trim.rs
+++ b/tests/regression_s441_trim.rs
@@ -1,0 +1,226 @@
+//! Issue #439 / P4-117: `trim` rejected 4:4:1 images shorter than one iMCU row.
+//!
+//! 4:4:1 is `h_samp=1, v_samp=4`, so its iMCU is 8x32 — unusually tall. A 27-row
+//! image contains **zero** whole iMCU rows, and the trim path computed
+//! `(27 / 32) * 32 == 0` and rejected the whole transform with "trim would
+//! remove all image data".
+//!
+//! Upstream never errors here. `trim_right_edge` and `trim_bottom_edge`
+//! (transupp.c:1570-1592) each open with `if (MCU_cols > 0 && …)` /
+//! `if (MCU_rows > 0 && …)`, so an axis with less than one whole iMCU is simply
+//! left untrimmed. `jpegtran -trim -flip vertical` on this exact input returns
+//! the full 35x27.
+//!
+//! These tests pin the geometry for every operation and cross-validate the
+//! pixels against stock `jpegtran`, feeding both implementations the *same*
+//! input JPEG so only the transform is under comparison.
+
+mod helpers;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use libjpeg_turbo_rs::{
+    compress, decompress, transform_jpeg_with_options, PixelFormat, Subsampling, TransformOp,
+    TransformOptions,
+};
+
+/// Non-MCU-aligned on both axes for 4:4:1: 35 is not a multiple of 8, and 27 is
+/// less than one 32-row iMCU. Matches the fixture `cross_product_transform`
+/// uses, so the eight cases it had to exclude are the eight covered here.
+const W: usize = 35;
+const H: usize = 27;
+
+fn source_jpeg() -> Vec<u8> {
+    let mut pixels: Vec<u8> = Vec::with_capacity(W * H * 3);
+    for y in 0..H {
+        for x in 0..W {
+            pixels.push(((x * 7) % 256) as u8);
+            pixels.push(((y * 9) % 256) as u8);
+            pixels.push((((x + y) * 5) % 256) as u8);
+        }
+    }
+    compress(&pixels, W, H, PixelFormat::Rgb, 90, Subsampling::S441)
+        .expect("encode 4:4:1 source fixture")
+}
+
+/// Every transform, with the dimensions stock `jpegtran -trim` produces for
+/// this input. Measured against libjpeg-turbo 3.1.4.1; the reasoning for each
+/// is that an axis is only trimmed when at least one whole iMCU fits, and
+/// transposing ops swap which source axis feeds which output axis.
+///
+/// iMCU is 8 wide x 32 tall. Source width 35 holds four whole iMCUs (→ 32);
+/// source height 27 holds none (→ left at 27).
+const EXPECTED: &[(TransformOp, &str, usize, usize)] = &[
+    // Trims the source width only.
+    (TransformOp::HFlip, "hflip", 32, 27),
+    // Trims the source height only — which the guard leaves alone.
+    (TransformOp::VFlip, "vflip", 35, 27),
+    // Trims neither: transpose never trims (transupp.c:1873).
+    (TransformOp::Transpose, "transpose", 27, 35),
+    // Output width comes from source height (untrimmable), so nothing changes.
+    (TransformOp::Rot90, "rot90", 27, 35),
+    // Both axes; only the width has a whole iMCU to keep.
+    (TransformOp::Rot180, "rot180", 32, 27),
+    // Output height comes from source width, which trims to 32.
+    (TransformOp::Rot270, "rot270", 27, 32),
+    // Both: source width trims to 32 (becomes output height), source height
+    // is left at 27 (becomes output width).
+    (TransformOp::Transverse, "transverse", 27, 32),
+];
+
+/// Issue #439: no 4:4:1 trim transform may be rejected, and each must produce
+/// the same geometry stock `jpegtran -trim` does.
+#[test]
+fn issue_439_s441_trim_matches_jpegtran_geometry() {
+    let jpeg: Vec<u8> = source_jpeg();
+    for &(op, name, want_w, want_h) in EXPECTED {
+        let opts: TransformOptions = TransformOptions {
+            op,
+            trim: true,
+            ..TransformOptions::default()
+        };
+        let out: Vec<u8> = transform_jpeg_with_options(&jpeg, &opts).unwrap_or_else(|e| {
+            panic!(
+                "issue #439: `{name}` with trim=true on a {W}x{H} 4:4:1 image was \
+                 rejected: {e}"
+            )
+        });
+        let img = decompress(&out)
+            .unwrap_or_else(|e| panic!("`{name}`: trimmed output does not decode: {e}"));
+        assert_eq!(
+            (img.width, img.height),
+            (want_w, want_h),
+            "`{name}`: trimmed geometry diverges from stock jpegtran -trim"
+        );
+    }
+}
+
+/// The same matrix, cross-validated pixel-for-pixel against stock `jpegtran`.
+///
+/// Both sides transform the *same* source JPEG, so any difference is in the
+/// transform rather than in the encoder that produced the input.
+#[test]
+fn issue_439_s441_trim_pixels_match_c_jpegtran() {
+    let jpegtran: PathBuf = require_c_tool!("jpegtran");
+    let djpeg: PathBuf = require_c_tool!("djpeg");
+
+    let jpeg: Vec<u8> = source_jpeg();
+    let src: helpers::TempFile = helpers::TempFile::new("issue439_src.jpg");
+    src.write_bytes(&jpeg);
+
+    // Exact accounting: every operation in the table must reach the pixel
+    // comparison, so a future early-exit cannot shrink this silently.
+    let mut compared: usize = 0;
+
+    for &(op, name, want_w, want_h) in EXPECTED {
+        let c_args: &[&str] = match op {
+            TransformOp::HFlip => &["-flip", "horizontal"],
+            TransformOp::VFlip => &["-flip", "vertical"],
+            TransformOp::Transpose => &["-transpose"],
+            TransformOp::Rot90 => &["-rotate", "90"],
+            TransformOp::Rot180 => &["-rotate", "180"],
+            TransformOp::Rot270 => &["-rotate", "270"],
+            TransformOp::Transverse => &["-transverse"],
+            TransformOp::None => unreachable!("None is not in EXPECTED"),
+        };
+
+        let c_out: helpers::TempFile = helpers::TempFile::new(&format!("issue439_c_{name}.jpg"));
+        let status = Command::new(&jpegtran)
+            .arg("-trim")
+            .args(c_args)
+            .arg("-outfile")
+            .arg(c_out.path())
+            .arg(src.path())
+            .output()
+            .unwrap_or_else(|e| panic!("`{name}`: failed to run jpegtran: {e}"));
+        assert!(
+            status.status.success(),
+            "`{name}`: jpegtran -trim failed: {}",
+            String::from_utf8_lossy(&status.stderr)
+        );
+
+        let opts: TransformOptions = TransformOptions {
+            op,
+            trim: true,
+            ..TransformOptions::default()
+        };
+        let rust_bytes: Vec<u8> = transform_jpeg_with_options(&jpeg, &opts)
+            .unwrap_or_else(|e| panic!("`{name}`: Rust transform failed: {e}"));
+        let rust_out: helpers::TempFile =
+            helpers::TempFile::new(&format!("issue439_rust_{name}.jpg"));
+        rust_out.write_bytes(&rust_bytes);
+
+        // Decode both through the same C decoder so only the transform differs.
+        let decode = |path: &std::path::Path, which: &str| -> (usize, usize, Vec<u8>) {
+            let out = Command::new(&djpeg)
+                .arg("-ppm")
+                .arg(path)
+                .output()
+                .unwrap_or_else(|e| panic!("`{name}`: failed to run djpeg on {which}: {e}"));
+            assert!(
+                out.status.success(),
+                "`{name}`: djpeg rejected the {which} output: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            helpers::parse_ppm(&out.stdout)
+                .unwrap_or_else(|| panic!("`{name}`: could not parse djpeg PPM for {which}"))
+        };
+
+        let (cw, ch, c_pixels) = decode(c_out.path(), "C");
+        let (rw, rh, rust_pixels) = decode(rust_out.path(), "Rust");
+
+        assert_eq!(
+            (rw, rh),
+            (cw, ch),
+            "`{name}`: dimensions diverge — Rust {rw}x{rh}, C {cw}x{ch}"
+        );
+        assert_eq!(
+            (rw, rh),
+            (want_w, want_h),
+            "`{name}`: both sides agree but on the wrong geometry"
+        );
+        let max_diff: u8 = helpers::pixel_max_diff(&rust_pixels, &c_pixels);
+        assert_eq!(
+            max_diff, 0,
+            "`{name}`: trimmed pixels differ from stock jpegtran (max_diff={max_diff})"
+        );
+        compared += 1;
+    }
+
+    assert_eq!(
+        compared,
+        EXPECTED.len(),
+        "every operation must reach the pixel comparison"
+    );
+}
+
+/// The guard must not weaken trimming where a whole iMCU *does* fit: 4:2:0 on
+/// the same fixture still trims both axes, exactly as before.
+#[test]
+fn issue_439_guard_does_not_disable_trimming_where_it_applies() {
+    let mut pixels: Vec<u8> = Vec::with_capacity(W * H * 3);
+    for y in 0..H {
+        for x in 0..W {
+            pixels.push(((x * 3) % 256) as u8);
+            pixels.push(((y * 5) % 256) as u8);
+            pixels.push((((x * y) % 251) % 256) as u8);
+        }
+    }
+    // 4:2:0 has a 16x16 iMCU, so 35x27 holds two whole iMCUs across and one
+    // down: trimming must still shrink both axes to 32x16.
+    let jpeg: Vec<u8> = compress(&pixels, W, H, PixelFormat::Rgb, 90, Subsampling::S420)
+        .expect("encode 4:2:0 fixture");
+    let opts: TransformOptions = TransformOptions {
+        op: TransformOp::Rot180,
+        trim: true,
+        ..TransformOptions::default()
+    };
+    let out: Vec<u8> = transform_jpeg_with_options(&jpeg, &opts).expect("4:2:0 rot180 trim");
+    let img = decompress(&out).expect("decode trimmed 4:2:0");
+    assert_eq!(
+        (img.width, img.height),
+        (32, 16),
+        "the P4-117 guard must only fire when an axis holds no whole iMCU"
+    );
+}


### PR DESCRIPTION
## Summary

- leave an axis untrimmed when it holds less than one whole iMCU, instead of rejecting the transform
- all seven operations now match stock `jpegtran -trim` geometry on a non-MCU-aligned 4:4:1 image
- add `tests/regression_s441_trim.rs`: geometry table, pixel-for-pixel cross-check against `jpegtran`, and a 4:2:0 control
- file the P4-117 phase entry that was missed when #439 was opened

## Motivation

4:4:1 is `h_samp=1, v_samp=4`, so its iMCU is 8 wide but **32 tall**. A 27-row image contains zero whole iMCU rows, so the trim path computed `(27 / 32) * 32 == 0` and returned `trim would remove all image data`. `VFlip`, `Rot90`, `Rot180` and `Transverse` all failed that way on the 35x27 fixture, in both baseline and progressive output.

Upstream has no error path here at all. `trim_right_edge` and `trim_bottom_edge` (`transupp.c:1570-1592`) each open with `if (MCU_cols > 0 && …)` / `if (MCU_rows > 0 && …)`: an axis holding less than one whole iMCU is simply left alone. Stock `jpegtran -trim -flip vertical` on this exact input returns the untouched 35x27.

## Correctness and compatibility

Measured against stock `jpegtran -trim` (libjpeg-turbo 3.1.4.1), source 35x27 4:4:1:

| op | C | ours |
| --- | --- | --- |
| hflip | 32x27 | 32x27 |
| vflip | 35x27 | 35x27 |
| transpose | 27x35 | 27x35 |
| rot90 | 27x35 | 27x35 |
| rot180 | 32x27 | 32x27 |
| rot270 | 27x32 | 27x32 |
| transverse | 27x32 | 27x32 |

- pixel cross-check: both sides transform the *same* source JPEG and decode through the same `djpeg`; `max_diff == 0` for all seven
- a 4:2:0 control proves the guard only fires where it should: 35x27 still trims to 32x16
- verified red before the fix — 2 of the 3 new tests failed on the rejection
- `cargo test --workspace --no-fail-fast`: **2458 passed, 0 failed, 1 ignored**
- `cargo fmt --check` and `cargo clippy --workspace --all-targets -D warnings` clean
- independent Rust code review applied. Codex review could not run: the account is over its usage limit until Aug 9

## Tracking

- P4-117 closed; its phase-file entry is created here, since #439 was filed without one
- `docs/FEATURE_PARITY.md` TJXOPT_TRIM entry notes the guard
- once this merges, `cross_product_transform`'s trim carve-out assertion (added in #435's branch) fires and directs the next session to delete it, restoring 78/78

Closes #439
Related: #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)