### PR TITLE
fix(capi): stop stamping crate-private test accessors as reference v8 API

### DIFF
--- a/crates/libjpeg-turbo-rs-capi/build.rs
+++ b/crates/libjpeg-turbo-rs-capi/build.rs
@@ -267,6 +267,27 @@ fn gnu_version_script() -> String {
     // upstream relies on against its own `*`.
     map.push_str("    jpeg_mem_dest;\n    jpeg_mem_src;\n");
     map.push_str("  local:\n    jsimd_*;\n    jconst_*;\n};\n\n");
+
+    // Crate-private accessors. They share the `jpeg_` prefix, so the `jpeg_*`
+    // pattern in LIBJPEG_8.0 below would otherwise stamp all 16 of them as
+    // reference libjpeg v8 API — 16 entry points no real libjpeg has, visible
+    // to anyone running `readelf --dyn-syms` on our `libjpeg.so.8` (P4-129).
+    //
+    // They are listed by exact name because an exact match outranks a pattern;
+    // that is the same precedence the MEM_SRCDST pair above relies on, and it
+    // is deterministic where pattern-vs-pattern ordering is not.
+    //
+    // They stay dynamically visible rather than being made `local:` because
+    // eight dlopen-based suites resolve them out of this very cdylib. Moving
+    // them to a distinct, obviously-not-upstream node keeps those tests working
+    // while ending the mislabelling, which is the alternative
+    // `docs/last_mile/phase4.md`'s P4-129 acceptance criterion 1 permits.
+    map.push_str("LIBJPEGTURBORS_PRIVATE_1.0 {\n  global:\n");
+    for name in CRATE_PRIVATE_TEST_ACCESSORS {
+        map.push_str(&format!("    {name};\n"));
+    }
+    map.push_str("};\n\n");
+
     map.push_str("LIBJPEG_8.0 {\n  global:\n    jpeg_*;\n");
     for name in CLASSIC_NON_JPEG_PREFIXED {
         map.push_str(&format!("    {name};\n"));
@@ -274,3 +295,28 @@ fn gnu_version_script() -> String {
     map.push_str("};\n");
     map
 }
+
+/// The `jpeg_capi_test_*` accessors defined in `src/jpeglib.rs`.
+///
+/// Kept in one place so the version script and
+/// `tests/capi_symbol_versions.rs` cannot drift apart: a 17th accessor added
+/// without updating this list falls through to `jpeg_*` and the reference-node
+/// allowlist assertion fails.
+pub(crate) const CRATE_PRIVATE_TEST_ACCESSORS: &[&str] = &[
+    "jpeg_capi_test_arith_code",
+    "jpeg_capi_test_density_unit",
+    "jpeg_capi_test_dimensions",
+    "jpeg_capi_test_get_compress_state",
+    "jpeg_capi_test_marker_list",
+    "jpeg_capi_test_output_dims",
+    "jpeg_capi_test_set_arith_code",
+    "jpeg_capi_test_set_compress_dims",
+    "jpeg_capi_test_set_optimize_coding",
+    "jpeg_capi_test_set_out_cs",
+    "jpeg_capi_test_set_progressive",
+    "jpeg_capi_test_set_restart_in_rows",
+    "jpeg_capi_test_set_restart_interval",
+    "jpeg_capi_test_set_smoothing_factor",
+    "jpeg_capi_test_x_density",
+    "jpeg_capi_test_y_density",
+];

--- a/crates/libjpeg-turbo-rs-capi/tests/capi_symbol_versions.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/capi_symbol_versions.rs
@@ -89,6 +89,73 @@ fn version_script_matches_the_upstream_node_layout() {
     }
 }
 
+/// P4-129: the 16 crate-private `jpeg_capi_test_*` accessors must not be
+/// stamped as reference libjpeg v8 API.
+///
+/// They share the `jpeg_` prefix, so the `jpeg_*` pattern in `LIBJPEG_8.0`
+/// swept all of them in, and a consumer running `readelf --dyn-syms` on our
+/// `libjpeg.so.8` saw 16 entry points at `@@LIBJPEG_8.0` that no real libjpeg
+/// has. They now sit in a node whose name cannot be mistaken for upstream's.
+///
+/// Asserted against the script text so it runs on every platform, not only ELF
+/// hosts: the assignment is the part that regresses, and it is readable
+/// anywhere.
+#[test]
+fn crate_private_accessors_are_not_stamped_as_reference_api() {
+    let script: String = version_script();
+    let private: &str = section(&script, "LIBJPEGTURBORS_PRIVATE_1.0");
+    let reference: &str = section(&script, "LIBJPEG_8.0");
+
+    // Read the names from the shim source rather than restating them, so this
+    // test cannot agree with a stale copy of the list.
+    let accessors: Vec<String> = crate_private_accessor_names();
+    assert_eq!(
+        accessors.len(),
+        16,
+        "expected the 16 accessors P4-129 enumerates, found {}: {accessors:?}",
+        accessors.len()
+    );
+
+    // Each is claimed by exact name, which outranks the `jpeg_*` pattern. A
+    // 17th accessor added without updating build.rs falls through to the
+    // reference node instead, and this fails.
+    for name in &accessors {
+        assert!(
+            private.contains(&format!("{name};")),
+            "`{name}` is not claimed by the crate-private node, so the `jpeg_*` \
+             pattern in LIBJPEG_8.0 stamps it as reference v8 API:\n{private}"
+        );
+        assert!(
+            !reference.contains(&format!("{name};")),
+            "`{name}` is named in the reference node:\n{reference}"
+        );
+    }
+}
+
+/// The `jpeg_capi_test_*` accessor names, parsed out of `src/jpeglib.rs`.
+fn crate_private_accessor_names() -> Vec<String> {
+    let source: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("jpeglib.rs");
+    let text: String = std::fs::read_to_string(&source)
+        .unwrap_or_else(|e| panic!("read {}: {e}", source.display()));
+    const PREFIX: &str = "pub extern \"C\" fn ";
+    let mut names: Vec<String> = text
+        .lines()
+        .filter_map(|line| {
+            let idx: usize = line.find(PREFIX)?;
+            let rest: &str = &line[idx + PREFIX.len()..];
+            let end: usize = rest.find('(')?;
+            let name: &str = &rest[..end];
+            name.starts_with("jpeg_capi_test_")
+                .then(|| name.to_string())
+        })
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
 /// The script must have no catch-all, which is where it deliberately parts
 /// company with upstream's own map.
 #[test]

--- a/docs/ABI_COMPATIBILITY.md
+++ b/docs/ABI_COMPATIBILITY.md
@@ -51,6 +51,30 @@ Distro packagers should treat the missing version definitions as an open
 replacement gap until P4-81 closes. The reproducible binding evidence is in
 `experiments/opencv_downstream_2026-08-02.md`.
 
+### Crate-private version node `LIBJPEGTURBORS_PRIVATE_1.0` (P4-129)
+
+`src/jpeglib.rs` defines 16 `jpeg_capi_test_*` accessors that the shim's own
+dlopen-based test suites resolve out of the shared library. They share the
+`jpeg_` prefix, so the `jpeg_*` pattern in the reference node used to stamp all
+16 as `@@LIBJPEG_8.0` — advertising 16 entry points **no real libjpeg has** as
+reference v8 API.
+
+They are now claimed by exact name under **`LIBJPEGTURBORS_PRIVATE_1.0`**, a
+node deliberately named so it cannot be mistaken for an upstream one. Exact
+names outrank patterns, which is the precedence the `jpeg_mem_dest` /
+`jpeg_mem_src` assignment already relies on.
+
+**These are not API.** They carry no stability guarantee, belong to no libjpeg
+or TurboJPEG surface, and exist only so the shim's tests can inspect state
+through the shared library. Do not link them.
+
+They stay dynamically visible rather than becoming `local:` because eight test
+suites resolve them from this cdylib; hiding them would break those without
+improving the shipped surface's honesty, which is what the mislabelling
+actually cost. `tests/capi_symbol_versions.rs` reads the accessor list out of
+`src/jpeglib.rs`, so a 17th added without updating `build.rs` fails CI instead
+of silently rejoining the reference node.
+
 ### ABI-layout compatibility matrix
 
 The matrix below covers struct-layout/SONAME compatibility only; it does not


### PR DESCRIPTION
## What

Closes **#460** (P4-129). `src/jpeglib.rs` defines 16 `jpeg_capi_test_*` accessors. They share the `jpeg_` prefix, so the `jpeg_*` pattern in the `LIBJPEG_8.0` node swept **every one of them in** — anyone running `readelf --dyn-syms` on our `libjpeg.so.8` saw 16 entry points at `@@LIBJPEG_8.0` that **no real libjpeg has**.

They now sit in **`LIBJPEGTURBORS_PRIVATE_1.0`**, claimed by exact name. An exact match outranks a pattern — the precedence the `jpeg_mem_dest`/`jpeg_mem_src` assignment already relies on, and deterministic where pattern-vs-pattern ordering is not.

## Criterion 3: which way to keep the consumers working

They stay **dynamically visible** rather than becoming `local:`, because **eight dlopen-based suites resolve these symbols out of this very cdylib.**

Feature-gating was the alternative, and I rejected it: the eight suites would need `required-features`, so a plain `cargo test` would **silently skip them** — the zero-test-match failure mode P4-61 records. Moving them to an obviously-not-upstream node ends the mislabelling, which is what the defect actually cost, without trading it for lost coverage. Criterion 1 permits this explicitly ("or exports them only under an explicitly non-reference node documented as crate-private").

## Criterion 2: the assertion can't go stale

The new test **reads the accessor list out of `src/jpeglib.rs`** rather than restating it, so it cannot agree with a stale copy. A 17th accessor added without updating `build.rs` falls through to `jpeg_*` and fails.

Verified **red** by removing the private node — the test names the accessor that rejoined the reference node:

```
test crate_private_accessors_are_not_stamped_as_reference_api ... FAILED
```

It runs on **every platform**, not only ELF hosts: the script text is what regresses, and it is readable anywhere. The ELF-level leg still needs Linux.

## Documented (criterion 1)

`docs/ABI_COMPATIBILITY.md` gains a section stating these are crate-private, carry no stability guarantee, belong to no libjpeg or TurboJPEG surface, and must not be linked.

## Left alone deliberately

The P4-81 caveat paragraph just above says the ***cargo cdylib*** carries no version nodes. That is still true — the versioned artifact is relinked by `scripts/install_capi.sh`. Not drift, so untouched.

`cargo test --workspace`: **2486 passed, 0 failed**.

Closes #460