### PR TITLE
fix(simd): validate slices in the four wasm32 colour wrappers

### DIFF
--- a/src/simd/wasm32/color.rs
+++ b/src/simd/wasm32/color.rs
@@ -26,11 +26,25 @@ fn mulhi_epi16(a: v128, b: v128) -> v128 {
 
 /// WASM simd128 YCbCr to interleaved RGB row conversion.
 pub fn wasm_ycbcr_to_rgb_row(y: &[u8], cb: &[u8], cr: &[u8], rgb: &mut [u8], width: usize) {
-    // SAFETY: Caller guarantees y.len() >= width, cb.len() >= width, cr.len() >= width,
-    // out.len() >= width * BPP. The loop processes 8 pixels per iteration with a scalar
-    // tail for width % 8 != 0, preventing out-of-bounds access.
-    unsafe {
-        wasm_ycbcr_to_rgb_row_inner(y, cb, cr, rgb, width);
+    // P4-135: `width` is a parameter independent of the slice lengths, and
+    // the SIMD loop stores through raw pointers without consulting them. The
+    // old comment stated this as a caller guarantee on a *safe* fn, which
+    // means it held for our dispatch and for nobody else.
+    let out_needed: Option<usize> = width.checked_mul(3);
+    let fits: bool = y.len() >= width
+        && cb.len() >= width
+        && cr.len() >= width
+        && out_needed.is_some_and(|n| rgb.len() >= n);
+
+    if fits {
+        // SAFETY: every slice holds the `width` samples the kernel reads and
+        // the `width * 3` bytes it writes. simd128 is a compile-time target
+        // feature on wasm32, so there is no runtime probe to make here.
+        unsafe {
+            wasm_ycbcr_to_rgb_row_inner(y, cb, cr, rgb, width);
+        }
+    } else {
+        crate::decode::color::ycbcr_to_rgb_row(y, cb, cr, rgb, width);
     }
 }
 
@@ -204,11 +218,25 @@ unsafe fn wasm_ycbcr_to_rgb_row_inner(
 
 /// WASM simd128 YCbCr to interleaved RGBA row conversion.
 pub fn wasm_ycbcr_to_rgba_row(y: &[u8], cb: &[u8], cr: &[u8], rgba: &mut [u8], width: usize) {
-    // SAFETY: Caller guarantees y.len() >= width, cb.len() >= width, cr.len() >= width,
-    // out.len() >= width * BPP. The loop processes 8 pixels per iteration with a scalar
-    // tail for width % 8 != 0, preventing out-of-bounds access.
-    unsafe {
-        wasm_ycbcr_to_rgba_row_inner(y, cb, cr, rgba, width);
+    // P4-135: `width` is a parameter independent of the slice lengths, and
+    // the SIMD loop stores through raw pointers without consulting them. The
+    // old comment stated this as a caller guarantee on a *safe* fn, which
+    // means it held for our dispatch and for nobody else.
+    let out_needed: Option<usize> = width.checked_mul(4);
+    let fits: bool = y.len() >= width
+        && cb.len() >= width
+        && cr.len() >= width
+        && out_needed.is_some_and(|n| rgba.len() >= n);
+
+    if fits {
+        // SAFETY: every slice holds the `width` samples the kernel reads and
+        // the `width * 4` bytes it writes. simd128 is a compile-time target
+        // feature on wasm32, so there is no runtime probe to make here.
+        unsafe {
+            wasm_ycbcr_to_rgba_row_inner(y, cb, cr, rgba, width);
+        }
+    } else {
+        crate::decode::color::ycbcr_to_rgba_row(y, cb, cr, rgba, width);
     }
 }
 
@@ -303,11 +331,25 @@ unsafe fn wasm_ycbcr_to_rgba_row_inner(
 
 /// WASM simd128 YCbCr to interleaved BGR row conversion.
 pub fn wasm_ycbcr_to_bgr_row(y: &[u8], cb: &[u8], cr: &[u8], bgr: &mut [u8], width: usize) {
-    // SAFETY: Caller guarantees y.len() >= width, cb.len() >= width, cr.len() >= width,
-    // bgr.len() >= width * 3. The loop processes 8 pixels per iteration with a scalar
-    // tail for width % 8 != 0, preventing out-of-bounds access.
-    unsafe {
-        wasm_ycbcr_to_bgr_row_inner(y, cb, cr, bgr, width);
+    // P4-135: `width` is a parameter independent of the slice lengths, and
+    // the SIMD loop stores through raw pointers without consulting them. The
+    // old comment stated this as a caller guarantee on a *safe* fn, which
+    // means it held for our dispatch and for nobody else.
+    let out_needed: Option<usize> = width.checked_mul(3);
+    let fits: bool = y.len() >= width
+        && cb.len() >= width
+        && cr.len() >= width
+        && out_needed.is_some_and(|n| bgr.len() >= n);
+
+    if fits {
+        // SAFETY: every slice holds the `width` samples the kernel reads and
+        // the `width * 3` bytes it writes. simd128 is a compile-time target
+        // feature on wasm32, so there is no runtime probe to make here.
+        unsafe {
+            wasm_ycbcr_to_bgr_row_inner(y, cb, cr, bgr, width);
+        }
+    } else {
+        crate::decode::color::ycbcr_to_bgr_row(y, cb, cr, bgr, width);
     }
 }
 
@@ -397,11 +439,25 @@ unsafe fn wasm_ycbcr_to_bgr_row_inner(
 
 /// WASM simd128 YCbCr to interleaved BGRA row conversion.
 pub fn wasm_ycbcr_to_bgra_row(y: &[u8], cb: &[u8], cr: &[u8], bgra: &mut [u8], width: usize) {
-    // SAFETY: Caller guarantees y.len() >= width, cb.len() >= width, cr.len() >= width,
-    // bgra.len() >= width * 4. The loop processes 8 pixels per iteration with a scalar
-    // tail for width % 8 != 0, preventing out-of-bounds access.
-    unsafe {
-        wasm_ycbcr_to_bgra_row_inner(y, cb, cr, bgra, width);
+    // P4-135: `width` is a parameter independent of the slice lengths, and
+    // the SIMD loop stores through raw pointers without consulting them. The
+    // old comment stated this as a caller guarantee on a *safe* fn, which
+    // means it held for our dispatch and for nobody else.
+    let out_needed: Option<usize> = width.checked_mul(4);
+    let fits: bool = y.len() >= width
+        && cb.len() >= width
+        && cr.len() >= width
+        && out_needed.is_some_and(|n| bgra.len() >= n);
+
+    if fits {
+        // SAFETY: every slice holds the `width` samples the kernel reads and
+        // the `width * 4` bytes it writes. simd128 is a compile-time target
+        // feature on wasm32, so there is no runtime probe to make here.
+        unsafe {
+            wasm_ycbcr_to_bgra_row_inner(y, cb, cr, bgra, width);
+        }
+    } else {
+        crate::decode::color::ycbcr_to_bgra_row(y, cb, cr, bgra, width);
     }
 }
 


### PR DESCRIPTION
## What

Continues the P4-135 sweep scoped on #481. These four carried the same shape as the AVX2 (#493) and SSE2 (#495) wrappers: a safe `pub fn` taking slices plus an **independent `width`**, dispatching straight into an unsafe kernel that stores through raw pointers without consulting the slice lengths.

Their comment stated the requirement as a caller guarantee:

```rust
// SAFETY: Caller guarantees y.len() >= width, ... out.len() >= width * BPP
```

That is true of our dispatch and of **nobody else**. A safe fn cannot delegate its soundness to callers it does not control.

## The fix

Each now checks every slice against `width`, computes `width * bpp` with `checked_mul`, and falls back to the scalar converter when the arguments cannot be satisfied.

**No runtime feature probe here** — `simd128` is a compile-time target feature on wasm32, so unlike the x86_64 wrappers there is nothing to detect. That's stated in the SAFETY comment rather than left as an unexplained difference between backends.

## Verified per target, not by inference

- `cargo check` clean on **wasm32-unknown-unknown** and **wasm32-wasip1**
- `clippy -D warnings` clean on wasm32-unknown-unknown with CI's allow-list
- `cargo test --workspace` on host: **2490 passed, 0 failed**

## Remaining

The four merged upsample+colour wrappers (`wasm32/merged.rs` ×2, `x86_64/avx2_merged.rs` ×2). **Still not batched** — h2v1 reads `2*width` luma against `width/2` chroma, so their bounds differ per function and a blanket rule would be wrong for them.

Sweep progress from #481's scan: **9 unsound wrappers found → 5 fixed → 4 remaining.**

Refs #474, #481