### PR TITLE
fix: raise the error codes the raw-data paths already named

### DIFF
--- a/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
+++ b/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
@@ -874,6 +874,9 @@ const JERR_BAD_DCT_COEF: c_int = 6;
 /// "Bogus marker length"
 const JERR_BAD_LENGTH: c_int = 12;
 #[allow(dead_code)]
+/// "Unsupported JPEG data precision %d"
+const JERR_BAD_PRECISION: c_int = 16;
+#[allow(dead_code)]
 /// "Improper call to JPEG library in state %d"
 const JERR_BAD_STATE: c_int = 21;
 #[allow(dead_code)]
@@ -4483,6 +4486,9 @@ pub extern "C" fn jpeg_read_raw_data(
             priv_state.last_error = CString::new(format!(
             "jpeg_read_raw_data: JERR_BUFFER_SIZE — max_lines ({max_lines}) < rows_per_iMCU ({rows_per_imcu})"
         )).unwrap_or_default();
+            // P4-100: the message already named this code; it never reached
+            // `error_exit`, so a C consumer saw only a FALSE/0 return.
+            invoke_error_exit(cinfo, JERR_BUFFER_SIZE);
             return 0;
         }
 
@@ -4626,6 +4632,9 @@ pub extern "C" fn jpeg12_read_raw_data(
                 c.data_precision
             ))
             .unwrap_or_default();
+            // P4-100: the message already named this code; it never reached
+            // `error_exit`, so a C consumer saw only a FALSE/0 return.
+            invoke_error_exit(cinfo, JERR_BAD_PRECISION);
             return 0;
         }
 
@@ -4653,6 +4662,9 @@ pub extern "C" fn jpeg12_read_raw_data(
             priv_state.last_error = CString::new(format!(
             "jpeg12_read_raw_data: JERR_BUFFER_SIZE — max_lines ({max_lines}) < rows_per_iMCU ({rows_per_imcu})"
         )).unwrap_or_default();
+            // P4-100: the message already named this code; it never reached
+            // `error_exit`, so a C consumer saw only a FALSE/0 return.
+            invoke_error_exit(cinfo, JERR_BUFFER_SIZE);
             return 0;
         }
 
@@ -7989,6 +8001,9 @@ pub extern "C" fn jpeg_write_raw_data(
                 "jpeg_write_raw_data: JERR_BAD_PRECISION (only data_precision=8 supported)",
             )
             .unwrap_or_default();
+            // P4-100: the message already named this code; it never reached
+            // `error_exit`, so a C consumer saw only a FALSE/0 return.
+            invoke_error_exit(cinfo, JERR_BAD_PRECISION);
             return 0;
         }
 
@@ -7997,6 +8012,9 @@ pub extern "C" fn jpeg_write_raw_data(
             priv_state.last_error =
                 CString::new("jpeg_write_raw_data: JERR_BAD_STATE (call jpeg_start_compress first with raw_data_in=TRUE)")
                     .unwrap_or_default();
+            // P4-100: the message already named this code; it never reached
+            // `error_exit`, so a C consumer saw only a FALSE/0 return.
+            invoke_error_exit(cinfo, JERR_BAD_STATE);
             return 0;
         }
 
@@ -8010,6 +8028,9 @@ pub extern "C" fn jpeg_write_raw_data(
                 "jpeg_write_raw_data: JERR_BUFFER_SIZE (num_lines={num_lines} < lines_per_iMCU={lines_per_imcu})"
             ))
             .unwrap_or_default();
+            // P4-100: the message already named this code; it never reached
+            // `error_exit`, so a C consumer saw only a FALSE/0 return.
+            invoke_error_exit(cinfo, JERR_BUFFER_SIZE);
             return 0;
         }
 
@@ -8441,6 +8462,9 @@ pub extern "C" fn jpeg12_write_raw_data(
                 c.data_precision
             ))
             .unwrap_or_default();
+            // P4-100: the message already named this code; it never reached
+            // `error_exit`, so a C consumer saw only a FALSE/0 return.
+            invoke_error_exit(cinfo, JERR_BAD_PRECISION);
             return 0;
         }
 
