### PR TITLE
test: triage the remaining oracle-side skips

### DIFF
--- a/docs/last_mile/phase4.md
+++ b/docs/last_mile/phase4.md
@@ -2344,7 +2344,12 @@ instance. What is left are oracle-side skips, which split two ways and must not
 be converted uniformly:
 
 * **defects** — the tool was discovered and its capability probed, so a failure
-  is in the request the test built. `tests/c_indexedcolortest.rs`'s five
+  is in the request the test built. Making `c_indexedcolortest` assert
+  immediately exposed a *parallelism race* the skip had been hiding: `run_djpeg`
+  named its temp input from `process::id()` alone, but cargo runs `#[test]`s on
+  parallel threads of one process, so concurrent cases deleted each other's
+  input mid-invocation. It surfaced as `djpeg: can't open …` and was swallowed.
+  The path is now unique per call. `tests/c_indexedcolortest.rs`'s five
   `-colors` sites are now panics; the `-colors` capability is probed once up
   front, so nothing downstream may treat its absence as news.
 * **capability gaps** — `cjpeg -precision 12`, `-precision 16 -lossless`, and

--- a/docs/last_mile/phase4.md
+++ b/docs/last_mile/phase4.md
@@ -2336,10 +2336,29 @@ test built, not an environment gap — the distinction the earlier pass drew for
 the ten named matrices. `cargo test --workspace --no-fail-fast`: 2466 passed,
 0 failed, 1 ignored (macOS aarch64).
 
-The item stays open: 67 test files still contain a `SKIP` site, and those have
-not been individually triaged into "legitimate environment gap" versus "failure
-reported as a skip". The sweep so far has only covered sites already identified
-by name.
+**Progress (2026-08-08, third pass) — triage rather than bulk conversion.** The
+forbidden shape CLAUDE.md names explicitly, a *Rust* failure turned into a
+skip, is now absent from the suite: a repo-wide search for
+`Err(_) => { eprintln!("SKIP…"); return/continue }` finds no remaining
+instance. What is left are oracle-side skips, which split two ways and must not
+be converted uniformly:
+
+* **defects** — the tool was discovered and its capability probed, so a failure
+  is in the request the test built. `tests/c_indexedcolortest.rs`'s five
+  `-colors` sites are now panics; the `-colors` capability is probed once up
+  front, so nothing downstream may treat its absence as news.
+* **capability gaps** — `cjpeg -precision 12`, `-precision 16 -lossless`, and
+  `-arithmetic -progressive` genuinely do not exist on older toolchains. Those
+  four sites keep their local skip but now assert `!helpers::is_ci()` first, so
+  CI — which provisions libjpeg-turbo 3.x — fails instead of skipping.
+
+Ten failure-shaped `SKIP` strings remain, four of them the CI-guarded
+capability cases above. The item stays open until the other six
+(`regression_420_dummy_block_columns`, `rgb565_dither`, `sof10_encode`,
+`encode_pipeline_golden`, and two in `hard_case_x_byte_and_restart`) are
+triaged the same way. Bulk-converting them would turn real environment gaps
+into failures on developer machines, which is why this is triage and not a
+regex.
 
 ## P4-119. `src/decode/pipeline.rs` Concentrates Half of the Decoder Implementation — **CLOSED 2026-08-02**
 

--- a/tests/c_indexedcolortest.rs
+++ b/tests/c_indexedcolortest.rs
@@ -246,12 +246,12 @@ fn c_indexedcolortest_8bit() {
                     num_colors, max_diff
                 );
             }
-            None => {
-                eprintln!(
-                    "SKIP: djpeg -colors {} -dither fs failed for 8-bit RGB",
-                    num_colors
-                );
-            }
+            None => panic!(
+                // P4-116: the `-colors` capability is probed once up front,
+                // so a failure here is a defect in the request we built.
+                "djpeg -colors {} -dither fs failed for 8-bit RGB",
+                num_colors
+            ),
         }
 
         // Test RGB→RGB quantization with no dithering
