### PR TITLE
fix(capi): replace saturating memory spans with checked arithmetic

### DIFF
--- a/crates/libjpeg-turbo-rs-capi/src/decompress.rs
+++ b/crates/libjpeg-turbo-rs-capi/src/decompress.rs
@@ -145,7 +145,16 @@ pub extern "C" fn tj3Decompress8(
         //
         // SAFETY: `dst_buf` is guaranteed by the caller to be at least
         // `effective_pitch * h` bytes; we never write beyond that.
-        let dst_total: usize = effective_pitch.saturating_mul(h);
+        // `saturating_mul` yielded usize::MAX on overflow -- precisely the
+        // wrong value here, since it becomes the length of a raw slice and
+        // claims the entire address space (P4-139).
+        let dst_total: usize = match effective_pitch.checked_mul(h) {
+            Some(v) => v,
+            None => {
+                inst.set_error("tj3Decompress8: pitch * height overflows", TJERR_FATAL);
+                return -1;
+            }
+        };
         let dst: &mut [u8] = unsafe { std::slice::from_raw_parts_mut(dst_buf, dst_total) };
 
         if let Err(e) = repack_into_pitched(&img.data, out_format, w, h, pf, dst, effective_pitch) {

--- a/crates/libjpeg-turbo-rs-capi/src/precision.rs
+++ b/crates/libjpeg-turbo-rs-capi/src/precision.rs
@@ -100,7 +100,13 @@ pub extern "C" fn tj3Compress12(
 
         // SAFETY: caller guarantees `src_buf` is valid for
         // `line_samples * h` samples.
-        let total_samples: usize = line_samples.saturating_mul(h);
+        let total_samples: usize = match line_samples.checked_mul(h) {
+            Some(v) => v,
+            None => {
+                inst.set_error("tj3Compress12: pitch * height overflows", TJERR_FATAL);
+                return -1;
+            }
+        };
         let raw: &[i16] = unsafe { std::slice::from_raw_parts(src_buf, total_samples) };
 
         let dense: Vec<i16> = if line_samples == w * components {
@@ -271,7 +277,13 @@ pub extern "C" fn tj3Decompress12(
 
         // SAFETY: caller guarantees `dst_buf` holds at least
         // `line_samples * height` samples.
-        let total: usize = line_samples.saturating_mul(img.height);
+        let total: usize = match line_samples.checked_mul(img.height) {
+            Some(v) => v,
+            None => {
+                inst.set_error("tj3Decompress12: pitch * height overflows", TJERR_FATAL);
+                return -1;
+            }
+        };
         let out: &mut [i16] = unsafe { std::slice::from_raw_parts_mut(dst_buf, total) };
         let row_samples: usize = img.width * components;
         for row in 0..img.height {
@@ -348,7 +360,13 @@ pub extern "C" fn tj3Compress16(
             return -1;
         }
 
-        let total: usize = line_samples.saturating_mul(h);
+        let total: usize = match line_samples.checked_mul(h) {
+            Some(v) => v,
+            None => {
+                inst.set_error("tj3Compress16: pitch * height overflows", TJERR_FATAL);
+                return -1;
+            }
+        };
         // SAFETY: caller guarantees `src_buf` is valid for `total` u16s.
         let raw: &[u16] = unsafe { std::slice::from_raw_parts(src_buf, total) };
         let dense: Vec<u16> = if line_samples == w * components {
@@ -489,7 +507,13 @@ pub extern "C" fn tj3Decompress16(
             return -1;
         }
 
-        let total: usize = line_samples.saturating_mul(img.height);
+        let total: usize = match line_samples.checked_mul(img.height) {
+            Some(v) => v,
+            None => {
+                inst.set_error("tj3Decompress16: pitch * height overflows", TJERR_FATAL);
+                return -1;
+            }
+        };
         let out: &mut [u16] = unsafe { std::slice::from_raw_parts_mut(dst_buf, total) };
         let row_samples: usize = img.width * components;
         for row in 0..img.height {


### PR DESCRIPTION
## What

Addresses **#478** (P4-139) for the five confirmed **saturating** instances.

Each computes a span that immediately becomes the **length of a raw slice**, so saturating to `usize::MAX` on overflow produces exactly the wrong value — a slice claiming the entire address space:

```rust
let dst_total: usize = effective_pitch.saturating_mul(h);
let dst: &mut [u8] = unsafe { std::slice::from_raw_parts_mut(dst_buf, dst_total) };
```

| site | entry point |
|---|---|
| `capi/src/decompress.rs:148` | `tj3Decompress8` |
| `capi/src/precision.rs:103` | `tj3Compress12` |
| `capi/src/precision.rs:274` | `tj3Decompress12` |
| `capi/src/precision.rs:351` | `tj3Compress16` |
| `capi/src/precision.rs:492` | `tj3Decompress16` |

All five now use `checked_mul` and report through the handle's error slot with `TJERR_FATAL` — the same way every other invalid argument is refused on these entry points.

The sixth confirmed instance the issue lists — the unchecked product at `src/api/progressive_output.rs:257` — was already fixed under #475.

## Not claimed

The `ScalingFactor` work (public `num`/`denom`, `new()` accepting `denom == 0`, and `assert!` panics on public API input) and the centralisation the issue is named for. Those change a public type's contract and belong in their own review.

`cargo test --workspace`: **2488 passed, 0 failed**.

Refs #478