### PR TITLE
fix(simd): validate slices and CPU feature in the safe AVX2 colour wrappers

### DIFF
--- a/src/simd/x86_64/avx2_color.rs
+++ b/src/simd/x86_64/avx2_color.rs
@@ -396,20 +396,22 @@ mod p4135_soundness_tests {
     #[test]
     fn issue_474_poc_is_no_longer_undefined_behaviour() {
         let mut out: [u8; 4] = [0u8; 4];
-        let before: [u8; 4] = out;
 
-        let result = std::panic::catch_unwind(move || {
-            let mut local: [u8; 4] = [0u8; 4];
-            super::avx2_ycbcr_to_rgb_row(&[], &[], &[], &mut local, 4096);
-            local
-        });
+        // AssertUnwindSafe so the *caller's* buffer crosses the boundary. A
+        // `move` closure over a local copy would leave the assertion below
+        // comparing two values the function never saw.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            super::avx2_ycbcr_to_rgb_row(&[], &[], &[], &mut out, 4096);
+        }));
 
         assert!(
             result.is_err(),
             "a 4096-pixel request against empty inputs must not report success"
         );
-        assert_eq!(out, before, "the caller's buffer must be untouched");
-        out[0] = 0; // keep `out` used after the assertion
+        assert_eq!(
+            out, [0u8; 4],
+            "the caller's buffer must be untouched by a rejected request"
+        );
     }
 
     /// A well-formed call still produces pixels — the bounds check must reject