@@ -274,12 +274,12 @@ fn c_indexedcolortest_8bit() {
                     num_colors, max_diff
                 );
             }
-            None => {
-                eprintln!(
-                    "SKIP: djpeg -colors {} -dither none failed for 8-bit RGB",
-                    num_colors
-                );
-            }
+            None => panic!(
+                // P4-116: the `-colors` capability is probed once up front,
+                // so a failure here is a defect in the request we built.
+                "djpeg -colors {} -dither none failed for 8-bit RGB",
+                num_colors
+            ),
         }
     }
 
@@ -345,12 +345,12 @@ fn c_indexedcolortest_12bit() {
                     num_colors, max_diff
                 );
             }
-            None => {
-                eprintln!(
-                    "SKIP: djpeg -colors {} failed for 12-bit scenario",
-                    num_colors
-                );
-            }
+            None => panic!(
+                // P4-116: the `-colors` capability is probed once up front,
+                // so a failure here is a defect in the request we built.
+                "djpeg -colors {} failed for 12-bit scenario",
+                num_colors
+            ),
         }
     }
 
@@ -408,12 +408,12 @@ fn c_indexedcolortest_cross_precision() {
                     num_colors, max_diff
                 );
             }
-            None => {
-                eprintln!(
-                    "SKIP: djpeg -colors {} failed for cross-precision",
-                    num_colors
-                );
-            }
+            None => panic!(
+                // P4-116: the `-colors` capability is probed once up front,
+                // so a failure here is a defect in the request we built.
+                "djpeg -colors {} failed for cross-precision",
+                num_colors
+            ),
         }
 
         // Also test no-dither for the cross-precision scenario
@@ -442,12 +442,12 @@ fn c_indexedcolortest_cross_precision() {
                     num_colors, max_diff
                 );
             }
-            None => {
-                eprintln!(
-                    "SKIP: djpeg -colors {} -dither none failed for cross-precision",
-                    num_colors
-                );
-            }
+            None => panic!(
+                // P4-116: the `-colors` capability is probed once up front,
+                // so a failure here is a defect in the request we built.
+                "djpeg -colors {} -dither none failed for cross-precision",
+                num_colors
+            ),
         }
     }
 

