### PR TITLE
fix(capi): make tj3Free/tj3Destroy unsafe fn and correct the ABI claim

### DIFF
--- a/crates/libjpeg-turbo-rs-capi/src/alloc.rs
+++ b/crates/libjpeg-turbo-rs-capi/src/alloc.rs
@@ -68,8 +68,24 @@ pub extern "C" fn tj3Alloc(bytes: usize) -> *mut c_void {
 }
 
 /// `tj3Free(ptr)` — libjpeg-turbo-compatible deallocator. NULL is a no-op.
+///
+/// # Safety
+///
+/// `ptr` must be NULL, or a pointer returned by [`tj3Alloc`] (or the same
+/// allocator's `malloc`) that has not already been freed. It is handed
+/// straight to `free`.
+///
+/// A stack address, an interior pointer, one from a different allocator, or
+/// one already freed is undefined behaviour. Nothing here can detect any of
+/// those — a raw pointer carries no provenance the callee can check — which is
+/// why this is `unsafe fn` rather than a safe one that implies otherwise
+/// (P4-137).
+///
+/// The obligation is the C caller's either way; `unsafe` changes nothing for
+/// them. It exists so *Rust* callers of this crate's `rlib` cannot reach
+/// `free` without acknowledging it.
 #[no_mangle]
-pub extern "C" fn tj3Free(ptr: *mut c_void) {
+pub unsafe extern "C" fn tj3Free(ptr: *mut c_void) {
     crate::unwind_guard!((), {
         libc_free(ptr as *mut u8);
     })

--- a/crates/libjpeg-turbo-rs-capi/src/legacy.rs
+++ b/crates/libjpeg-turbo-rs-capi/src/legacy.rs
@@ -78,10 +78,18 @@ pub extern "C" fn tjInitTransform() -> *mut c_void {
 }
 
 /// `tjDestroy(handle)` — identical to `tj3Destroy`.
+///
+/// # Safety
+///
+/// Forwards `handle` to [`tj3Destroy`] unchanged, so it carries exactly that
+/// function's obligation: NULL or a live handle from `tjInit*`/`tj3Init`,
+/// never one already destroyed, and no concurrent call using the same handle.
 #[no_mangle]
-pub extern "C" fn tjDestroy(handle: *mut c_void) -> c_int {
+pub unsafe extern "C" fn tjDestroy(handle: *mut c_void) -> c_int {
     crate::unwind_guard!(-1, {
-        tj3Destroy(handle);
+        // SAFETY: the caller's obligation, restated on this function and
+        // discharged unchanged — `handle` is theirs, not one we constructed.
+        unsafe { tj3Destroy(handle) };
         0
     })
 }
@@ -585,7 +593,10 @@ pub extern "C" fn tjLoadImage(
         if buf.is_null() {
             copy_handle_error_to_no_handle_slot(h);
         }
-        crate::tj3::tj3Destroy(h);
+        // SAFETY: `h` came from tj3Init above, is non-null, has not been
+        // destroyed, and no other thread can name it — it never left this
+        // function.
+        unsafe { crate::tj3::tj3Destroy(h) };
         buf
     })
 }
@@ -619,7 +630,10 @@ pub extern "C" fn tjSaveImage(
         if rc != 0 {
             copy_handle_error_to_no_handle_slot(h);
         }
-        crate::tj3::tj3Destroy(h);
+        // SAFETY: `h` came from tj3Init above, is non-null, has not been
+        // destroyed, and no other thread can name it — it never left this
+        // function.
+        unsafe { crate::tj3::tj3Destroy(h) };
         rc
     })
 }

--- a/crates/libjpeg-turbo-rs-capi/src/lib.rs
+++ b/crates/libjpeg-turbo-rs-capi/src/lib.rs
@@ -28,10 +28,21 @@
 //! consumers can mix-and-match the C and Rust APIs.
 
 #![deny(unsafe_op_in_unsafe_fn)]
-// `extern "C"` shim functions intentionally accept raw pointers from C and
-// dereference them after validating against NULL. Marking each function
-// `unsafe fn` would change the ABI-visible symbol name and break the
-// drop-in contract, so we silence clippy at the crate level here.
+// `extern "C"` shim functions accept raw pointers from C and dereference them
+// after a NULL check.
+//
+// This suppression previously justified itself with "marking each function
+// `unsafe fn` would change the ABI-visible symbol name and break the drop-in
+// contract". **That is false, and it was measured.** `extern "C"` fixes the
+// calling convention and `#[no_mangle]` fixes the symbol name; `unsafe` adds
+// an obligation for *Rust* callers only. Converting `tj3Free` and `tj3Destroy`
+// left `nm -gU` output byte-identical (`_tj3Alloc`, `_tj3Destroy`, `_tj3Free`).
+//
+// The suppression therefore stays only because the conversion is unfinished:
+// ~84 of the 159 exports still take raw pointers, and `handle_as_mut` still
+// forges an unbounded lifetime across nine modules. It is a TODO, not a
+// rationale. Tracked as P4-137 (#476); the two exports that could double-free
+// or `free()` an arbitrary pointer are already converted.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 // Exported symbols must match the C case (`tj3Init`, `tj3Destroy`, ...),
 // so we disable the snake_case lint at the crate root.

