### PR TITLE
fix(capi): reject NULL/empty input in jpeg_mem_src as upstream does

### DIFF
--- a/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
+++ b/crates/libjpeg-turbo-rs-capi/src/jpeglib.rs
@@ -911,6 +911,12 @@ const JERR_BAD_STATE: c_int = 21;
 /// "Buffer passed to JPEG library is too small"
 const JERR_BUFFER_SIZE: c_int = 24;
 #[allow(dead_code)]
+/// "Empty input file" — raised by `jpeg_mem_src` for a NULL or zero-length
+/// buffer (`jdatasrc.c`). Index derived from `jerror.h`'s JMESSAGE order and
+/// cross-checked against the four codes already pinned above, which the raw
+/// ordinal overshoots by exactly one.
+const JERR_INPUT_EMPTY: c_int = 43;
+#[allow(dead_code)]
 /// "Suspension not allowed here"
 const JERR_CANT_SUSPEND: c_int = 25;
 #[allow(dead_code)]
@@ -1634,6 +1640,16 @@ pub extern "C" fn jpeg_mem_src(cinfo: *mut c_void, buf: *const u8, size: std::os
             None => return,
         };
 
+        // Upstream treats an empty input as fatal before touching any state
+        // (`jdatasrc.c`: `if (inbuffer == NULL || insize == 0) ERREXIT(cinfo,
+        // JERR_INPUT_EMPTY)`). We used to accept it and install a source
+        // manager over a NULL pointer, so the failure surfaced later as a
+        // decode error — or not at all — instead of at the call C rejects
+        // (P4-109).
+        if buf.is_null() || size == 0 {
+            invoke_error_exit(cinfo, JERR_INPUT_EMPTY);
+            return;
+        }
         let len: usize = size as usize;
         priv_state.source = JpegSource::Memory { ptr: buf, len };
         install_source_mgr(c, priv_state, buf, len);

--- a/crates/libjpeg-turbo-rs-capi/tests/capi_classic_error_codes.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/capi_classic_error_codes.rs
@@ -54,6 +54,7 @@ const EXPECTED: &[(&str, i32, &str)] = &[
         38,
         "Output file write error --- out of disk space?",
     ),
