### PR TITLE
fix(simd): validate the nine SIMD wrappers the first sweep missed

### DIFF
--- a/src/simd/wasm32/upsample.rs
+++ b/src/simd/wasm32/upsample.rs
@@ -156,8 +156,24 @@ pub fn wasm_fancy_h2v2_row(cur: &[u8], neighbor: &[u8], output: &mut [u8], in_wi
     }
 
     // SAFETY: wasm simd128 is enabled by target_feature. We verified in_width >= 3.
-    unsafe {
-        wasm_fancy_h2v2_row_inner(cur, neighbor, output, in_width);
+    // P4-135: 2:1 horizontal upsample against a neighbouring row -- `cur` and
+    // `neighbor` each hold `in_width`, `output` holds `in_width * 2`. The row
+    // arguments are not interchangeable (near vs far weighting), so this checks
+    // lengths only; ordering stays the caller's contract. No runtime probe:
+    // simd128 is a compile-time target feature on wasm32.
+    let out_needed: Option<usize> = in_width.checked_mul(2);
+    let fits: bool = cur.len() >= in_width
+        && neighbor.len() >= in_width
+        && out_needed.is_some_and(|n| output.len() >= n);
+
+    if fits {
+        // SAFETY: both inputs hold `in_width` samples and `output` holds the
+        // `in_width * 2` this kernel writes.
+        unsafe {
+            wasm_fancy_h2v2_row_inner(cur, neighbor, output, in_width);
+        }
+    } else {
+        crate::decode::upsample::fancy_h2v2_row(cur, neighbor, output, in_width);
     }
 
     // Last pixel (scalar edge): odd position

--- a/src/simd/x86_64/avx2_color_encode.rs
+++ b/src/simd/x86_64/avx2_color_encode.rs
@@ -48,8 +48,23 @@ pub fn avx2_rgb_to_ycbcr_row(rgb: &[u8], y: &mut [u8], cb: &mut [u8], cr: &mut [
     if width == 0 {
         return;
     }
-    unsafe {
-        avx2_rgb_to_ycbcr_row_inner(rgb, y, cb, cr, width);
+    // P4-135: `width` is independent of the slice lengths, and the SIMD
+    // loop loads/stores by raw pointer without consulting them. The input
+    // holds `width * 3` bytes; each output plane holds `width`.
+    let src_needed: Option<usize> = width.checked_mul(3);
+    let fits: bool = src_needed.is_some_and(|n| rgb.len() >= n)
+        && y.len() >= width
+        && cb.len() >= width
+        && cr.len() >= width;
+
+    if fits && crate::cpu_has!("avx2") {
+        // SAFETY: AVX2 confirmed immediately above, and every slice holds
+        // the samples this kernel reads and writes.
+        unsafe {
+            avx2_rgb_to_ycbcr_row_inner(rgb, y, cb, cr, width);
+        }
+    } else {
+        crate::encode::color::rgb_to_ycbcr_row(rgb, y, cb, cr, width);
     }
 }
 
@@ -64,8 +79,23 @@ pub fn avx2_rgba_to_ycbcr_row(
     if width == 0 {
         return;
     }
-    unsafe {
-        avx2_rgba_to_ycbcr_row_inner(rgba, y, cb, cr, width);
+    // P4-135: `width` is independent of the slice lengths, and the SIMD
+    // loop loads/stores by raw pointer without consulting them. The input
+    // holds `width * 4` bytes; each output plane holds `width`.
+    let src_needed: Option<usize> = width.checked_mul(4);
+    let fits: bool = src_needed.is_some_and(|n| rgba.len() >= n)
+        && y.len() >= width
+        && cb.len() >= width
+        && cr.len() >= width;
+
+    if fits && crate::cpu_has!("avx2") {
+        // SAFETY: AVX2 confirmed immediately above, and every slice holds
+        // the samples this kernel reads and writes.
+        unsafe {
+            avx2_rgba_to_ycbcr_row_inner(rgba, y, cb, cr, width);
+        }
+    } else {
+        crate::encode::color::rgba_to_ycbcr_row(rgba, y, cb, cr, width);
     }
 }
 
@@ -74,8 +104,23 @@ pub fn avx2_bgr_to_ycbcr_row(bgr: &[u8], y: &mut [u8], cb: &mut [u8], cr: &mut [
     if width == 0 {
         return;
     }
-    unsafe {
-        avx2_bgr_to_ycbcr_row_inner(bgr, y, cb, cr, width);
+    // P4-135: `width` is independent of the slice lengths, and the SIMD
+    // loop loads/stores by raw pointer without consulting them. The input
+    // holds `width * 3` bytes; each output plane holds `width`.
+    let src_needed: Option<usize> = width.checked_mul(3);
+    let fits: bool = src_needed.is_some_and(|n| bgr.len() >= n)
+        && y.len() >= width
+        && cb.len() >= width
+        && cr.len() >= width;
+
+    if fits && crate::cpu_has!("avx2") {
+        // SAFETY: AVX2 confirmed immediately above, and every slice holds
+        // the samples this kernel reads and writes.
+        unsafe {
+            avx2_bgr_to_ycbcr_row_inner(bgr, y, cb, cr, width);
+        }
+    } else {
+        crate::encode::color::bgr_to_ycbcr_row_scalar(bgr, y, cb, cr, width);
     }
 }
 
@@ -90,8 +135,23 @@ pub fn avx2_bgra_to_ycbcr_row(
     if width == 0 {
         return;
     }
-    unsafe {
-        avx2_bgra_to_ycbcr_row_inner(bgra, y, cb, cr, width);
+    // P4-135: `width` is independent of the slice lengths, and the SIMD
+    // loop loads/stores by raw pointer without consulting them. The input
+    // holds `width * 4` bytes; each output plane holds `width`.
+    let src_needed: Option<usize> = width.checked_mul(4);
+    let fits: bool = src_needed.is_some_and(|n| bgra.len() >= n)
+        && y.len() >= width
+        && cb.len() >= width
+        && cr.len() >= width;
+
+    if fits && crate::cpu_has!("avx2") {
+        // SAFETY: AVX2 confirmed immediately above, and every slice holds
+        // the samples this kernel reads and writes.
+        unsafe {
+            avx2_bgra_to_ycbcr_row_inner(bgra, y, cb, cr, width);
+        }
+    } else {
+        crate::encode::color::bgra_to_ycbcr_row_scalar(bgra, y, cb, cr, width);
     }
 }
 

--- a/src/simd/x86_64/avx2_upsample.rs
+++ b/src/simd/x86_64/avx2_upsample.rs
@@ -39,9 +39,20 @@ pub fn avx2_fancy_upsample_h2v1(input: &[u8], in_width: usize, output: &mut [u8]
     output[last * 2] = ((3 * input[last] as u16 + input[last - 1] as u16 + 1) >> 2) as u8;
     output[last * 2 + 1] = input[last];
 
-    // SAFETY: AVX2 availability guaranteed by dispatch in x86_64::routines().
-    unsafe {
-        avx2_fancy_h2v1_inner(input, in_width, output);
+    // P4-135: 2:1 horizontal upsample -- reads `in_width`, writes
+    // `in_width * 2`. `in_width` is a parameter independent of both
+    // slices, and the SIMD block below indexes by raw pointer.
+    let out_needed: Option<usize> = in_width.checked_mul(2);
+    let fits: bool = input.len() >= in_width && out_needed.is_some_and(|n| output.len() >= n);
+
+    if fits && crate::cpu_has!("avx2") {
+        // SAFETY: AVX2 confirmed above; both inputs hold `in_width`
+        // samples and `output` holds the `in_width * 2` it writes.
+        unsafe {
+            avx2_fancy_h2v1_inner(input, in_width, output);
+        }
+    } else {
+        crate::decode::upsample::fancy_h2v1(input, in_width, output, in_width * 2);
     }
 }
 
@@ -194,9 +205,24 @@ pub fn avx2_fancy_h2v2_row(cur: &[u8], neighbor: &[u8], output: &mut [u8], in_wi
     let cs1: i32 = cur[1] as i32 * 3 + neighbor[1] as i32;
     output[1] = ((cs0 * 3 + cs1 + 7) >> 4) as u8;
 
-    // SAFETY: AVX2 availability guaranteed by dispatch in x86_64::routines().
-    unsafe {
-        avx2_fancy_h2v2_row_inner(cur, neighbor, output, in_width);
+    // P4-135: 2:1 horizontal upsample against a neighbouring row --
+    // `cur` and `neighbor` each hold `in_width`, `output` holds
+    // `in_width * 2`. The row arguments are not interchangeable (near
+    // vs far weighting), so this only checks lengths; ordering stays
+    // the caller's contract.
+    let out_needed: Option<usize> = in_width.checked_mul(2);
+    let fits: bool = cur.len() >= in_width
+        && neighbor.len() >= in_width
+        && out_needed.is_some_and(|n| output.len() >= n);
+
+    if fits && crate::cpu_has!("avx2") {
+        // SAFETY: AVX2 confirmed above; both inputs hold `in_width`
+        // samples and `output` holds the `in_width * 2` it writes.
+        unsafe {
+            avx2_fancy_h2v2_row_inner(cur, neighbor, output, in_width);
+        }
+    } else {
+        crate::decode::upsample::fancy_h2v2_row(cur, neighbor, output, in_width);
     }
 
     // Last pixel (scalar edge): odd position

--- a/src/simd/x86_64/upsample.rs
+++ b/src/simd/x86_64/upsample.rs
@@ -41,8 +41,20 @@ pub fn sse2_fancy_upsample_h2v1(input: &[u8], in_width: usize, output: &mut [u8]
     // in_width >= 3 is guaranteed by the early returns above.
     // Loop condition `i + 8 <= in_width - 1` ensures input has >=9 readable bytes
     // and output has >=16 writable bytes at each iteration.
-    unsafe {
-        sse2_fancy_h2v1_inner(input, in_width, output);
+    // P4-135: 2:1 horizontal upsample -- reads `in_width`, writes
+    // `in_width * 2`. `in_width` is a parameter independent of both
+    // slices, and the SIMD block below indexes by raw pointer.
+    let out_needed: Option<usize> = in_width.checked_mul(2);
+    let fits: bool = input.len() >= in_width && out_needed.is_some_and(|n| output.len() >= n);
+
+    if fits && crate::cpu_has!("sse2") {
+        // SAFETY: SSE2 confirmed above; both inputs hold `in_width`
+        // samples and `output` holds the `in_width * 2` it writes.
+        unsafe {
+            sse2_fancy_h2v1_inner(input, in_width, output);
+        }
+    } else {
+        crate::decode::upsample::fancy_h2v1(input, in_width, output, in_width * 2);
     }
 }
 
@@ -146,9 +158,24 @@ pub fn sse2_fancy_h2v2_row(cur: &[u8], neighbor: &[u8], output: &mut [u8], in_wi
     let cs1: i32 = cur[1] as i32 * 3 + neighbor[1] as i32;
     output[1] = ((cs0 * 3 + cs1 + 7) >> 4) as u8;
 
-    // SAFETY: SSE2 availability guaranteed by dispatch in x86_64::routines().
-    unsafe {
-        sse2_fancy_h2v2_row_inner(cur, neighbor, output, in_width);
+    // P4-135: 2:1 horizontal upsample against a neighbouring row --
+    // `cur` and `neighbor` each hold `in_width`, `output` holds
+    // `in_width * 2`. The row arguments are not interchangeable (near
+    // vs far weighting), so this only checks lengths; ordering stays
+    // the caller's contract.
+    let out_needed: Option<usize> = in_width.checked_mul(2);
+    let fits: bool = cur.len() >= in_width
+        && neighbor.len() >= in_width
+        && out_needed.is_some_and(|n| output.len() >= n);
+
+    if fits && crate::cpu_has!("sse2") {
+        // SAFETY: SSE2 confirmed above; both inputs hold `in_width`
+        // samples and `output` holds the `in_width * 2` it writes.
+        unsafe {
+            sse2_fancy_h2v2_row_inner(cur, neighbor, output, in_width);
+        }
+    } else {
+        crate::decode::upsample::fancy_h2v2_row(cur, neighbor, output, in_width);
     }
 
     // Last pixel (scalar edge): odd position


### PR DESCRIPTION
## My earlier sweep was incomplete

#493/#495/#496/#497 reported **9** unsound wrappers and fixed all 9. **That count was wrong.**

The scan matched only wrappers whose body *begins* with `unsafe`. Any wrapper doing scalar work first — an edge pixel, a first or last row — was invisible to it. That shape is normal in the upsample and encode-colour kernels, so the miss was **systematic, not incidental**. The real total was 18.

## Rescanned, then checked the rescan

New criterion: any safe `pub fn` taking a slice **plus a separate length** whose body contains `unsafe` *anywhere*, split by whether it already carries a `.len() >=` check. That surfaced 10.

One is a **false positive**: `neon_fancy_upsample_h2v2` slices with bounds-checked indexing and calls a *safe* row function — it contains no `unsafe` of its own, and my body-extent heuristic had over-matched into the next item. Verified per function rather than trusting the second scan either.

**Nine real:**

| File | Functions |
| --- | --- |
| `x86_64/avx2_color_encode.rs` | `rgb`/`rgba`/`bgr`/`bgra_to_ycbcr_row` |
| `x86_64/upsample.rs` | `sse2_fancy_upsample_h2v1`, `sse2_fancy_h2v2_row` |
| `x86_64/avx2_upsample.rs` | `avx2_fancy_upsample_h2v1`, `avx2_fancy_h2v2_row` |
| `wasm32/upsample.rs` | `wasm_fancy_h2v2_row` |

## Bounds read per kernel, not assumed

- **encode colour** — `width * bpp` in, three `width` planes out
- **h2v1** — reads `in_width`, writes `in_width * 2`
- **h2v2** — additionally takes a neighbouring row of `in_width`

All products go through `checked_mul`. x86_64 confirms its feature with `cpu_has!` in the same function performing the `unsafe` call; wasm32 doesn't, because `simd128` is a compile-time target feature there.

## Also closes criterion 7 for these

Retires eight SAFETY comments claiming availability is *"verified at dispatch time"* / *"guaranteed by dispatch"* — the same claim criterion 3 rejected: true of our call sites, not of the functions' contracts.

## Verified per target

`clippy -D warnings` clean on **x86_64-apple-darwin**, **wasm32-unknown-unknown**, **wasm32-wasip1**; `no_std` check clean; `cargo test --workspace` **2493 passed / 0 failed**; x86_64 `--lib` **258 passed**.

Refs #474, #481