--- a/crates/libjpeg-turbo-rs-capi/src/tj3.rs
+++ b/crates/libjpeg-turbo-rs-capi/src/tj3.rs
@@ -183,8 +183,23 @@ pub extern "C" fn tj3InitVersion(init_type: c_int, api_version: c_int) -> *mut c
 }
 
 /// `tj3Destroy(handle)` — free a handle. NULL is a no-op.
+///
+/// # Safety
+///
+/// `handle` must be NULL, or a handle returned by [`tj3Init`] that has not
+/// already been destroyed. Ownership transfers here: the allocation is
+/// reclaimed through `Box::from_raw`, so the pointer dangles on return and
+/// must not be used again.
+///
+/// **Calling this twice with the same handle is a double free**, and no check
+/// here can catch it — the pointer looks identical both times. Detecting it
+/// needs generation-tagged handles in a registry, which P4-137 records as an
+/// open decision rather than something this signature can supply.
+///
+/// The caller must also ensure no other thread is inside a call using the same
+/// handle: those reconstruct `&mut TjInstance` from it and would alias.
 #[no_mangle]
-pub extern "C" fn tj3Destroy(handle: *mut c_void) {
+pub unsafe extern "C" fn tj3Destroy(handle: *mut c_void) {
     crate::unwind_guard!((), {
         if handle.is_null() {
             return;

--- a/crates/libjpeg-turbo-rs-capi/tests/yuv_decompress_planes_component_guard.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/yuv_decompress_planes_component_guard.rs
@@ -59,8 +59,9 @@ fn tj3_decompress_to_yuv_planes8_rejects_four_component_jpeg() {
         plane_ptrs.as_mut_ptr(),
         std::ptr::null(),
     );
-    tj3Destroy(handle);
-
+    // SAFETY: `handle` is a live handle this test created and has not
+    // destroyed; nothing else can reach it.
+    unsafe { tj3Destroy(handle) };
     assert!(
         planes[3].iter().all(|&b| b == CANARY),
         "wrote a 4th plane through dstPlanes[3], past the caller's 3-entry array"

--- a/crates/libjpeg-turbo-rs-capi/tests/yuv_four_component_c_parity.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/yuv_four_component_c_parity.rs
@@ -78,8 +78,9 @@ fn rust_return_codes(jpeg: &[u8]) -> (c_int, c_int) {
         packed.as_mut_ptr(),
         ALIGN,
     );
-    tj3Destroy(handle);
-
+    // SAFETY: `handle` is a live handle this test created and has not
+    // destroyed; nothing else can reach it.
+    unsafe { tj3Destroy(handle) };
     let mut planes: Vec<Vec<u8>> = (0..3).map(|_| vec![0u8; WIDTH * HEIGHT]).collect();
     let mut plane_ptrs: Vec<*mut u8> = planes.iter_mut().map(|p| p.as_mut_ptr()).collect();
     let handle: *mut c_void = tj3Init(TJINIT_DECOMPRESS);
@@ -91,8 +92,9 @@ fn rust_return_codes(jpeg: &[u8]) -> (c_int, c_int) {
         plane_ptrs.as_mut_ptr(),
         std::ptr::null(),
     );
-    tj3Destroy(handle);
-
+    // SAFETY: `handle` is a live handle this test created and has not
+    // destroyed; nothing else can reach it.
+    unsafe { tj3Destroy(handle) };
     (rc_yuv8, rc_planes8)
 }
 

--- a/crates/libjpeg-turbo-rs-capi/tests/yuv_four_component_guard.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/yuv_four_component_guard.rs
@@ -61,8 +61,9 @@ fn tj3_decompress_to_yuv8_rejects_four_component_jpeg() {
         dst_buf.as_mut_ptr(),
         ALIGN,
     );
-    tj3Destroy(handle);
-
+    // SAFETY: `handle` is a live handle this test created and has not
+    // destroyed; nothing else can reach it.
+    unsafe { tj3Destroy(handle) };
     assert_eq!(rc, -1, "4-component JPEG must be rejected, not packed");
     assert!(
         dst_buf[sized_len..].iter().all(|&b| b == SENTINEL),
@@ -93,8 +94,9 @@ fn tj3_decompress_to_yuv_planes8_rejects_four_component_jpeg() {
         plane_ptrs.as_mut_ptr(),
         std::ptr::null(),
     );
-    tj3Destroy(handle);
-
+    // SAFETY: `handle` is a live handle this test created and has not
+    // destroyed; nothing else can reach it.
+    unsafe { tj3Destroy(handle) };
     assert_eq!(rc, -1, "4-component JPEG must be rejected, not written out");
     assert!(
         planes[3].iter().all(|&b| b == SENTINEL),

--- a/crates/libjpeg-turbo-rs-capi/tests/yuv_validate_before_decode.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/yuv_validate_before_decode.rs
@@ -95,8 +95,9 @@ fn four_component_frame_is_rejected_without_decoding() {
     assert!(!handle.is_null());
     let rc: c_int = tj3DecompressToYUV8(handle, jpeg.as_ptr(), jpeg.len(), dst.as_mut_ptr(), ALIGN);
     let err: String = error_of(handle);
-    tj3Destroy(handle);
-
+    // SAFETY: `handle` is a live handle this test created and has not
+    // destroyed; nothing else can reach it.
+    unsafe { tj3Destroy(handle) };
     assert_eq!(rc, -1, "4-component frame must be rejected");
     assert!(
         err.contains("3 or fewer components"),
@@ -126,8 +127,9 @@ fn max_pixels_bounds_the_packed_entry_point() {
 
     let rc: c_int = tj3DecompressToYUV8(handle, jpeg.as_ptr(), jpeg.len(), dst.as_mut_ptr(), ALIGN);
     let err: String = error_of(handle);
-    tj3Destroy(handle);
-
+    // SAFETY: `handle` is a live handle this test created and has not
+    // destroyed; nothing else can reach it.
+    unsafe { tj3Destroy(handle) };
     assert_eq!(rc, -1, "a frame over TJPARAM_MAXPIXELS must be rejected");
     assert!(
         err.to_lowercase().contains("pixel"),
@@ -159,8 +161,9 @@ fn null_plane_pointer_leaves_all_caller_buffers_untouched() {
         ptrs.as_mut_ptr(),
         std::ptr::null(),
     );
-    tj3Destroy(handle);
-
+    // SAFETY: `handle` is a live handle this test created and has not
+    // destroyed; nothing else can reach it.
+    unsafe { tj3Destroy(handle) };
     assert_eq!(rc, -1, "a NULL plane pointer must be rejected");
     for (i, plane) in planes.iter().enumerate().take(2) {
         assert!(
@@ -185,8 +188,9 @@ fn bad_align_outranks_the_component_check_as_in_c() {
     assert!(!handle.is_null());
     let rc: c_int = tj3DecompressToYUV8(handle, jpeg.as_ptr(), jpeg.len(), dst.as_mut_ptr(), 0);
     let err: String = error_of(handle);
-    tj3Destroy(handle);
-
+    // SAFETY: `handle` is a live handle this test created and has not
+    // destroyed; nothing else can reach it.
+    unsafe { tj3Destroy(handle) };
     assert_eq!(rc, -1, "align = 0 must be rejected");
     assert!(
         !err.contains("3 or fewer components"),


### PR DESCRIPTION
## What

Addresses **#476** (P4-137) for the two exports carrying the actual hazards, and **settles the factual question blocking the rest.**

## The recorded rationale was wrong — now measured, not argued

The crate-wide suppression justified itself with:

> marking each function `unsafe fn` would change the ABI-visible symbol name and break the drop-in contract

**False.** `extern "C"` fixes the calling convention, `#[no_mangle]` fixes the symbol; `unsafe` adds an obligation for *Rust* callers only. Symbol diff across the change:

```
before: _tj3Alloc  _tj3Destroy  _tj3Free
after:  _tj3Alloc  _tj3Destroy  _tj3Free      → IDENTICAL
```

The comment now records that measurement and says plainly the suppression is an **unfinished TODO, not a rationale** — ~84 of 159 exports still take raw pointers, and `handle_as_mut` still forges an unbounded lifetime across nine modules.

## Converted

- **`tj3Free`** — hands an arbitrary caller pointer to `free()`.
- **`tj3Destroy`** — reconstructs ownership via `Box::from_raw`; two safe calls with one handle is a double free.
- **`tjDestroy`** — forwards its handle unchanged, so it inherits the obligation.

Each gets a `# Safety` section naming validity, ownership transfer, the **undetectable** double-destroy (a registry with generation tags is what would catch it — P4-137's open decision), and the threading requirement.

## The conversion immediately paid off

It surfaced **three internal call sites in `legacy.rs`** that had been invoking a double-free-capable function with no acknowledgement. That is the point of the change, not a side effect. The two image-IO wrappers own the handle they create, so their obligation is discharged locally; `tjDestroy` passes its to its own caller.

## A mistake worth recording

My first pass rewrote `tj3Destroy(...)` occurrences inside **embedded C harness strings**, injecting Rust `unsafe` into generated C:

```
error: use of undeclared identifier 'unsafe'
```

Eight tests caught it. `capi_classic_lifecycle.rs` is now deliberately untouched — *every* `tj3Destroy` in it is C source, not Rust (note `extern void tj3Destroy(tjhandle);`). Twelve genuine Rust call sites across four other test files wrap the call.

## Not claimed — the issue stays open

Criteria **2** (delete the crate-wide allow), **4** (`with_handle` closure helper), **5** (checked slice construction), **6** (handle-registry decision), **7** (docs boundary). The ~84-export sweep is a separate change; this one makes it safe to attempt by proving the ABI does not move.

`cargo test --workspace`: **2488 passed, 0 failed**.

Refs #476