--- a/tests/c_indexedcolortest.rs
+++ b/tests/c_indexedcolortest.rs
@@ -99,9 +99,20 @@ fn count_unique_colors_rgb(pixels: &[u8]) -> usize {
 /// Run djpeg with the given arguments, returning stdout bytes on success.
 /// Arguments are passed after the input file path.
 fn run_djpeg(djpeg: &Path, args: &[&str], input_jpeg: &[u8]) -> Option<Vec<u8>> {
-    // Write input JPEG to a temp file
-    let tmp_in: PathBuf =
-        std::env::temp_dir().join(format!("indexedcolortest_in_{}.jpg", std::process::id()));
+    // Write input JPEG to a temp file.
+    //
+    // The name must be unique per *call*, not per process: cargo runs `#[test]`
+    // functions on parallel threads of one process, so a path keyed only on
+    // `process::id()` let concurrent cases delete each other's input while
+    // djpeg was reading it. That surfaced as `djpeg: can't open ...` and was
+    // being swallowed as a skip, so the race stayed invisible (P4-116).
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let unique: u64 = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp_in: PathBuf = std::env::temp_dir().join(format!(
+        "indexedcolortest_in_{}_{}.jpg",
+        std::process::id(),
+        unique
+    ));
     std::fs::write(&tmp_in, input_jpeg).ok()?;
 
     let output = Command::new(djpeg).args(args).arg(&tmp_in).output().ok()?;

--- a/tests/precision.rs
+++ b/tests/precision.rs
@@ -569,6 +569,12 @@ fn c_djpeg_precision_diff_zero() {
                 .expect("failed to run cjpeg");
 
             if !output.status.success() {
+                // P4-116: CI provisions libjpeg-turbo 3.x, which has this
+                // capability, so a failure there is a provisioning defect.
+                assert!(
+                    !helpers::is_ci(),
+                    "CI must provide a cjpeg -precision 12-capable toolchain"
+                );
                 eprintln!(
                     "SKIP {}: cjpeg -precision 12 failed: {}",
                     label,
@@ -666,6 +672,12 @@ fn c_djpeg_precision_diff_zero() {
                 .expect("failed to run cjpeg");
 
             if !output.status.success() {
+                // P4-116: CI provisions libjpeg-turbo 3.x, which has this
+                // capability, so a failure there is a provisioning defect.
+                assert!(
+                    !helpers::is_ci(),
+                    "CI must provide a cjpeg -precision 16 -lossless-capable toolchain"
+                );
                 eprintln!(
                     "SKIP {}: cjpeg -precision 16 -lossless 1,0 failed: {}",
                     label,

--- a/tests/sof10_decode.rs
+++ b/tests/sof10_decode.rs
@@ -213,6 +213,12 @@ fn sof10_c_encoded_decode_pixel_validation() {
         .output()
         .expect("failed to run cjpeg");
     if !output.status.success() {
+        // P4-116: CI provisions libjpeg-turbo 3.x, which has this
+        // capability, so a failure there is a provisioning defect.
+        assert!(
+            !helpers::is_ci(),
+            "CI must provide a cjpeg -arithmetic -progressive-capable toolchain"
+        );
         eprintln!(
             "SKIP: cjpeg -arithmetic -progressive failed: {}",
             String::from_utf8_lossy(&output.stderr)
@@ -397,6 +403,12 @@ fn c_djpeg_sof10_decode_diff_zero() {
             .output()
             .expect("failed to run cjpeg");
         if !output.status.success() {
+            // P4-116: CI provisions libjpeg-turbo 3.x, which has this
+            // capability, so a failure there is a provisioning defect.
+            assert!(
+                !helpers::is_ci(),
+                "CI must provide a cjpeg -arithmetic -progressive-capable toolchain"
+            );
             eprintln!(
                 "SKIP: cjpeg -arithmetic -progressive failed: {}",
                 String::from_utf8_lossy(&output.stderr)


### PR DESCRIPTION
## Summary

- confirm the shape CLAUDE.md forbids outright — a **Rust** failure reported as a skip — is now absent repo-wide
- convert `c_indexedcolortest`'s five `-colors` sites to panics (capability already probed ⇒ failure is a defect)
- add CI guards to four genuine capability gaps so CI fails where it currently skips

## Why this is triage, not a regex

The remaining `SKIP` sites are oracle-side and split two ways:

**Defects.** `c_indexedcolortest` probes `-colors` once up front. By the time its comparison sites run, a `djpeg` failure is a defect in the request the test built, not news about the tool. Those are panics.

**Capability gaps.** `cjpeg -precision 12`, `-precision 16 -lossless`, and `-arithmetic -progressive` genuinely do not exist on older toolchains. Those keep their local skip but assert `!helpers::is_ci()` first — CI provisions libjpeg-turbo 3.x, so a missing capability there is a provisioning failure.

Bulk-converting the rest would turn real environment gaps into failures on developer machines. Six failure-shaped `SKIP` strings are therefore left untriaged and named in the phase file: `regression_420_dummy_block_columns`, `rgb565_dither`, `sof10_encode`, `encode_pipeline_golden`, and two in `hard_case_x_byte_and_restart`.

## Correctness

- `cargo test --workspace --no-fail-fast`: **2466 passed, 0 failed, 1 ignored** (macOS aarch64)
- `cargo fmt --check` and `cargo clippy --workspace --all-targets -D warnings` clean

Codex review could not run: the account is over its usage limit until Aug 9.

Related: #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)