### PR TITLE
fix(simd): make the SIMD kernel modules crate-private (P4-135 criterion 2)

### DIFF
--- a/.github/workflows/armv7.yml
+++ b/.github/workflows/armv7.yml
@@ -68,10 +68,15 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y gcc-arm-linux-gnueabihf qemu-user
           qemu-arm --version
+      # `simd_dispatch` is no longer a `tests/` target: it moved into the
+      # crate as `src/simd/simd_dispatch_tests.rs` so the SIMD modules could
+      # become private (P4-135 criterion 2, #474). It runs as part of `--lib`,
+      # which this job already builds and executes under qemu, so the coverage
+      # is unchanged -- naming it here now fails with "no test target named".
       - name: Build lib + dispatch tests for armv7
         run: |
           cargo test --release --target armv7-unknown-linux-gnueabihf --no-run \
-            --lib --test simd_dispatch --test no_std_dispatch
+            --lib --test no_std_dispatch
         timeout-minutes: 20
       # Scoped to C-tool-free targets on purpose: the byte-exact
       # cross-checks shell out to native x86_64 djpeg/cjpeg, and the
@@ -84,7 +89,7 @@ jobs:
           set -euo pipefail
           cargo test --release --target armv7-unknown-linux-gnueabihf --no-run \
             --message-format=json \
-            --lib --test simd_dispatch --test no_std_dispatch \
+            --lib --test no_std_dispatch \
             | jq -r 'select(.executable != null) | .executable' \
             | while read -r binary; do
                 echo "=== $binary ==="

--- a/src/simd/aarch64/mod.rs
+++ b/src/simd/aarch64/mod.rs
@@ -9,11 +9,24 @@ use alloc::vec::Vec;
 use alloc::{format, vec};
 pub mod color;
 pub mod color_encode;
+// Kept reachable but unreferenced. Making the arch modules crate-private
+// (P4-135 criterion 2, #474) turned `dead_code` into a real signal here: 33
+// NEON items in these three modules are called by neither the library nor any
+// test. 26 of them are in `idct_scaled`, which is independent confirmation of
+// **P4-71** — scaled decode never dispatches to the SIMD reduced-size IDCT on
+// any architecture, so those kernels have never had a caller.
+//
+// Allowed rather than deleted: removing them would discard working kernels
+// that P4-71 exists to start using. The allow is scoped to these three modules
+// so genuine dead code elsewhere in the backend still fails the build.
+#[allow(dead_code)]
 pub mod downsample;
 pub mod fdct;
 pub mod idct;
+#[allow(dead_code)]
 pub mod idct_scaled;
 pub mod merged;
+#[allow(dead_code)]
 pub mod quantize;
 pub mod upsample;
 

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -4,16 +4,46 @@
 //! On aarch64, NEON is always available (ARMv8 mandatory).
 //! Set `JSIMD_FORCENONE=1` to force scalar fallback.
 
-pub mod scalar;
+// P4-135 criterion 2 (#474): the arch kernel modules are crate-private. They
+// were `pub` only because the SIMD suites lived in `tests/` and reached them
+// through `libjpeg_turbo_rs::simd::*`; those suites now live in this module,
+// so the kernels are no longer callable from a downstream crate.
+//
+// `detect`, `detect_encoder`, `SimdRoutines` and `QuantDivisors` stay public:
+// `benches/{decode,encode}.rs` use them to select a routine set, and they
+// reach kernels only through the dispatch table, never by path. There is no
+// trade-off between benchmark coverage and reachability here.
+pub(crate) mod scalar;
+
+#[cfg(test)]
+mod neon_color_tests;
+#[cfg(test)]
+mod neon_idct_tests;
+#[cfg(test)]
+mod neon_upsample_tests;
+#[cfg(test)]
+mod simd_avx2_encode_tests;
+#[cfg(test)]
+mod simd_avx2_tests;
+#[cfg(test)]
+mod simd_dispatch_tests;
+#[cfg(test)]
+mod simd_neon_encode_tests;
+#[cfg(test)]
+mod simd_neon_scaled_tests;
+#[cfg(test)]
+mod simd_parity_tests;
+#[cfg(test)]
+mod simd_x86_tests;
 
 #[cfg(target_arch = "aarch64")]
-pub mod aarch64;
+pub(crate) mod aarch64;
 
 #[cfg(target_arch = "x86_64")]
-pub mod x86_64;
+pub(crate) mod x86_64;
 
 #[cfg(target_arch = "wasm32")]