@@ -8449,6 +8473,9 @@ pub extern "C" fn jpeg12_write_raw_data(
             priv_state.last_error =
                 CString::new("jpeg12_write_raw_data: JERR_BAD_STATE (call jpeg_start_compress first with raw_data_in=TRUE)")
                     .unwrap_or_default();
+            // P4-100: the message already named this code; it never reached
+            // `error_exit`, so a C consumer saw only a FALSE/0 return.
+            invoke_error_exit(cinfo, JERR_BAD_STATE);
             return 0;
         }
 
@@ -8461,6 +8488,9 @@ pub extern "C" fn jpeg12_write_raw_data(
                 "jpeg12_write_raw_data: JERR_BUFFER_SIZE (num_lines={num_lines} < lines_per_iMCU={lines_per_imcu})"
             ))
             .unwrap_or_default();
+            // P4-100: the message already named this code; it never reached
+            // `error_exit`, so a C consumer saw only a FALSE/0 return.
+            invoke_error_exit(cinfo, JERR_BUFFER_SIZE);
             return 0;
         }
 

--- a/crates/libjpeg-turbo-rs-capi/tests/capi_classic_error_codes.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/capi_classic_error_codes.rs
@@ -33,6 +33,11 @@ const EXPECTED: &[(&str, i32, &str)] = &[
     ),
     ("JERR_BAD_LENGTH", 12, "Bogus marker length"),
     (
+        "JERR_BAD_PRECISION",
+        16,
+        "Unsupported JPEG data precision %d",
+    ),
+    (
         "JERR_BAD_STATE",
         21,
         "Improper call to JPEG library in state %d",

--- a/docs/last_mile/phase4.md
+++ b/docs/last_mile/phase4.md
@@ -1900,8 +1900,15 @@ would have let a short raw encode produce a file.
 
 **Status (2026-08-08): partial.** Criteria (1)-(3) hold for
 `jpeg_start_decompress` and `jpeg_finish_compress`, and the finish state gate
-now matches upstream exactly. Not yet done: the remaining private-string-only
-sites (54 of the original 59 `last_error` assignments still have no
+now matches upstream exactly. Nine more sites now raise: every
+raw-data validation failure in `jpeg_read_raw_data`, `jpeg12_read_raw_data`,
+`jpeg_write_raw_data` and `jpeg12_write_raw_data` already *named* its
+upstream code in the message (`JERR_BUFFER_SIZE`, `JERR_BAD_PRECISION`,
+`JERR_BAD_STATE`) but never reached `error_exit`, so a C consumer saw only a
+`0` return. `JERR_BAD_PRECISION` joins the cross-checked constant set.
+
+Not yet done: the remaining private-string-only
+sites (45 of the original 59 `last_error` assignments still have no
 `error_exit` nearby), criterion (4)'s stock-versus-Rust setjmp harness matrix,
 and P4-104's *decompressor* state work, which is separate from the compressor
 states corrected here. `cargo test --workspace --no-fail-fast`: 2466 passed, 0 failed,


### PR DESCRIPTION
## Summary

- nine raw-data validation failures now reach `error_exit` with the code their message already named
- add `JERR_BAD_PRECISION` (16) to the constant set and to the upstream cross-check — **15 codes** now verified by value *and* message text

## Motivation

These sites spelled the upstream code out in the message:

```
"jpeg_write_raw_data: JERR_BAD_STATE (call jpeg_start_compress first with raw_data_in=TRUE)"
```

…and then never called `error_exit`. A C consumer saw a bare `0` return and no `msg_code`, so the diagnostic the shim had already written existed only in a private Rust string it can't read.

Affected: `jpeg_read_raw_data`, `jpeg12_read_raw_data`, `jpeg_write_raw_data`, `jpeg12_write_raw_data` — covering `JERR_BUFFER_SIZE`, `JERR_BAD_PRECISION` and `JERR_BAD_STATE`.

All nine are early parameter checks with no heap-owning local live at the raise point, so routing them through `invoke_error_exit` carries none of the `longjmp`-past-a-`Vec` hazard that forced the deferred-reporting design elsewhere.

## Correctness

- `cargo test --workspace --no-fail-fast`: **2466 passed, 0 failed, 1 ignored** (macOS aarch64)
- `cargo fmt --check` and `cargo clippy --workspace --all-targets -D warnings` clean

## Scope

P4-100 remains PARTIAL: 45 private-string-only sites remain, and criterion (4)'s setjmp harness matrix is still unwritten.

Codex review could not run: the account is over its usage limit until Aug 9.

Related: #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)