+    ("JERR_INPUT_EMPTY", 43, "Empty input file"),
     (
         "JERR_IMAGE_TOO_BIG",
         42,

--- a/crates/libjpeg-turbo-rs-capi/tests/mem_src_empty_input.rs
+++ b/crates/libjpeg-turbo-rs-capi/tests/mem_src_empty_input.rs
@@ -1,0 +1,80 @@
+//! Issue #469 (P4-109): `jpeg_mem_src` must reject NULL / zero-length input
+//! the way upstream does, rather than installing a source manager over it.
+//!
+//! Upstream `jdatasrc.c`:
+//!
+//! ```c
+//! if (inbuffer == NULL || insize == 0)   /* Treat empty input as fatal error */
+//!   ERREXIT(cinfo, JERR_INPUT_EMPTY);
+//! ```
+//!
+//! This shim accepted both and installed a manager pointing at the empty
+//! buffer, so the failure surfaced later as a decode error — or not at all —
+//! instead of at the call C rejects.
+//!
+//! The assertion is on `error_exit` firing with `msg_code == JERR_INPUT_EMPTY`,
+//! not merely on "something failed": the point of the contract is *which*
+//! error a C consumer's handler sees.
+
+use std::ffi::{c_int, c_void};
+
+use libjpeg_turbo_rs_capi::{
+    jpeg_CreateDecompress, jpeg_destroy_decompress, jpeg_mem_src, jpeg_std_error, JpegErrorMgr,
+};
+use std::sync::atomic::{AtomicI32, Ordering};
+
+/// `jerror.h` JMESSAGE ordinal for `JERR_INPUT_EMPTY`.
+const JERR_INPUT_EMPTY: c_int = 43;
+
+static LAST_MSG_CODE: AtomicI32 = AtomicI32::new(-1);
+
+/// Replacement `error_exit` that records the code and returns.
+///
+/// libjpeg's contract is that `error_exit` never returns, and a real consumer
+/// would `longjmp` out. A Rust test cannot: panicking across an `extern "C"`
+/// boundary aborts the process rather than unwinding, which is exactly what
+/// the first version of this test did. Returning is safe here because
+/// `jpeg_mem_src` returns immediately after raising — the contract this test
+/// exercises is *which code is raised*, not what a handler does next.
+unsafe extern "C" fn recording_error_exit(cinfo: *mut c_void) {
+    // Read through the real `JpegErrorMgr` rather than a hand-computed offset:
+    // `cinfo`'s first field is `err`, and the struct is the crate's own
+    // ABI-pinned mirror, so this cannot drift from the layout under test.
+    let err: *mut JpegErrorMgr = unsafe { *(cinfo as *const *mut JpegErrorMgr) };
+    LAST_MSG_CODE.store(unsafe { (*err).msg_code }, Ordering::SeqCst);
+}
+
+fn drive(buf: *const u8, size: std::os::raw::c_ulong) -> c_int {
+    LAST_MSG_CODE.store(-1, Ordering::SeqCst);
+    let mut cinfo: Vec<u8> = vec![0u8; 1024];
+    let mut jerr: JpegErrorMgr = unsafe { std::mem::zeroed() };
+    unsafe {
+        let errp: *mut JpegErrorMgr = jpeg_std_error(&mut jerr as *mut JpegErrorMgr);
+        assert!(!errp.is_null(), "jpeg_std_error");
+        (*errp).error_exit = Some(recording_error_exit);
+        *(cinfo.as_mut_ptr() as *mut *mut JpegErrorMgr) = errp;
+        jpeg_CreateDecompress(cinfo.as_mut_ptr() as *mut c_void, 80, cinfo.len());
+        jpeg_mem_src(cinfo.as_mut_ptr() as *mut c_void, buf, size);
+        jpeg_destroy_decompress(cinfo.as_mut_ptr() as *mut c_void);
+    }
+    LAST_MSG_CODE.load(Ordering::SeqCst)
+}
+
+#[test]
+fn jpeg_mem_src_rejects_null_buffer_with_input_empty() {
+    assert_eq!(
+        drive(std::ptr::null(), 16),
+        JERR_INPUT_EMPTY,
+        "a NULL buffer must raise JERR_INPUT_EMPTY, as jdatasrc.c does"
+    );
+}
+
+#[test]
+fn jpeg_mem_src_rejects_zero_length_with_input_empty() {
+    let data: [u8; 4] = [0xFF, 0xD8, 0xFF, 0xD9];
+    assert_eq!(
+        drive(data.as_ptr(), 0),
+        JERR_INPUT_EMPTY,
+        "a zero-length input must raise JERR_INPUT_EMPTY even with a valid pointer"
+    );
+}


### PR DESCRIPTION
## What

Addresses **#469** (P4-109) for the first of its listed divergences.

`jdatasrc.c` treats an empty input as fatal *before touching any state*:

```c
if (inbuffer == NULL || insize == 0)   /* Treat empty input as fatal error */
  ERREXIT(cinfo, JERR_INPUT_EMPTY);
```

The shim accepted both and installed a source manager pointing at the empty (or NULL) buffer, so the failure surfaced later as a decode error — **or not at all**. A consumer whose error handler keys on `msg_code` never saw `JERR_INPUT_EMPTY`.

## Deriving the code needed care

Counting `jerror.h`'s `JMESSAGE` entries gives **44**. But the same count overshoots *every* code already pinned in this crate by exactly one:

| constant | counted | actual |
|---|---|---|
| `JERR_BAD_PRECISION` | 17 | 16 |
| `JERR_BUFFER_SIZE` | 25 | 24 |
| `JERR_FILE_WRITE` | 39 | 38 |
| `JERR_OUT_OF_MEMORY` | 57 | 56 |

Validating the method against known values rather than trusting it gives **43**.

**And that isn't left resting on my arithmetic.** The crate's own `capi_classic_error_codes` suite cross-checks every shim error constant against upstream's `jerror.h`, and it failed on this commit until the constant was registered:

```
these shim error constants are not cross-checked against upstream: ["JERR_INPUT_EMPTY"]
```

With the entry added, `classic_error_codes_match_upstream` confirms 43 **independently**. That guard is a good one — it caught exactly the thing it exists for.

## The regression

Asserts the specific `msg_code`, not merely that something failed — *which* error a C consumer's handler sees is the contract.

Its callback records and returns rather than unwinding: panicking across an `extern "C"` boundary **aborts the process**, which is what my first version did (SIGABRT). Returning is safe here because `jpeg_mem_src` returns immediately after raising.

Measured **red at `101732ff`**: both cases report `msg_code -1` (error_exit never fired) against the expected 43.

## Not claimed

The rest of P4-109 (FILE buffering and stream position, Windows support, consistent `error_exit` routing) and **all of P4-97** — `jpeg_resync_to_restart` is still an unconditional success no-op. The issue stays open.

`cargo test --workspace`: **2492 passed, 0 failed**.

Refs #469