### PR TITLE
docs: record the YUV decompress C-vs-Rust divergence in the mapping docs

### DIFF
--- a/docs/C_API_REFERENCE.md
+++ b/docs/C_API_REFERENCE.md
@@ -127,8 +127,8 @@
 
 | C Function | Description | Rust | Status |
 |---|---|---|---|
-| `tj3DecompressToYUV8(handle, jpeg, size, dst, align)` | JPEG → packed YUV | `yuv::decompress_to_yuv()` | ✅ |
-| `tj3DecompressToYUVPlanes8(handle, jpeg, size, planes, strides)` | JPEG → planar YUV | `yuv::decompress_to_yuv_planes()` | ✅ |
+| `tj3DecompressToYUV8(handle, jpeg, size, dst, align)` | JPEG → packed YUV | `yuv::decompress_to_yuv()` — not interchangeable: the C entry point rejects 4-component CMYK/YCCK frames (P4-125), the Rust function packs all four planes | ✅ |
+| `tj3DecompressToYUVPlanes8(handle, jpeg, size, planes, strides)` | JPEG → planar YUV | `yuv::decompress_to_yuv_planes()` — same divergence; the Rust function returns one plane per SOF component, so four for CMYK/YCCK | ✅ |
 
 ### Color Decode (YUV → RGB, no JPEG)
 

--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -325,8 +325,8 @@
 - [x] `tj3CompressFromYUVPlanes8()` — Planar YUV → JPEG (`yuv::compress_from_yuv_planes()`)
 
 ### JPEG → YUV (decompress to YUV)
-- [x] `tj3DecompressToYUV8()` — JPEG → packed YUV buffer (`yuv::decompress_to_yuv()`)
-- [x] `tj3DecompressToYUVPlanes8()` — JPEG → separate Y/Cb/Cr plane buffers (`yuv::decompress_to_yuv_planes()`)
+- [x] `tj3DecompressToYUV8()` — JPEG → packed YUV buffer (`yuv::decompress_to_yuv()`; the two are not interchangeable — the C entry point rejects 4-component CMYK/YCCK frames per P4-125, the Rust function packs all four planes)
+- [x] `tj3DecompressToYUVPlanes8()` — JPEG → separate Y/Cb/Cr plane buffers (`yuv::decompress_to_yuv_planes()`; same divergence — the Rust function returns one plane per SOF component, so four for CMYK/YCCK)
 
 ### YUV → RGB (color conversion only, no JPEG)
 - [x] `tj3DecodeYUV8()` — Packed YUV → RGB (`yuv::decode_yuv()`)

--- a/docs/last_mile/phase4.md
+++ b/docs/last_mile/phase4.md
@@ -3107,7 +3107,21 @@ runs all three binaries with `LIBJPEG_TURBO_PREFIX=/opt/libjpeg-turbo`, which
 makes the oracle fatal rather than skippable there. Reachable plane
 counts are `{1, 3, 4}` because `detect_subsampling` already rejects 2, so the
 only newly-rejected input is the 4-component frame itself. The second-layer gap
-this work surfaced is tracked as P4-126.
+this work surfaced is tracked as P4-126, and the validation-ordering gap the same
+review surfaced is P4-127.
+
+**Follow-up (2026-08-09): canonical mapping rows corrected.** Closing this item
+made the C entry points diverge from the root-crate functions they are mapped to,
+but `docs/C_API_REFERENCE.md` (Decompression to YUV) and
+`docs/FEATURE_PARITY.md` (JPEG → YUV) still presented
+`tj3DecompressToYUV8` ≡ `yuv::decompress_to_yuv()` and
+`tj3DecompressToYUVPlanes8` ≡ `yuv::decompress_to_yuv_planes()` without
+qualification. The C entry points now reject 4-component CMYK/YCCK frames while
+the Rust functions still return one plane per SOF component — the divergence this
+patch recorded in the `src/api/yuv.rs` doc comments but not in the two canonical
+mapping documents. Both rows now state it. The `✅` status is unchanged and
+correct: the exported C functions are complete and match C, which is what this
+item established; it is the Rust-native equivalents that differ.
 
 ## P4-126. `yuv_plane_width`/`yuv_plane_height` accept any component index where C rejects `componentID >= nc` — **OPEN**
 


### PR DESCRIPTION
## What

#450 (P4-125) made `tj3DecompressToYUV8` and `tj3DecompressToYUVPlanes8` reject 4-component CMYK/YCCK frames. The two canonical mapping documents still presented them as plain equivalents of the root-crate functions:

```
| tj3DecompressToYUV8(...)       | JPEG → packed YUV | yuv::decompress_to_yuv()        | ✅ |
| tj3DecompressToYUVPlanes8(...) | JPEG → planar YUV | yuv::decompress_to_yuv_planes() | ✅ |
```

Those Rust functions still return **one plane per SOF component** — four for CMYK/YCCK. So the rows assert an equivalence that no longer holds, in the file `CLAUDE.md` points readers at as "the definitive mapping of every C function → Rust equivalent".

#450 recorded the divergence in the `src/api/yuv.rs` doc comments but not in the mapping docs. This propagates it.

## The change

- `docs/C_API_REFERENCE.md` (Decompression to YUV) and `docs/FEATURE_PARITY.md` (JPEG → YUV): both rows now name the divergence.
- `docs/last_mile/phase4.md`: a follow-up note in P4-125's closure recording the correction, and the cross-reference to P4-127 that closure was missing.

**The `✅` status is deliberately unchanged.** Per the legend it means "end-to-end public equivalent"; the exported C functions are complete and match C, which is exactly what P4-125 established. It is the *Rust-native* functions that differ, so the qualification belongs in the Rust column — the same way rows 122 and 151 carry `(caller buffer, #354)` and `(no per-handle getter)`.

## Scope check

I checked the sibling rows for the same class of drift rather than fixing only the two I noticed. The compress (`tj3CompressFromYUV8/Planes8`), encode (`tj3EncodeYUV8/Planes8`) and decode (`tj3DecodeYUV8/Planes8`) entry points take a caller-supplied plane count rather than one derived from the JPEG's SOF marker, and carry no such guard — `MAX_YUV_PLANES` is referenced only at the two decompress sites (`crates/libjpeg-turbo-rs-capi/src/yuv.rs:617`, `:665`). Their rows are correct as they stand.

Verified the edited Markdown tables still parse (5 pipes, matching the header) and that no `|` was introduced inside the new text.

Docs only; no runtime behaviour changes.

Related: #450