### PR TITLE
docs: record that the P4-16 reopen trigger fired and the threading gap widened

### DIFF
--- a/docs/ABI_COMPATIBILITY.md
+++ b/docs/ABI_COMPATIBILITY.md
@@ -100,7 +100,16 @@ Concretely:
 
 **Why this contract.** The v8 `struct jpeg_decompress_struct` is ABI-mirrored byte-for-byte (`crates/libjpeg-turbo-rs-capi/src/jpeglib.rs:3900-3970` pins the offsets). There is no room to append a `priv_ptr` field without breaking offset compatibility with upstream-compiled consumers, so private state lives in TLS instead. Implementation pointers: `DECOMPRESS_PRIVATE_STATE` at `jpeglib.rs:368-372` (decompress side) + compress equivalent at `:3492-3505`.
 
-**Divergence from upstream.** Upstream libjpeg-turbo's contract is "single-threaded per `cinfo`, but ownership transfer between threads is OK provided the application enforces non-concurrent access." We are stricter: ownership stays on the creating thread. If your consumer needs cross-thread `cinfo` ownership transfer (the canonical example is FFmpeg's frame-thread JPEG path), file an issue with the use case — the migration to a global `OnceLock<RwLock<HashMap>>` is tracked as P4-16 Option A in `docs/last_mile/phase4.md` and we will prioritise based on adoption signal.
+**Divergence from upstream.** Upstream libjpeg-turbo's contract is "single-threaded per `cinfo`, but ownership transfer between threads is OK provided the application enforces non-concurrent access." We are stricter: ownership stays on the creating thread.
+
+**Status (2026-08-09): the reopen trigger has fired, and the gap has widened.** This paragraph used to end by inviting an issue and promising to "prioritise based on adoption signal". That signal arrived — the constraint is now tracked as **P4-132 (#463)**, which reopens P4-16 Option A — so the invitation is no longer the current state and is not repeated here.
+
+Two things changed since P4-16 measured this in 2026-05:
+
+- **Upstream moved off thread-local storage.** libjpeg-turbo 3.2 beta1 overhauled its SIMD dispatchers to initialise per instance rather than per thread, explicitly *"eliminating the need for thread-local storage in the libjpeg API library."* P4-16's comparison was written against the older upstream implementation; our TLS-keyed side tables are now a wider divergence than when the trade-off was accepted.
+- **The oracle CI runs against 3.1.4.1**, one minor behind, so nothing in this repository has measured 3.2's threading behaviour (see P4-130 / #461).
+
+The migration remains a global map keyed by `cinfo` pointer, but a `Mutex<HashMap>` alone is not sufficient: a freed and reallocated `cinfo` can land at the same address and collide with a stale entry, so the private state needs a generation counter and a single release point. That requirement is recorded on **#463**, not here.
 
 ### Legacy TurboJPEG 1.x/2.x aliases — partial coverage (P4-18)
 


### PR DESCRIPTION
## What

Addresses **#463** (P4-132) for the part that is a **doc-freshness defect** rather than the refactor.

## The paragraph was addressing a reader in the past

The threading-contract section ended by inviting an issue for cross-thread `cinfo` ownership transfer and promising to *"prioritise based on adoption signal"*. **That signal arrived** — #463 is precisely the issue P4-16's own reopen trigger asked for. A reader reaching that paragraph today is told to file something that already exists.

## Two facts changed since P4-16 measured the trade-off

Neither was in the doc:

- **Upstream moved off TLS.** libjpeg-turbo 3.2 beta1 overhauled its SIMD dispatchers to initialise **per instance rather than per thread**, explicitly *"eliminating the need for thread-local storage in the libjpeg API library."* Our TLS-keyed side tables are therefore a **wider** divergence than when the trade-off was accepted — not the same one P4-16 weighed.
- **The oracle CI still runs 3.1.4.1**, so nothing in this repository has measured 3.2's threading behaviour (P4-130 / #461).

## One constraint worth stating before someone starts

Keying a global map by `cinfo` pointer means a freed and reallocated `cinfo` can land at the same address and collide with a stale entry — so `Mutex<HashMap>` alone is **not** sufficient; the private state needs a generation counter and a single release point. The detail stays on #463; the doc now says enough that nobody starts the naive version.

## Not claimed

Criterion **5** asks for these sections to be rewritten *to the new contract*, which requires the migration itself, plus criteria **1–4** (the global map, the 1% single-threaded benchmark bar, the generation-counter defence, and the create-on-A / destroy-on-B tests). The issue stays open for all of them.

Docs only; no runtime behaviour changes.

Refs #463