### PR TITLE
fix(simd): validate slices and CPU feature in the SSE2 colour wrapper

### DIFF
--- a/src/simd/x86_64/color.rs
+++ b/src/simd/x86_64/color.rs
@@ -19,11 +19,36 @@ const PW_MF0344: i16 = -22554; // -FIX(0.34414) for G vpmaddwd
 const PW_F0285: i16 = 18734; // FIX(0.28586) for G vpmaddwd
 
 /// SSE2-accelerated YCbCr to interleaved RGB row conversion.
+/// SSE2 YCbCr -> RGB row conversion.
+///
+/// This is the dispatch table's x86_64 fallback, so it runs on any machine
+/// without AVX2 — which makes it the widest-reaching instance of the P4-135
+/// shape fixed in `avx2_color.rs`.
+///
+/// It is a **safe** fn, so it must hold for every argument combination, not
+/// just what dispatch produces. The previous comment claimed "slice bounds are
+/// enforced by the while loop condition `x + 8 <= width`" — but `width` is a
+/// *parameter*, independent of the slice lengths, and the loop loads through
+/// `y.as_ptr().add(x)` without consulting them. A caller passing empty slices
+/// and a large `width` read and wrote out of bounds with no `unsafe` at the
+/// call site.
 pub fn sse2_ycbcr_to_rgb_row(y: &[u8], cb: &[u8], cr: &[u8], rgb: &mut [u8], width: usize) {
-    // SAFETY: SSE2 availability is verified at dispatch time via is_x86_feature_detected!().
-    // Slice bounds are enforced by the while loop condition `x + 8 <= width`.
-    unsafe {
-        sse2_ycbcr_to_rgb_row_inner(y, cb, cr, rgb, width);
+    // `width * 3` comes from frame geometry; unchecked it wraps and the
+    // comparison below passes for a buffer far too small.
+    let rgb_needed: Option<usize> = width.checked_mul(3);
+    let fits: bool = y.len() >= width
+        && cb.len() >= width
+        && cr.len() >= width
+        && rgb_needed.is_some_and(|n| rgb.len() >= n);
+
+    if fits && crate::cpu_has!("sse2") {
+        // SAFETY: SSE2 confirmed immediately above, and every slice holds the
+        // `width` samples the kernel reads and the `width * 3` bytes it writes.
+        unsafe {
+            sse2_ycbcr_to_rgb_row_inner(y, cb, cr, rgb, width);
+        }
+    } else {
+        crate::decode::color::ycbcr_to_rgb_row(y, cb, cr, rgb, width);
     }
 }
 


### PR DESCRIPTION
## What

Extends #493's P4-135 fix to **`sse2_ycbcr_to_rgb_row`** — the x86_64 dispatch table's **fallback**, and therefore the widest-reaching instance of the same shape: it runs on any x86_64 machine without AVX2.

Its comment claimed:

> Slice bounds are enforced by the while loop condition `x + 8 <= width`.

**They are not.** `width` is a parameter independent of the slice lengths, and the loop loads through `y.as_ptr().add(x)` without consulting them. Empty slices with a large `width` read and wrote out of bounds from safe Rust — exactly what the P4-135 proof-of-concept does on the AVX2 path.

Same fix as #493: every slice checked against `width`, `width * 3` via `checked_mul`, SSE2 confirmed through `cpu_has!` in the function performing the `unsafe` call, and a scalar fallback for anything that doesn't fit.

## Found by scanning, not assuming

I checked whether #493 was the only instance rather than treating it as one. Full results are posted on #481. Summary:

- **9 wrappers** carry the unsound shape (slice + separate length parameter).
- This PR fixes **1** — the dispatch fallback.
- The remaining **8** are the four wasm32 colour variants and four merged upsample+colour ones. **Deliberately not batched here:** the merged kernels have different geometry (h2v1 reads `2*width` luma for `width/2` chroma), so a blanket rule would be *wrong* for them. They need per-function analysis.

## The scan corrected its own first answer

A naive *"safe fn wrapping `unsafe`"* grep flagged **19** wrappers. Ten of those take **fixed-size array references** (`&[i16; 64]`, `&mut [u8; 64]`) where the length is carried by the type and cannot disagree with a separate parameter — reporting them would have overstated the problem by roughly 2×. **aarch64 has none of the unsound shape**, which matches #474's own note that "the three IDCT fields need no change".

`cargo test --workspace`: **2490 passed, 0 failed**. x86_64 `--lib`: **201 passed**. `no_std` check clean.

Refs #474, #481