### PR TITLE
docs(simd): replace the unsafe-op estimate with measured per-target counts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,11 +119,17 @@ pub mod api;
 pub mod common;
 pub mod decode;
 pub mod encode;
-// The SIMD backends predate the crate-level lint and carry ~780 bare
-// unsafe operations inside their unsafe fns; wrapping each with its own
-// block + SAFETY note is a mechanical-but-careful sweep tracked in
-// LAST_MILE (filed with issue #389). Non-SIMD code gets the full deny
-// immediately.
+// The SIMD backends predate the crate-level lint. Wrapping each bare
+// operation with its own block + SAFETY note is a mechanical-but-careful
+// sweep tracked in LAST_MILE (filed with issue #389, sized by #474
+// criterion 6). Non-SIMD code gets the full deny immediately.
+//
+// Scope, measured 2026-08-10 by deleting the `allow` below and counting
+// `cargo check --lib [--target T] 2>&1 | grep -c '^error\[E0133\]'`:
+// aarch64-apple-darwin 679, x86_64-apple-darwin 630,
+// wasm32-unknown-unknown 229. These overlap — each build sees its own
+// backend plus the shared scalar code — so they are not additive, and no
+// single target reproduces the "~780" this comment used to claim.
 #[allow(unsafe_op_in_unsafe_fn)]
 pub mod simd;
 pub mod transform;


### PR DESCRIPTION
## The number was not reproducible

The comment on `pub mod simd` said the backends carry **~780** bare unsafe operations inside `unsafe fn`s. Deleting the `allow` and counting `error[E0133]`:

| Target | Count |
| --- | --- |
| `aarch64-apple-darwin` | 679 |
| `x86_64-apple-darwin` | 630 |
| `wasm32-unknown-unknown` | 229 |

No target yields 780.

## Why three numbers instead of one

They **overlap rather than sum** — each build sees its own backend plus the shared scalar code — so no single figure can describe the sweep. Recording one number was the original mistake, not just recording a wrong one.

The comment now carries all three, the command that regenerates them, and the measurement date, so the next session can distinguish drift from a legitimate per-target difference.

## Scope

This **sizes** #474 criterion 6 (removing the `allow`). It does not perform the sweep — that stays open. Comment-only, no runtime impact.

Refs #474, #389