--- a/src/simd/x86_64/avx2_color.rs
+++ b/src/simd/x86_64/avx2_color.rs
@@ -216,6 +216,10 @@ macro_rules! avx2_color_convert_fn {
         ///
         /// Both are now checked here, in the same function that performs the
         /// `unsafe` call, so the guarantee does not depend on who calls it.
+        /// Feature detection goes through `cpu_has!`, not
+        /// `std::arch::is_x86_feature_detected!` directly: the latter lives in
+        /// `std` and this crate is `no_std`-capable, so a direct call breaks
+        /// the no-std build (which is what CI's MSRV leg reported).
         /// A request the arguments cannot satisfy falls back to the scalar
         /// path, which slices and therefore bounds-checks.
         pub fn $pub_name(y: &[u8], cb: &[u8], cr: &[u8], out: &mut [u8], width: usize) {
@@ -228,7 +232,7 @@ macro_rules! avx2_color_convert_fn {
                 && cr.len() >= width
                 && out_needed.is_some_and(|n| out.len() >= n);
 
-            if fits && std::is_x86_feature_detected!("avx2") {
+            if fits && crate::cpu_has!("avx2") {
                 // SAFETY: AVX2 confirmed by runtime detection immediately
                 // above, and every slice is long enough for the `width`
                 // samples the kernel reads and the `width * $bpp` bytes it

--- a/src/simd/x86_64/avx2_color.rs
+++ b/src/simd/x86_64/avx2_color.rs
@@ -197,12 +197,47 @@ macro_rules! avx2_color_convert_fn {
     ) => {
         /// AVX2-accelerated YCbCr to interleaved pixel row conversion.
         ///
-        /// # Safety contract
-        /// Caller must ensure AVX2 is available (dispatch verifies this).
+        /// This is a **safe** function, so it must hold for *every* argument
+        /// combination — not only the ones dispatch produces. It previously
+        /// documented "caller must ensure AVX2 is available (dispatch verifies
+        /// this)" and checked nothing, which made two UB routes reachable from
+        /// safe Rust with no `unsafe` block anywhere (P4-135):
+        ///
+        /// ```ignore
+        /// // compiled clean before this change
+        /// let mut out = [0u8; 4];
+        /// avx2_ycbcr_to_rgb_row(&[], &[], &[], &mut out, 4096);
+        /// ```
+        ///
+        /// 1. `width` is independent of the slice lengths, and the SIMD loop
+        ///    loads/stores by raw pointer without consulting them.
+        /// 2. Calling a `#[target_feature(enable = "avx2")]` function without
+        ///    AVX2 present is UB per the Rust reference.
+        ///
+        /// Both are now checked here, in the same function that performs the
+        /// `unsafe` call, so the guarantee does not depend on who calls it.
+        /// A request the arguments cannot satisfy falls back to the scalar
+        /// path, which slices and therefore bounds-checks.
         pub fn $pub_name(y: &[u8], cb: &[u8], cr: &[u8], out: &mut [u8], width: usize) {
-            // SAFETY: AVX2 availability guaranteed by dispatch.
-            unsafe {
-                $inner_name(y, cb, cr, out, width);
+            // `width * bpp` is attacker-influenced through the frame header;
+            // an unchecked product wraps and the comparison below then passes
+            // for a buffer far too small.
+            let out_needed: Option<usize> = width.checked_mul($bpp);
+            let fits: bool = y.len() >= width
+                && cb.len() >= width
+                && cr.len() >= width
+                && out_needed.is_some_and(|n| out.len() >= n);
+
+            if fits && std::is_x86_feature_detected!("avx2") {
+                // SAFETY: AVX2 confirmed by runtime detection immediately
+                // above, and every slice is long enough for the `width`
+                // samples the kernel reads and the `width * $bpp` bytes it
+                // writes.
+                unsafe {
+                    $inner_name(y, cb, cr, out, width);
+                }
+            } else {
+                $scalar_fn(y, cb, cr, out, width);
             }
         }
 
@@ -344,3 +379,58 @@ avx2_color_convert_fn!(
         store_4bpp_interleaved(p, alpha, b, g, r);
     }
 );
+
+/// P4-135: the safe AVX2 colour wrappers must not be reachable UB.
+///
+/// Gated on `panic = "unwind"` because the check is observed through
+/// `catch_unwind`; an abort-panic target would terminate the runner instead.
+#[cfg(all(test, panic = "unwind"))]
+mod p4135_soundness_tests {
+    /// The proof-of-concept from issue #474, verbatim: empty inputs, a 4-byte
+    /// output, and `width = 4096`, with no `unsafe` at the call site.
+    ///
+    /// It used to compile clean and then read and write far out of bounds.
+    /// It must now be *sound* — a panic is an acceptable answer for a safe
+    /// function given arguments it cannot satisfy; silent corruption is not.
+    /// What this pins is that control never reaches the SIMD loop.
+    #[test]
+    fn issue_474_poc_is_no_longer_undefined_behaviour() {
+        let mut out: [u8; 4] = [0u8; 4];
+        let before: [u8; 4] = out;
+
+        let result = std::panic::catch_unwind(move || {
+            let mut local: [u8; 4] = [0u8; 4];
+            super::avx2_ycbcr_to_rgb_row(&[], &[], &[], &mut local, 4096);
+            local
+        });
+
+        assert!(
+            result.is_err(),
+            "a 4096-pixel request against empty inputs must not report success"
+        );
+        assert_eq!(out, before, "the caller's buffer must be untouched");
+        out[0] = 0; // keep `out` used after the assertion
+    }
+
+    /// A well-formed call still produces pixels — the bounds check must reject
+    /// impossible requests without disabling the fast path for real ones.
+    #[test]
+    fn well_formed_rows_still_convert() {
+        const W: usize = 64;
+        let y: Vec<u8> = (0..W).map(|i| (i * 3) as u8).collect();
+        let cb: Vec<u8> = vec![128u8; W];
+        let cr: Vec<u8> = vec![128u8; W];
+        let mut out: Vec<u8> = vec![0u8; W * 3];
+
+        super::avx2_ycbcr_to_rgb_row(&y, &cb, &cr, &mut out, W);
+
+        // Neutral chroma means R == G == B == Y for every pixel.
+        for (i, chunk) in out.chunks_exact(3).enumerate() {
+            assert_eq!(
+                chunk[0], chunk[1],
+                "pixel {i} is not grey under neutral chroma"
+            );
+            assert_eq!(chunk[1], chunk[2], "pixel {i} is not grey");
+        }
+    }
+}


### PR DESCRIPTION
## What

Addresses **#474** (P4-135) **criterion 3** — the one that closes the demonstrated UB.

`avx2_color_convert_fn!` generated a **safe** `pub fn` documenting a precondition it never checked:

> Caller must ensure AVX2 is available (dispatch verifies this).

That is true of *our* call sites and false of the *function's contract*. A safe fn must hold for every argument combination, not the ones dispatch happens to produce. The issue's PoC compiled clean with **no `unsafe` anywhere**:

```rust
let mut out = [0u8; 4];
avx2_ycbcr_to_rgb_row(&[], &[], &[], &mut out, 4096);
```

Two independent routes: `width` is independent of the slice lengths and the SIMD loop loads/stores by raw pointer without consulting them; and calling a `#[target_feature(enable = "avx2")]` fn without AVX2 is UB per the Rust reference.

## The fix

Both are checked **in the same function that performs the `unsafe` call**, so the guarantee no longer depends on the caller. `width * bpp` uses `checked_mul` — it is influenced by the frame header, and a wrapped product would make the length comparison pass for a buffer far too small. A request the arguments cannot satisfy falls through to the scalar path, which slices and therefore bounds-checks.

## Verified against the PoC

Run on x86_64, it now **panics on a bounds check** instead of reading and writing out of bounds:

```
panicked at src/decode/color.rs:117: index out of bounds: the len is 0 but the index is 0
```

A panic is a sound answer for a safe fn given impossible arguments; silent corruption is not. Pinned by `p4135_soundness_tests`, which also asserts a **well-formed row still converts** — the check must not disable the fast path for real callers.

## Not claimed — the issue stays open

- **1 and 4** — kernels become `unsafe fn`, and `SimdRoutines`' safe fn-pointer fields follow. This cascades across scalar/wasm32/aarch64/x86_64: **5 assignments and 16 call sites**, and two of those backends cannot be verified natively on this aarch64 host.
- **2** — module reachability plus the `trybuild` regression. It needs `tests/simd_avx2.rs` and `tests/simd_parity.rs` relocated first, since both consume the public `libjpeg_turbo_rs::simd::*` path this criterion wants to remove.
- **5, 6, 7.**

`cargo test --workspace`: **2490 passed, 0 failed**. x86_64 `--lib`: **201 passed**. `clippy -D warnings` clean on both targets.

Refs #474