### PR TITLE
docs: correct P4-14's error contract before it is implemented (#467)

### DIFF
--- a/docs/last_mile/phase4.md
+++ b/docs/last_mile/phase4.md
@@ -307,6 +307,31 @@ Verified with `cargo test --release --test hard_case_x_byte_and_restart` → 6 p
 
 ## P4-14. `max_memory_to_use` Is ABI-Mirrored But Not Enforced in the C-Side Allocation Path — **OPEN**
 
+**Correction (2026-08-11): the error contract this item and [#467](https://github.com/developer0hye/libjpeg-turbo-rs/issues/467)
+specify is wrong, and the "no spill path" constraint dissolves.** Recorded
+before implementation so the work is not done twice.
+
+Upstream does **not** raise `JERR_OUT_OF_MEMORY` when `max_memory_to_use` is
+exceeded. The budget is consulted by `jpeg_mem_available`
+(`jmemnobs.c:66-78`), which returns the remaining allowance;
+`realize_virt_arrays` parcels the shortfall into strips
+(`jmemmgr.c:745-760`) and only fails when it must spill — at which point
+`jmemnobs.c:87-92` raises **`JERR_NO_BACKING_STORE` (51)**.
+
+And the constraint this item records — that we have no backing store, so true
+enforcement means reimplementing the spill path — **does not apply**:
+`references/libjpeg-turbo/CMakeLists.txt:678` compiles `src/jmemnobs.c`
+unconditionally. The library we are replacing has no backing store either. Our
+"all data in RAM, never spills" is not a divergence; it is the same design, and
+matching upstream is a ~60-line change in `realize_virt_arrays_impl` rather than
+a new subsystem.
+
+Gaps the implementation will need: `memmgr.rs` has no error plumbing (`:732`
+records "we lack the error-mgr handle"), but `realize_virt_arrays_impl` takes
+`cinfo` and `jpeglib.rs`'s `invoke_error_exit` derives `err` from it — making
+that helper `pub(crate)` is the whole gap. `total_space_allocated`, upstream's
+third argument to the budget check, does not exist on our side yet.
+
 **Motivation.** Cold inspection of `crates/libjpeg-turbo-rs-capi/src/memmgr.rs` shows:
 
 - `JpegMemoryMgr::max_memory_to_use: c_long` is at the correct upstream offset (compile-time `offset_of!` assertion at `:181`), defaulted to `~1GB` at `:817` — ABI fidelity is intact.


### PR DESCRIPTION
Docs only, no runtime change. Recorded before implementation so the work is not done twice against the wrong spec.

## What #467 asks for, and why it is wrong

> asserts upstream's exit path — `error_exit(JERR_OUT_OF_MEMORY)`, msg_code 16 — on a budget-exceed virtual-array allocation

**Upstream does not raise `JERR_OUT_OF_MEMORY` when `max_memory_to_use` is exceeded.** The budget is consulted by `jpeg_mem_available`, not by the allocator:

```c
/* jmemnobs.c:66-78 */
if (cinfo->mem->max_memory_to_use) {
  if ((size_t)cinfo->mem->max_memory_to_use > already_allocated)
    return cinfo->mem->max_memory_to_use - already_allocated;
  else
    return 0;
} else {
  return max_bytes_needed;   /* "we got all you want bud!" */
}
```

`realize_virt_arrays` then parcels the shortfall into strips (`jmemmgr.c:745-760`) and only fails when it must spill — where `jmemnobs.c:87-92` raises **`JERR_NO_BACKING_STORE`**.

The number is wrong twice over: `JERR_OUT_OF_MEMORY` is **56**, not 16, and the code actually raised here is `JERR_NO_BACKING_STORE` = **51**.

## The "Known constraint" dissolves

P4-14 records that we have no backing store, so true enforcement "either reimplements the spill path or changes the failure semantics", and asks for that choice to be recorded.

There is no choice to make. `references/libjpeg-turbo/CMakeLists.txt:678` compiles `src/jmemnobs.c` **unconditionally** — the no-backing-store variant. The library we are replacing has no backing store either.

So our `memmgr.rs:20-28` comment ("keeps all of the data in RAM and never spills to disk") is not describing a divergence. It is describing the same design upstream ships. Matching upstream is a ~60-line change in `realize_virt_arrays_impl`, not a new subsystem — which moves this item from "needs a design decision" to "needs an afternoon".

## Implementation notes left for whoever picks it up

- `memmgr.rs` has no error plumbing (`:732` — "we lack the error-mgr handle"), but `realize_virt_arrays_impl` receives `cinfo` and `jpeglib.rs`'s `invoke_error_exit` derives `err` from it. Making that helper `pub(crate)` is the whole gap.
- `total_space_allocated` — upstream's third argument to the budget check — does not exist on our side yet.
- The P4-120 half (allocator failure injection, `msg_parm` payload proof) is independent of this correction and stands as written.

## Why a PR rather than just an issue comment

`LAST_MILE.md` and the phase files are the tracker the next session reads, and `CLAUDE.md` treats stale prose there as a defect. An issue comment alone would leave `phase4.md` still specifying the wrong contract.

Related: #467, #481.