-pub mod wasm32;
+pub(crate) mod wasm32;
 
 /// Function-pointer dispatch table for SIMD-accelerated decode operations.
 pub struct SimdRoutines {

--- a/src/simd/neon_color_tests.rs
+++ b/src/simd/neon_color_tests.rs
@@ -1,9 +1,16 @@
+//! Relocated from `tests/neon_color.rs` for P4-135 criterion 2 (#474).
+//!
+//! This suite reaches SIMD kernels directly, which is why the arch
+//! modules had to stay `pub` and were therefore callable from any
+//! downstream crate. As an in-crate test it uses `crate::`, so they
+//! can be private. Moved verbatim apart from the path rewrite.
+
 //! NEON YCbCr→pixel color conversion tests.
 #![cfg(target_arch = "aarch64")]
 
-use libjpeg_turbo_rs::decode::color;
-use libjpeg_turbo_rs::simd;
-use libjpeg_turbo_rs::simd::aarch64::color as neon_color;
+use crate::decode::color;
+use crate::simd;
+use crate::simd::aarch64::color as neon_color;
 
 fn scalar_rgb(y: &[u8], cb: &[u8], cr: &[u8], width: usize) -> Vec<u8> {
     std::env::set_var("JSIMD_FORCENONE", "1");
@@ -15,7 +22,7 @@ fn scalar_rgb(y: &[u8], cb: &[u8], cr: &[u8], width: usize) -> Vec<u8> {
 }
 
 fn neon_rgb(y: &[u8], cb: &[u8], cr: &[u8], width: usize) -> Vec<u8> {
-    let routines = libjpeg_turbo_rs::simd::aarch64::routines();
+    let routines = crate::simd::aarch64::routines();
     let mut rgb = vec![0u8; width * 3];
     (routines.ycbcr_to_rgb_row)(y, cb, cr, &mut rgb, width);
     rgb

--- a/src/simd/neon_idct_tests.rs
+++ b/src/simd/neon_idct_tests.rs
@@ -1,3 +1,10 @@
+//! Relocated from `tests/neon_idct.rs` for P4-135 criterion 2 (#474).
+//!
+//! This suite reaches SIMD kernels directly, which is why the arch
+//! modules had to stay `pub` and were therefore callable from any
+//! downstream crate. As an in-crate test it uses `crate::`, so they
+//! can be private. Moved verbatim apart from the path rewrite.
+
 //! NEON IDCT tests — verify byte-exact match with scalar implementation.
 //!
 //! Note: The NEON IDCT uses i16 workspace internally (matching libjpeg-turbo's
@@ -7,7 +14,7 @@
 //! paths agree.
 #![cfg(target_arch = "aarch64")]
 
-use libjpeg_turbo_rs::simd;
+use crate::simd;
 
 /// Helper: compute scalar IDCT result for comparison.
 fn scalar_idct(coeffs: &[i16; 64], quant: &[u16; 64]) -> [u8; 64] {
@@ -24,7 +31,7 @@ fn scalar_idct(coeffs: &[i16; 64], quant: &[u16; 64]) -> [u8; 64] {
 
 /// Helper: compute NEON IDCT result.
 fn neon_idct(coeffs: &[i16; 64], quant: &[u16; 64]) -> [u8; 64] {
-    use libjpeg_turbo_rs::simd::aarch64;
+    use crate::simd::aarch64;
     let routines = aarch64::routines();
     let mut output = [0u8; 64];
     (routines.idct_islow)(coeffs, quant, &mut output);

--- a/src/simd/neon_upsample_tests.rs
+++ b/src/simd/neon_upsample_tests.rs
@@ -1,8 +1,15 @@
+//! Relocated from `tests/neon_upsample.rs` for P4-135 criterion 2 (#474).
+//!
+//! This suite reaches SIMD kernels directly, which is why the arch
+//! modules had to stay `pub` and were therefore callable from any
+//! downstream crate. As an in-crate test it uses `crate::`, so they
+//! can be private. Moved verbatim apart from the path rewrite.
+
 //! NEON fancy h2v1 upsampling tests.
 #![cfg(target_arch = "aarch64")]
 
-use libjpeg_turbo_rs::decode::upsample;
-use libjpeg_turbo_rs::simd;
+use crate::decode::upsample;
+use crate::simd;
 
 fn scalar_upsample(input: &[u8], in_width: usize) -> Vec<u8> {
     std::env::set_var("JSIMD_FORCENONE", "1");
@@ -14,7 +21,7 @@ fn scalar_upsample(input: &[u8], in_width: usize) -> Vec<u8> {
 }
 
 fn neon_upsample(input: &[u8], in_width: usize) -> Vec<u8> {
-    let routines = libjpeg_turbo_rs::simd::aarch64::routines();
+    let routines = crate::simd::aarch64::routines();
     let mut output = vec![0u8; in_width * 2];
     (routines.fancy_upsample_h2v1)(input, in_width, &mut output);
     output
@@ -41,7 +48,7 @@ fn neon_upsample_h2v2(input: &[u8], in_width: usize, in_height: usize) -> Vec<u8
     let out_width = in_width * 2;
     let out_height = in_height * 2;
     let mut output = vec![0u8; out_width * out_height];
-    libjpeg_turbo_rs::simd::aarch64::upsample::neon_fancy_upsample_h2v2(
+    crate::simd::aarch64::upsample::neon_fancy_upsample_h2v2(
         input,
         in_width,
         in_height,

--- a/src/simd/simd_avx2_encode_tests.rs
+++ b/src/simd/simd_avx2_encode_tests.rs
@@ -1,3 +1,10 @@
+//! Relocated from `tests/simd_avx2_encode.rs` for P4-135 criterion 2 (#474).
+//!
+//! This suite reaches SIMD kernels directly, which is why the arch
+//! modules had to stay `pub` and were therefore callable from any
+//! downstream crate. As an in-crate test it uses `crate::`, so they
+//! can be private. Moved verbatim apart from the path rewrite.
+
 //! Integration tests for x86_64 AVX2 encode-side SIMD operations.
 //!
 //! Verifies that AVX2-accelerated RGB->YCbCr color conversion produces
@@ -5,8 +12,8 @@
 
 #[cfg(target_arch = "x86_64")]
 mod tests {
-    use libjpeg_turbo_rs::encode::color::rgb_to_ycbcr_row;
-    use libjpeg_turbo_rs::simd::x86_64::avx2_color_encode::avx2_rgb_to_ycbcr_row;
+    use crate::encode::color::rgb_to_ycbcr_row;
+    use crate::simd::x86_64::avx2_color_encode::avx2_rgb_to_ycbcr_row;
 
     fn skip_if_no_avx2() -> bool {
         !is_x86_feature_detected!("avx2")

--- a/src/simd/simd_avx2_tests.rs
+++ b/src/simd/simd_avx2_tests.rs
@@ -1,3 +1,10 @@
+//! Relocated from `tests/simd_avx2.rs` for P4-135 criterion 2 (#474).
+//!
+//! This suite reaches SIMD kernels directly, which is why the arch
+//! modules had to stay `pub` and were therefore callable from any
+//! downstream crate. As an in-crate test it uses `crate::`, so they
+//! can be private. Moved verbatim apart from the path rewrite.
+
 //! Tests for x86_64 AVX2 SIMD routines.
 //!
 //! Each AVX2 function is validated against the scalar implementation to ensure
@@ -5,8 +12,8 @@
 
 #[cfg(target_arch = "x86_64")]
 mod tests {
-    use libjpeg_turbo_rs::decode::{color, idct, upsample};
-    use libjpeg_turbo_rs::simd::x86_64::{avx2_color, avx2_idct, avx2_upsample};
+    use crate::decode::{color, idct, upsample};
+    use crate::simd::x86_64::{avx2_color, avx2_idct, avx2_upsample};
 
     // -----------------------------------------------------------------------
     // Helper: compute scalar IDCT reference output (dequant + IDCT + level-shift + clamp)
@@ -508,11 +515,11 @@ mod tests {
             return;
         }
         // Verify that AVX2 functions can be used as SimdRoutines function pointers
-        use libjpeg_turbo_rs::simd::SimdRoutines;
+        use crate::simd::SimdRoutines;
         let _routines = SimdRoutines {
             idct_islow: avx2_idct::avx2_idct_islow,
-            idct_ifast: libjpeg_turbo_rs::simd::scalar::scalar_idct_ifast,
-            idct_float: libjpeg_turbo_rs::simd::scalar::scalar_idct_float,
+            idct_ifast: crate::simd::scalar::scalar_idct_ifast,
+            idct_float: crate::simd::scalar::scalar_idct_float,
             ycbcr_to_rgb_row: avx2_color::avx2_ycbcr_to_rgb_row,
             fancy_upsample_h2v1: avx2_upsample::avx2_fancy_upsample_h2v1,
         };

--- a/src/simd/simd_dispatch_tests.rs
+++ b/src/simd/simd_dispatch_tests.rs
@@ -1,4 +1,11 @@
-use libjpeg_turbo_rs::simd::{self, SimdRoutines};
+//! Relocated from `tests/simd_dispatch.rs` for P4-135 criterion 2 (#474).
+//!
+//! This suite reaches SIMD kernels directly, which is why the arch
+//! modules had to stay `pub` and were therefore callable from any
+//! downstream crate. As an in-crate test it uses `crate::`, so they
+//! can be private. Moved verbatim apart from the path rewrite.
+
+use crate::simd::{self, SimdRoutines};
 
 #[test]
 fn detect_returns_valid_routines() {
@@ -36,7 +43,7 @@ fn forcenone_forces_scalar() {
 
 #[test]
 fn scalar_idct_matches_existing_functions() {
-    use libjpeg_turbo_rs::decode::idct;
+    use crate::decode::idct;
 
     // Create a block with known coefficients in natural (row-major) order.
     // Position [0] = DC, [1] = (0,1), [8] = (1,0), [16] = (2,0)
@@ -76,7 +83,7 @@ fn scalar_idct_matches_existing_functions() {
 
 #[test]
 fn scalar_ycbcr_to_rgb_matches_existing() {
-    use libjpeg_turbo_rs::decode::color;
+    use crate::decode::color;
 
     let routines = simd::detect();
 
@@ -96,7 +103,7 @@ fn scalar_ycbcr_to_rgb_matches_existing() {
 
 #[test]
 fn scalar_fancy_upsample_matches_existing() {
-    use libjpeg_turbo_rs::decode::upsample;
+    use crate::decode::upsample;
 
     let routines = simd::detect();
 

--- a/src/simd/simd_neon_encode_tests.rs
+++ b/src/simd/simd_neon_encode_tests.rs
@@ -1,3 +1,10 @@
+//! Relocated from `tests/simd_neon_encode.rs` for P4-135 criterion 2 (#474).
+//!
+//! This suite reaches SIMD kernels directly, which is why the arch
+//! modules had to stay `pub` and were therefore callable from any
+//! downstream crate. As an in-crate test it uses `crate::`, so they
+//! can be private. Moved verbatim apart from the path rewrite.
+
 //! Integration tests for aarch64 NEON encode-side SIMD operations.
 //!
 //! Verifies that NEON-accelerated FDCT, RGB->YCbCr color conversion,
@@ -5,11 +12,11 @@
 
 #[cfg(target_arch = "aarch64")]
 mod tests {
-    use libjpeg_turbo_rs::encode::color::rgb_to_ycbcr_row;
-    use libjpeg_turbo_rs::encode::fdct::fdct_islow;
-    use libjpeg_turbo_rs::simd::aarch64::color_encode::neon_rgb_to_ycbcr_row;
-    use libjpeg_turbo_rs::simd::aarch64::downsample::{neon_downsample_h2v1, neon_downsample_h2v2};
-    use libjpeg_turbo_rs::simd::aarch64::fdct::neon_fdct;
+    use crate::encode::color::rgb_to_ycbcr_row;
+    use crate::encode::fdct::fdct_islow;
+    use crate::simd::aarch64::color_encode::neon_rgb_to_ycbcr_row;
+    use crate::simd::aarch64::downsample::{neon_downsample_h2v1, neon_downsample_h2v2};
+    use crate::simd::aarch64::fdct::neon_fdct;
 
     // -----------------------------------------------------------------------
     // FDCT tests

--- a/src/simd/simd_neon_scaled_tests.rs
+++ b/src/simd/simd_neon_scaled_tests.rs
@@ -1,3 +1,10 @@
+//! Relocated from `tests/simd_neon_scaled.rs` for P4-135 criterion 2 (#474).
+//!
+//! This suite reaches SIMD kernels directly, which is why the arch
+//! modules had to stay `pub` and were therefore callable from any
+//! downstream crate. As an in-crate test it uses `crate::`, so they
+//! can be private. Moved verbatim apart from the path rewrite.
+
 //! Integration tests for aarch64 NEON scaled IDCT and quantization SIMD operations.
 //!
 //! Verifies that NEON-accelerated scaled IDCT (4x4, 2x2, 1x1) and quantization
@@ -5,11 +12,9 @@
 
 #[cfg(target_arch = "aarch64")]
 mod tests {
-    use libjpeg_turbo_rs::decode::idct_scaled::{idct_1x1, idct_2x2, idct_4x4};
-    use libjpeg_turbo_rs::simd::aarch64::idct_scaled::{
-        neon_idct_1x1, neon_idct_2x2, neon_idct_4x4,
-    };
-    use libjpeg_turbo_rs::simd::aarch64::quantize::neon_quantize;
+    use crate::decode::idct_scaled::{idct_1x1, idct_2x2, idct_4x4};
+    use crate::simd::aarch64::idct_scaled::{neon_idct_1x1, neon_idct_2x2, neon_idct_4x4};
+    use crate::simd::aarch64::quantize::neon_quantize;
 
     // -----------------------------------------------------------------------
     // Scalar quantize reference for testing

--- a/src/simd/simd_parity_tests.rs
+++ b/src/simd/simd_parity_tests.rs
@@ -1,3 +1,10 @@
+//! Relocated from `tests/simd_parity.rs` for P4-135 criterion 2 (#474).
+//!
+//! This suite reaches SIMD kernels directly, which is why the arch
+//! modules had to stay `pub` and were therefore callable from any
+//! downstream crate. As an in-crate test it uses `crate::`, so they
+//! can be private. Moved verbatim apart from the path rewrite.
+
 //! Cross-arch SIMD parity tests.
 //!
 //! For every SIMD kernel pair (scalar reference vs SIMD implementation)
@@ -37,10 +44,10 @@
 //! `assert!(diff <= measured + 1)` with the measured value documented
 //! in a comment. No such kernel is currently in scope.
 
-use libjpeg_turbo_rs::encode::pipeline::compute_reciprocal;
-use libjpeg_turbo_rs::encode::tables::ZIGZAG_ORDER;
-use libjpeg_turbo_rs::simd::scalar;
-use libjpeg_turbo_rs::simd::QuantDivisors;
+use crate::encode::pipeline::compute_reciprocal;
+use crate::encode::tables::ZIGZAG_ORDER;
+use crate::simd::scalar;
+use crate::simd::QuantDivisors;
 
 /// Number of random inputs per kernel. Large enough to probe corner
 /// cases (DC-only, saturating, sign-extended) while keeping the suite
@@ -213,7 +220,7 @@ fn parity_idct_islow_full() {
 
         #[cfg(target_arch = "aarch64")]
         {
-            use libjpeg_turbo_rs::simd::aarch64::idct::neon_idct_islow;
+            use crate::simd::aarch64::idct::neon_idct_islow;
             let mut simd_out: [u8; 64] = [0u8; 64];
             neon_idct_islow(&coeffs, &quant, &mut simd_out);
             assert_eq!(simd_out, scalar_out, "NEON idct_islow mismatch at iter {i}");
@@ -221,13 +228,13 @@ fn parity_idct_islow_full() {
         #[cfg(target_arch = "x86_64")]
         {
             if is_x86_feature_detected!("avx2") {
-                use libjpeg_turbo_rs::simd::x86_64::avx2_idct::avx2_idct_islow;
+                use crate::simd::x86_64::avx2_idct::avx2_idct_islow;
                 let mut simd_out: [u8; 64] = [0u8; 64];
                 avx2_idct_islow(&coeffs, &quant, &mut simd_out);
                 assert_eq!(simd_out, scalar_out, "AVX2 idct_islow mismatch at iter {i}");
             }
             if is_x86_feature_detected!("sse2") {
-                use libjpeg_turbo_rs::simd::x86_64::idct::sse2_idct_islow;
+                use crate::simd::x86_64::idct::sse2_idct_islow;
                 let mut simd_out: [u8; 64] = [0u8; 64];
                 sse2_idct_islow(&coeffs, &quant, &mut simd_out);
                 assert_eq!(simd_out, scalar_out, "SSE2 idct_islow mismatch at iter {i}");
@@ -235,7 +242,7 @@ fn parity_idct_islow_full() {
         }
         #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
         {
-            use libjpeg_turbo_rs::simd::wasm32::idct::wasm_idct_islow;
+            use crate::simd::wasm32::idct::wasm_idct_islow;
             let mut simd_out: [u8; 64] = [0u8; 64];
             wasm_idct_islow(&coeffs, &quant, &mut simd_out);
             assert_eq!(simd_out, scalar_out, "WASM idct_islow mismatch at iter {i}");
@@ -256,7 +263,7 @@ fn parity_idct_islow_full() {
 #[test]
 #[cfg_attr(not(target_arch = "aarch64"), allow(unused_variables))]
 fn parity_idct_4x4() {
-    use libjpeg_turbo_rs::decode::idct_scaled::idct_4x4;
+    use crate::decode::idct_scaled::idct_4x4;
     let mut rng: Mulberry32 = Mulberry32::new(0xA5A5_0002);
     for i in 0..N {
         let coeffs: [i16; 64] = random_coeffs(&mut rng);
@@ -266,7 +273,7 @@ fn parity_idct_4x4() {
 
         #[cfg(target_arch = "aarch64")]
         {
-            use libjpeg_turbo_rs::simd::aarch64::idct_scaled::neon_idct_4x4;
+            use crate::simd::aarch64::idct_scaled::neon_idct_4x4;
             let mut simd_out: [u8; 16] = [0u8; 16];
             neon_idct_4x4(&coeffs, &quant, &mut simd_out);
             assert_eq!(simd_out, scalar_out, "NEON idct_4x4 mismatch at iter {i}");
@@ -277,7 +284,7 @@ fn parity_idct_4x4() {
 #[test]
 #[cfg_attr(not(target_arch = "aarch64"), allow(unused_variables))]
 fn parity_idct_2x2() {
-    use libjpeg_turbo_rs::decode::idct_scaled::idct_2x2;
+    use crate::decode::idct_scaled::idct_2x2;
     let mut rng: Mulberry32 = Mulberry32::new(0xA5A5_0003);
     for i in 0..N {
         let coeffs: [i16; 64] = random_coeffs(&mut rng);
@@ -287,7 +294,7 @@ fn parity_idct_2x2() {
 
         #[cfg(target_arch = "aarch64")]
         {
-            use libjpeg_turbo_rs::simd::aarch64::idct_scaled::neon_idct_2x2;
+            use crate::simd::aarch64::idct_scaled::neon_idct_2x2;
             let mut simd_out: [u8; 4] = [0u8; 4];
             neon_idct_2x2(&coeffs, &quant, &mut simd_out);
             assert_eq!(simd_out, scalar_out, "NEON idct_2x2 mismatch at iter {i}");
@@ -298,7 +305,7 @@ fn parity_idct_2x2() {
 #[test]
 #[cfg_attr(not(target_arch = "aarch64"), allow(unused_variables))]
 fn parity_idct_1x1() {
-    use libjpeg_turbo_rs::decode::idct_scaled::idct_1x1;
+    use crate::decode::idct_scaled::idct_1x1;
     let mut rng: Mulberry32 = Mulberry32::new(0xA5A5_0004);
     for i in 0..N {
         let coeffs: [i16; 64] = random_coeffs(&mut rng);
@@ -307,7 +314,7 @@ fn parity_idct_1x1() {
 
         #[cfg(target_arch = "aarch64")]
         {
-            use libjpeg_turbo_rs::simd::aarch64::idct_scaled::neon_idct_1x1;
+            use crate::simd::aarch64::idct_scaled::neon_idct_1x1;
             let mut simd_out: [u8; 1] = [0u8; 1];
             neon_idct_1x1(&coeffs, &quant, &mut simd_out);
             assert_eq!(
@@ -338,7 +345,7 @@ fn parity_ycbcr_to_rgb_rows() {
 
             #[cfg(target_arch = "aarch64")]
             {
-                use libjpeg_turbo_rs::simd::aarch64::color::{
+                use crate::simd::aarch64::color::{
                     neon_ycbcr_to_bgr_row, neon_ycbcr_to_bgra_row, neon_ycbcr_to_rgb_row,
                     neon_ycbcr_to_rgba_row,
                 };
@@ -350,13 +357,7 @@ fn parity_ycbcr_to_rgb_rows() {
                 // RGBA / BGR / BGRA compared against their own scalar reference
                 let mut scalar_rgba: Vec<u8> = vec![0u8; width * 4];
                 let mut simd_rgba: Vec<u8> = vec![0u8; width * 4];
-                libjpeg_turbo_rs::decode::color::ycbcr_to_rgba_row(
-                    &y,
-                    &cb,
-                    &cr,
-                    &mut scalar_rgba,
-                    width,
-                );
+                crate::decode::color::ycbcr_to_rgba_row(&y, &cb, &cr, &mut scalar_rgba, width);
                 neon_ycbcr_to_rgba_row(&y, &cb, &cr, &mut simd_rgba, width);
                 assert_eq!(
                     simd_rgba, scalar_rgba,
@@ -365,25 +366,13 @@ fn parity_ycbcr_to_rgb_rows() {
 
                 let mut scalar_bgr: Vec<u8> = vec![0u8; width * 3];
                 let mut simd_bgr: Vec<u8> = vec![0u8; width * 3];
-                libjpeg_turbo_rs::decode::color::ycbcr_to_bgr_row(
-                    &y,
-                    &cb,
-                    &cr,
-                    &mut scalar_bgr,
-                    width,
-                );
+                crate::decode::color::ycbcr_to_bgr_row(&y, &cb, &cr, &mut scalar_bgr, width);
                 neon_ycbcr_to_bgr_row(&y, &cb, &cr, &mut simd_bgr, width);
                 assert_eq!(simd_bgr, scalar_bgr, "NEON BGR mismatch w={width} iter={i}");
 
                 let mut scalar_bgra: Vec<u8> = vec![0u8; width * 4];
                 let mut simd_bgra: Vec<u8> = vec![0u8; width * 4];
-                libjpeg_turbo_rs::decode::color::ycbcr_to_bgra_row(
-                    &y,
-                    &cb,
-                    &cr,
-                    &mut scalar_bgra,
-                    width,
-                );
+                crate::decode::color::ycbcr_to_bgra_row(&y, &cb, &cr, &mut scalar_bgra, width);
                 neon_ycbcr_to_bgra_row(&y, &cb, &cr, &mut simd_bgra, width);
                 assert_eq!(
                     simd_bgra, scalar_bgra,
@@ -394,13 +383,13 @@ fn parity_ycbcr_to_rgb_rows() {
             #[cfg(target_arch = "x86_64")]
             {
                 if is_x86_feature_detected!("avx2") {
-                    use libjpeg_turbo_rs::simd::x86_64::avx2_color::avx2_ycbcr_to_rgb_row;
+                    use crate::simd::x86_64::avx2_color::avx2_ycbcr_to_rgb_row;
                     let mut simd_rgb: Vec<u8> = vec![0u8; width * 3];
                     avx2_ycbcr_to_rgb_row(&y, &cb, &cr, &mut simd_rgb, width);
                     assert_eq!(simd_rgb, scalar_rgb, "AVX2 RGB mismatch w={width} iter={i}");
                 }
                 if is_x86_feature_detected!("sse2") {
-                    use libjpeg_turbo_rs::simd::x86_64::color::sse2_ycbcr_to_rgb_row;
+                    use crate::simd::x86_64::color::sse2_ycbcr_to_rgb_row;
                     let mut simd_rgb: Vec<u8> = vec![0u8; width * 3];
                     sse2_ycbcr_to_rgb_row(&y, &cb, &cr, &mut simd_rgb, width);
                     assert_eq!(simd_rgb, scalar_rgb, "SSE2 RGB mismatch w={width} iter={i}");
@@ -409,7 +398,7 @@ fn parity_ycbcr_to_rgb_rows() {
 
             #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
             {
-                use libjpeg_turbo_rs::simd::wasm32::color::{
+                use crate::simd::wasm32::color::{
                     wasm_ycbcr_to_bgr_row, wasm_ycbcr_to_bgra_row, wasm_ycbcr_to_rgb_row,
                     wasm_ycbcr_to_rgba_row,
                 };
@@ -420,13 +409,7 @@ fn parity_ycbcr_to_rgb_rows() {
 
                 let mut scalar_rgba: Vec<u8> = vec![0u8; width * 4];
                 let mut simd_rgba: Vec<u8> = vec![0u8; width * 4];
-                libjpeg_turbo_rs::decode::color::ycbcr_to_rgba_row(
-                    &y,
-                    &cb,
-                    &cr,
-                    &mut scalar_rgba,
-                    width,
-                );
+                crate::decode::color::ycbcr_to_rgba_row(&y, &cb, &cr, &mut scalar_rgba, width);
                 wasm_ycbcr_to_rgba_row(&y, &cb, &cr, &mut simd_rgba, width);
                 assert_eq!(
                     simd_rgba, scalar_rgba,
@@ -435,25 +418,13 @@ fn parity_ycbcr_to_rgb_rows() {
 
                 let mut scalar_bgr: Vec<u8> = vec![0u8; width * 3];
                 let mut simd_bgr: Vec<u8> = vec![0u8; width * 3];
-                libjpeg_turbo_rs::decode::color::ycbcr_to_bgr_row(
-                    &y,
-                    &cb,
-                    &cr,
-                    &mut scalar_bgr,
-                    width,
-                );
+                crate::decode::color::ycbcr_to_bgr_row(&y, &cb, &cr, &mut scalar_bgr, width);
                 wasm_ycbcr_to_bgr_row(&y, &cb, &cr, &mut simd_bgr, width);
                 assert_eq!(simd_bgr, scalar_bgr, "WASM BGR mismatch w={width} iter={i}");
 
                 let mut scalar_bgra: Vec<u8> = vec![0u8; width * 4];
                 let mut simd_bgra: Vec<u8> = vec![0u8; width * 4];
-                libjpeg_turbo_rs::decode::color::ycbcr_to_bgra_row(
-                    &y,
-                    &cb,
-                    &cr,
-                    &mut scalar_bgra,
-                    width,
-                );
+                crate::decode::color::ycbcr_to_bgra_row(&y, &cb, &cr, &mut scalar_bgra, width);
                 wasm_ycbcr_to_bgra_row(&y, &cb, &cr, &mut simd_bgra, width);
                 assert_eq!(
                     simd_bgra, scalar_bgra,
@@ -480,7 +451,7 @@ fn parity_fancy_upsample_h2v1() {
 
             #[cfg(target_arch = "aarch64")]
             {
-                use libjpeg_turbo_rs::simd::aarch64::upsample::neon_fancy_upsample_h2v1;
+                use crate::simd::aarch64::upsample::neon_fancy_upsample_h2v1;
                 let mut simd_out: Vec<u8> = vec![0u8; in_width * 2];
                 neon_fancy_upsample_h2v1(&input, in_width, &mut simd_out);
                 assert_eq!(
@@ -491,7 +462,7 @@ fn parity_fancy_upsample_h2v1() {
             #[cfg(target_arch = "x86_64")]
             {
                 if is_x86_feature_detected!("avx2") {
-                    use libjpeg_turbo_rs::simd::x86_64::avx2_upsample::avx2_fancy_upsample_h2v1;
+                    use crate::simd::x86_64::avx2_upsample::avx2_fancy_upsample_h2v1;
                     let mut simd_out: Vec<u8> = vec![0u8; in_width * 2];
                     avx2_fancy_upsample_h2v1(&input, in_width, &mut simd_out);
                     assert_eq!(
@@ -500,7 +471,7 @@ fn parity_fancy_upsample_h2v1() {
                     );
                 }
                 if is_x86_feature_detected!("sse2") {
-                    use libjpeg_turbo_rs::simd::x86_64::upsample::sse2_fancy_upsample_h2v1;
+                    use crate::simd::x86_64::upsample::sse2_fancy_upsample_h2v1;
                     let mut simd_out: Vec<u8> = vec![0u8; in_width * 2];
                     sse2_fancy_upsample_h2v1(&input, in_width, &mut simd_out);
                     assert_eq!(
@@ -511,7 +482,7 @@ fn parity_fancy_upsample_h2v1() {
             }
             #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
             {
-                use libjpeg_turbo_rs::simd::wasm32::upsample::wasm_fancy_upsample_h2v1;
+                use crate::simd::wasm32::upsample::wasm_fancy_upsample_h2v1;
                 let mut simd_out: Vec<u8> = vec![0u8; in_width * 2];
                 wasm_fancy_upsample_h2v1(&input, in_width, &mut simd_out);
                 assert_eq!(
@@ -525,7 +496,7 @@ fn parity_fancy_upsample_h2v1() {
 
 #[test]
 fn parity_fancy_upsample_h2v2() {
-    use libjpeg_turbo_rs::decode::upsample::fancy_h2v2;
+    use crate::decode::upsample::fancy_h2v2;
 
     let mut rng: Mulberry32 = Mulberry32::new(0xA5A5_0021);
     // H2V2 needs a 2D plane; use a small set of (w, h) pairs and run
@@ -551,7 +522,7 @@ fn parity_fancy_upsample_h2v2() {
 
             #[cfg(target_arch = "aarch64")]
             {
-                use libjpeg_turbo_rs::simd::aarch64::upsample::neon_fancy_upsample_h2v2;
+                use crate::simd::aarch64::upsample::neon_fancy_upsample_h2v2;
                 let mut simd_out: Vec<u8> = vec![0u8; out_w * out_h];
                 neon_fancy_upsample_h2v2(&input, w, h, &mut simd_out, out_w);
                 assert_eq!(
@@ -562,7 +533,7 @@ fn parity_fancy_upsample_h2v2() {
             #[cfg(target_arch = "x86_64")]
             {
                 if is_x86_feature_detected!("avx2") {
-                    use libjpeg_turbo_rs::simd::x86_64::avx2_upsample::avx2_fancy_upsample_h2v2;
+                    use crate::simd::x86_64::avx2_upsample::avx2_fancy_upsample_h2v2;
                     let mut simd_out: Vec<u8> = vec![0u8; out_w * out_h];
                     avx2_fancy_upsample_h2v2(&input, w, h, &mut simd_out, out_w);
                     assert_eq!(
@@ -571,7 +542,7 @@ fn parity_fancy_upsample_h2v2() {
                     );
                 }
                 if is_x86_feature_detected!("sse2") {
-                    use libjpeg_turbo_rs::simd::x86_64::upsample::sse2_fancy_upsample_h2v2;
+                    use crate::simd::x86_64::upsample::sse2_fancy_upsample_h2v2;
                     let mut simd_out: Vec<u8> = vec![0u8; out_w * out_h];
                     sse2_fancy_upsample_h2v2(&input, w, h, &mut simd_out, out_w);
                     assert_eq!(
@@ -582,7 +553,7 @@ fn parity_fancy_upsample_h2v2() {
             }
             #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
             {
-                use libjpeg_turbo_rs::simd::wasm32::upsample::wasm_fancy_upsample_h2v2;
+                use crate::simd::wasm32::upsample::wasm_fancy_upsample_h2v2;
                 let mut simd_out: Vec<u8> = vec![0u8; out_w * out_h];
                 wasm_fancy_upsample_h2v2(&input, w, h, &mut simd_out, out_w);
                 assert_eq!(
@@ -600,7 +571,7 @@ fn parity_fancy_upsample_h2v2() {
 
 #[test]
 fn parity_merged_upsample_h2v1() {
-    use libjpeg_turbo_rs::decode::merged_upsample::merged_h2v1_ycbcr_to_rgb;
+    use crate::decode::merged_upsample::merged_h2v1_ycbcr_to_rgb;
 
     let mut rng: Mulberry32 = Mulberry32::new(0xA5A5_0030);
     for &luma_w in &[2usize, 4, 6, 8, 16, 18, 32, 62, 64, 128] {
@@ -615,7 +586,7 @@ fn parity_merged_upsample_h2v1() {
 
             #[cfg(target_arch = "aarch64")]
             {
-                use libjpeg_turbo_rs::simd::aarch64::merged::neon_merged_h2v1_ycbcr_to_rgb;
+                use crate::simd::aarch64::merged::neon_merged_h2v1_ycbcr_to_rgb;
                 let mut simd_rgb: Vec<u8> = vec![0u8; luma_w * 3];
                 neon_merged_h2v1_ycbcr_to_rgb(&y, &cb, &cr, &mut simd_rgb, luma_w);
                 assert_eq!(
@@ -626,7 +597,7 @@ fn parity_merged_upsample_h2v1() {
             #[cfg(target_arch = "x86_64")]
             {
                 if is_x86_feature_detected!("avx2") {
-                    use libjpeg_turbo_rs::simd::x86_64::avx2_merged::avx2_merged_h2v1_ycbcr_to_rgb;
+                    use crate::simd::x86_64::avx2_merged::avx2_merged_h2v1_ycbcr_to_rgb;
                     let mut simd_rgb: Vec<u8> = vec![0u8; luma_w * 3];
                     avx2_merged_h2v1_ycbcr_to_rgb(&y, &cb, &cr, &mut simd_rgb, luma_w);
                     assert_eq!(
@@ -637,7 +608,7 @@ fn parity_merged_upsample_h2v1() {
             }
             #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
             {
-                use libjpeg_turbo_rs::simd::wasm32::merged::wasm_merged_h2v1_ycbcr_to_rgb;
+                use crate::simd::wasm32::merged::wasm_merged_h2v1_ycbcr_to_rgb;
                 let mut simd_rgb: Vec<u8> = vec![0u8; luma_w * 3];
                 wasm_merged_h2v1_ycbcr_to_rgb(&y, &cb, &cr, &mut simd_rgb, luma_w);
                 assert_eq!(
@@ -651,7 +622,7 @@ fn parity_merged_upsample_h2v1() {
 
 #[test]
 fn parity_merged_upsample_h2v2() {
-    use libjpeg_turbo_rs::decode::merged_upsample::merged_h2v2_ycbcr_to_rgb;
+    use crate::decode::merged_upsample::merged_h2v2_ycbcr_to_rgb;
 
     let mut rng: Mulberry32 = Mulberry32::new(0xA5A5_0031);
     for &luma_w in &[2usize, 4, 8, 16, 32, 64, 128] {
@@ -676,7 +647,7 @@ fn parity_merged_upsample_h2v2() {
 
             #[cfg(target_arch = "aarch64")]
             {
-                use libjpeg_turbo_rs::simd::aarch64::merged::neon_merged_h2v2_ycbcr_to_rgb;
+                use crate::simd::aarch64::merged::neon_merged_h2v2_ycbcr_to_rgb;
                 let mut simd_rgb0: Vec<u8> = vec![0u8; luma_w * 3];
                 let mut simd_rgb1: Vec<u8> = vec![0u8; luma_w * 3];
                 neon_merged_h2v2_ycbcr_to_rgb(
@@ -700,7 +671,7 @@ fn parity_merged_upsample_h2v2() {
             #[cfg(target_arch = "x86_64")]
             {
                 if is_x86_feature_detected!("avx2") {
-                    use libjpeg_turbo_rs::simd::x86_64::avx2_merged::avx2_merged_h2v2_ycbcr_to_rgb;
+                    use crate::simd::x86_64::avx2_merged::avx2_merged_h2v2_ycbcr_to_rgb;
                     let mut simd_rgb0: Vec<u8> = vec![0u8; luma_w * 3];
                     let mut simd_rgb1: Vec<u8> = vec![0u8; luma_w * 3];
                     avx2_merged_h2v2_ycbcr_to_rgb(
@@ -724,7 +695,7 @@ fn parity_merged_upsample_h2v2() {
             }
             #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
             {
-                use libjpeg_turbo_rs::simd::wasm32::merged::wasm_merged_h2v2_ycbcr_to_rgb;
+                use crate::simd::wasm32::merged::wasm_merged_h2v2_ycbcr_to_rgb;
                 let mut simd_rgb0: Vec<u8> = vec![0u8; luma_w * 3];
                 let mut simd_rgb1: Vec<u8> = vec![0u8; luma_w * 3];
                 wasm_merged_h2v2_ycbcr_to_rgb(
@@ -775,7 +746,7 @@ fn parity_rgb_to_ycbcr_rows() {
 
             #[cfg(target_arch = "aarch64")]
             {
-                use libjpeg_turbo_rs::simd::aarch64::color_encode::{
+                use crate::simd::aarch64::color_encode::{
                     neon_bgr_to_ycbcr_row, neon_bgra_to_ycbcr_row, neon_rgb_to_ycbcr_row,
                     neon_rgba_to_ycbcr_row,
                 };
@@ -795,7 +766,7 @@ fn parity_rgb_to_ycbcr_rows() {
                 let mut sc_y: Vec<u8> = vec![0u8; width];
                 let mut sc_cb: Vec<u8> = vec![0u8; width];
                 let mut sc_cr: Vec<u8> = vec![0u8; width];
-                libjpeg_turbo_rs::encode::color::rgba_to_ycbcr_row(
+                crate::encode::color::rgba_to_ycbcr_row(
                     &rgba, &mut sc_y, &mut sc_cb, &mut sc_cr, width,
                 );
                 let mut sd_y: Vec<u8> = vec![0u8; width];
@@ -810,7 +781,7 @@ fn parity_rgb_to_ycbcr_rows() {
                 let mut sc_y2: Vec<u8> = vec![0u8; width];
                 let mut sc_cb2: Vec<u8> = vec![0u8; width];
                 let mut sc_cr2: Vec<u8> = vec![0u8; width];
-                libjpeg_turbo_rs::encode::color::bgr_to_ycbcr_row_scalar(
+                crate::encode::color::bgr_to_ycbcr_row_scalar(
                     bgr,
                     &mut sc_y2,
                     &mut sc_cb2,
@@ -829,7 +800,7 @@ fn parity_rgb_to_ycbcr_rows() {
                 let mut sc_y3: Vec<u8> = vec![0u8; width];
                 let mut sc_cb3: Vec<u8> = vec![0u8; width];
                 let mut sc_cr3: Vec<u8> = vec![0u8; width];
-                libjpeg_turbo_rs::encode::color::bgra_to_ycbcr_row_scalar(
+                crate::encode::color::bgra_to_ycbcr_row_scalar(
                     bgra,
                     &mut sc_y3,
                     &mut sc_cb3,
@@ -847,7 +818,7 @@ fn parity_rgb_to_ycbcr_rows() {
             #[cfg(target_arch = "x86_64")]
             {
                 if is_x86_feature_detected!("avx2") {
-                    use libjpeg_turbo_rs::simd::x86_64::avx2_color_encode::{
+                    use crate::simd::x86_64::avx2_color_encode::{
                         avx2_bgr_to_ycbcr_row, avx2_bgra_to_ycbcr_row, avx2_rgb_to_ycbcr_row,
                         avx2_rgba_to_ycbcr_row,
                     };
@@ -864,7 +835,7 @@ fn parity_rgb_to_ycbcr_rows() {
                     let mut sc_y: Vec<u8> = vec![0u8; width];
                     let mut sc_cb: Vec<u8> = vec![0u8; width];
                     let mut sc_cr: Vec<u8> = vec![0u8; width];
-                    libjpeg_turbo_rs::encode::color::rgba_to_ycbcr_row(
+                    crate::encode::color::rgba_to_ycbcr_row(
                         &rgba, &mut sc_y, &mut sc_cb, &mut sc_cr, width,
                     );
                     let mut sd_y: Vec<u8> = vec![0u8; width];
@@ -879,7 +850,7 @@ fn parity_rgb_to_ycbcr_rows() {
                     let mut sc_y2: Vec<u8> = vec![0u8; width];
                     let mut sc_cb2: Vec<u8> = vec![0u8; width];
                     let mut sc_cr2: Vec<u8> = vec![0u8; width];
-                    libjpeg_turbo_rs::encode::color::bgr_to_ycbcr_row_scalar(
+                    crate::encode::color::bgr_to_ycbcr_row_scalar(
                         bgr,
                         &mut sc_y2,
                         &mut sc_cb2,
@@ -898,7 +869,7 @@ fn parity_rgb_to_ycbcr_rows() {
                     let mut sc_y3: Vec<u8> = vec![0u8; width];
                     let mut sc_cb3: Vec<u8> = vec![0u8; width];
                     let mut sc_cr3: Vec<u8> = vec![0u8; width];
-                    libjpeg_turbo_rs::encode::color::bgra_to_ycbcr_row_scalar(
+                    crate::encode::color::bgra_to_ycbcr_row_scalar(
                         bgra,
                         &mut sc_y3,
                         &mut sc_cb3,
@@ -916,7 +887,7 @@ fn parity_rgb_to_ycbcr_rows() {
             }
             #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
             {
-                use libjpeg_turbo_rs::simd::wasm32::color_encode::{
+                use crate::simd::wasm32::color_encode::{
                     wasm_bgr_to_ycbcr_row, wasm_bgra_to_ycbcr_row, wasm_rgb_to_ycbcr_row,
                     wasm_rgba_to_ycbcr_row,
                 };
@@ -931,7 +902,7 @@ fn parity_rgb_to_ycbcr_rows() {
                 let mut sc_y: Vec<u8> = vec![0u8; width];
                 let mut sc_cb: Vec<u8> = vec![0u8; width];
                 let mut sc_cr: Vec<u8> = vec![0u8; width];
-                libjpeg_turbo_rs::encode::color::rgba_to_ycbcr_row(
+                crate::encode::color::rgba_to_ycbcr_row(
                     &rgba, &mut sc_y, &mut sc_cb, &mut sc_cr, width,
                 );
                 let mut sd_y: Vec<u8> = vec![0u8; width];
@@ -946,7 +917,7 @@ fn parity_rgb_to_ycbcr_rows() {
                 let mut sc_y2: Vec<u8> = vec![0u8; width];
                 let mut sc_cb2: Vec<u8> = vec![0u8; width];
                 let mut sc_cr2: Vec<u8> = vec![0u8; width];
-                libjpeg_turbo_rs::encode::color::bgr_to_ycbcr_row_scalar(
+                crate::encode::color::bgr_to_ycbcr_row_scalar(
                     bgr,
                     &mut sc_y2,
                     &mut sc_cb2,
@@ -965,7 +936,7 @@ fn parity_rgb_to_ycbcr_rows() {
                 let mut sc_y3: Vec<u8> = vec![0u8; width];
                 let mut sc_cb3: Vec<u8> = vec![0u8; width];
                 let mut sc_cr3: Vec<u8> = vec![0u8; width];
-                libjpeg_turbo_rs::encode::color::bgra_to_ycbcr_row_scalar(
+                crate::encode::color::bgra_to_ycbcr_row_scalar(
                     bgra,
                     &mut sc_y3,
                     &mut sc_cb3,
@@ -1014,7 +985,7 @@ fn parity_fdct_quantize_islow() {
             // There is no pub `neon_fdct_quantize`; the dispatcher picks
             // it via EncoderSimdRoutines. Use the public encoder detector
             // and invoke through the function pointer.
-            let routines = libjpeg_turbo_rs::simd::detect_encoder();
+            let routines = crate::simd::detect_encoder();
             let mut simd_in: [i16; 64] = scalar_input;
             let mut simd_out: [i16; 64] = [0i16; 64];
             (routines.fdct_quantize)(&mut simd_in, &quant_divisors, &mut simd_out);
@@ -1023,7 +994,7 @@ fn parity_fdct_quantize_islow() {
         #[cfg(target_arch = "x86_64")]
         {
             if is_x86_feature_detected!("avx2") {
-                let routines = libjpeg_turbo_rs::simd::detect_encoder();
+                let routines = crate::simd::detect_encoder();
                 let mut simd_in: [i16; 64] = scalar_input;
                 let mut simd_out: [i16; 64] = [0i16; 64];
                 (routines.fdct_quantize)(&mut simd_in, &quant_divisors, &mut simd_out);
@@ -1032,7 +1003,7 @@ fn parity_fdct_quantize_islow() {
         }
         #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
         {
-            let routines = libjpeg_turbo_rs::simd::detect_encoder();
+            let routines = crate::simd::detect_encoder();
             let mut simd_in: [i16; 64] = scalar_input;
             let mut simd_out: [i16; 64] = [0i16; 64];
             (routines.fdct_quantize)(&mut simd_in, &quant_divisors, &mut simd_out);

--- a/src/simd/simd_x86_tests.rs
+++ b/src/simd/simd_x86_tests.rs
@@ -1,7 +1,14 @@
+//! Relocated from `tests/simd_x86.rs` for P4-135 criterion 2 (#474).
+//!
+//! This suite reaches SIMD kernels directly, which is why the arch
+//! modules had to stay `pub` and were therefore callable from any
+//! downstream crate. As an in-crate test it uses `crate::`, so they
+//! can be private. Moved verbatim apart from the path rewrite.
+
 //! x86_64 SSE2 SIMD tests -- verify byte-exact match with scalar implementation.
 #![cfg(target_arch = "x86_64")]
 
-use libjpeg_turbo_rs::simd;
+use crate::simd;
 
 fn scalar_routines() -> simd::SimdRoutines {
     std::env::set_var("JSIMD_FORCENONE", "1");


### PR DESCRIPTION
## What

Closes the **reachability half of #474**. The proof-of-concept this issue opens with no longer compiles against the library from a downstream crate:

```
error[E0603]: module `x86_64` is private
```

Verified by building an actual external crate against this one, not by inspection.

## How

The ten SIMD suites that forced `pub mod simd` — `simd_parity`, `simd_avx2`, `simd_avx2_encode`, `simd_neon_encode`, `simd_neon_scaled`, `neon_upsample`, `neon_color`, `neon_idct`, `simd_dispatch`, `simd_x86` — move from `tests/` into `src/simd/` as `cfg(test)` modules, rewritten only for `libjpeg_turbo_rs::` → `crate::`.

**Counts checked per target before and after**, because silent test loss is the failure mode here:

| | before | after |
|---|---|---|
| host (aarch64) | 85 | 85 |
| x86_64 | 57 | 57 |
| x86_64 `--lib` total | 201 | **258** (= 201 + 57) |

## I was wrong about the blocker

I recorded this on #481 and again on #474 as blocked on a design decision — benchmark coverage versus reachability. **There is no trade-off.**

`benches/decode.rs` and `benches/encode.rs` use only `detect()`, `detect_encoder()` and `QuantDivisors`: they select a routine set and go through the dispatch table, and never name a kernel. Those stay public, the arch modules don't, and `cargo build --benches` is unaffected. I should have checked what the benches actually called before characterising it as a decision for someone else.

## A finding this surfaced

Making the modules private turned `dead_code` into a real signal: **33 NEON items** in `aarch64/{downsample,idct_scaled,quantize}` are called by neither the library nor any test.

**26 are in `idct_scaled`** — independent confirmation of **P4-71**: scaled decode never dispatches to the SIMD reduced-size IDCT, so those kernels have never had a caller.

Allowed rather than deleted (removing them would discard working kernels P4-71 exists to start using), scoped to those three modules so genuine dead code elsewhere still fails the build, with the finding recorded at the declaration.

## Not claimed

The `trybuild` compile-fail regression criterion 2 also asks for. The property is demonstrated here against a real external crate but is **not yet asserted in CI**. Criteria 1, 4–7 unchanged.

`cargo test --workspace`: **2493 passed, 0 failed**. x86_64 `--lib`: **258 passed**. `clippy --workspace --all-targets -D warnings`: clean.

Refs #474, #481, #71