### PR TITLE
ci: run the C-ABI crate's unit tests on the stable toolchain (P4-104, #468)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,21 @@ jobs:
           --test capi_classic_error_codes
           --test capi_error_message_rendering
           --test capi_max_memory_budget -- --nocapture
+      # The C-ABI crate's OWN unit tests, on the stable toolchain.
+      #
+      # `cargo test --lib` in the Unit Tests job selects the default workspace
+      # member only — the root crate — so these 24 tests do not run there.
+      # They are not uncovered: `sanitizers.yml` runs `cargo test --workspace
+      # --lib` under ASan and UBSan on every PR. What this adds is a stable,
+      # *uninstrumented* run, so a failure here is not confounded with
+      # sanitizer instrumentation and does not depend on that workflow.
+      #
+      # Includes P4-104's `every_state_constant_matches_upstream_jpegint_h`,
+      # which cross-checks all 15 `global_state` values against the pinned
+      # `jpegint.h` with exact accounting, so a 16th upstream state fails
+      # rather than passing unnoticed.
+      - name: C-ABI crate unit tests (stable, uninstrumented)
+        run: cargo test -p libjpeg-turbo-rs-capi --lib
       # P4-13/P4-17's documented suspension proof is also in the C-ABI
       # workspace member. Its helper requires cjpeg/djpeg in CI and compilation
       # or oracle failures are fatal, so this cannot report green after a skip.

--- a/docs/last_mile/phase4.md
+++ b/docs/last_mile/phase4.md
@@ -2338,13 +2338,41 @@ The 12-bit initialization/order portion remains in P4-98.
 shim's `DSTATE_STOPPING`, the opposite of upstream's abort-reset completion.
 That false oracle was removed in the filing PR.
 
-**Root cause.** The shim defines `DSTATE_STOPPING = 206`, but upstream assigns
-206 to `DSTATE_RAW_OK` and STOPPING is 210; several intermediate states are
-missing. Successful header parse remains `DSTATE_INHEADER` instead of READY and
-has no repeated-call guard. Finish unconditionally sets its misnumbered
-STOPPING, clears caches/source, and returns TRUE rather than rejecting unread
-rows/bad state, draining EOI with suspension, calling `term_source`, and
-abort-resetting for reuse.
+**Root cause (numbering half corrected 2026-08-11; see below).** Successful
+header parse remains `DSTATE_INHEADER` instead of READY and has no
+repeated-call guard. Finish unconditionally sets STOPPING, clears
+caches/source, and returns TRUE rather than rejecting unread rows/bad state,
+draining EOI with suspension, calling `term_source`, and abort-resetting for
+reuse.
+
+> **The state *numbering* is correct, and the paragraph above used to say
+> otherwise.** It opened by claiming the shim defines `DSTATE_STOPPING = 206`
+> against upstream's 210 with intermediate states missing. That was fixed —
+> the Status section below documents it, including the red-test proof — but
+> this paragraph was never updated, so the item's own root cause contradicted
+> its own status.
+>
+> **A smaller finding about where that guard runs.** It is a `--lib` unit test
+> in the C-ABI crate, and CI's `Unit Tests` job runs `cargo test --lib`, which
+> selects the default workspace member — the root crate — only. So it does not
+> run *there*. It does run on every PR, under `sanitizers.yml`, whose ASan and
+> UBSan jobs both invoke `cargo test --workspace --lib`.
+>
+> An earlier draft of this note claimed the C-ABI crate's 24 unit tests "never
+> executed in CI". **That was wrong**, and is corrected here rather than
+> quietly dropped — the sanitizer jobs had them covered. What the new
+> `cargo test -p libjpeg-turbo-rs-capi --lib` step adds is coverage on the
+> *stable, uninstrumented* toolchain, so a failure in these tests is not
+> confounded with sanitizer instrumentation and does not depend on the
+> sanitizer workflow being reached.
+>
+> Found by writing a *new* integration test for this criterion, which turned
+> out to be a weaker duplicate of the existing one — it enumerated a hardcoded
+> list, so a sixteenth upstream state would not have failed it — and was
+> deleted rather than merged.
+>
+> **What remains under P4-104 is the transitions**, which the paragraph above
+> now describes on its own.
 
 **Acceptance criteria.** Match every upstream state constant and transition
 after create/header/start, buffered/raw/coefficient operation, finish, and


### PR DESCRIPTION
A small change with an unusual history — most of what I did for this ended up deleted, and the write-up is the point.

## What landed

`cargo test --lib` in the `Unit Tests` job selects the default workspace member — the root crate — so the C-ABI crate's **24 unit tests** don't run there. This adds `cargo test -p libjpeg-turbo-rs-capi --lib`.

Among them is P4-104's own guard, `every_state_constant_matches_upstream_jpegint_h`: it parses the pinned `jpegint.h` and compares all 15 `global_state` values with **exact accounting**, so a sixteenth upstream state fails rather than passing unnoticed. `cinfo->global_state` is a public field — `jpeg_abort` switches on the 100/200 range and consumers inspect it to know the stage — so that guard is load-bearing.

## Two corrections to my own work

Both came out of review, and both are worth stating plainly:

**1. I wrote 277 lines of test that already existed, worse.** Setting out to satisfy P4-104's "state constants match upstream's numbering, asserted against `jpeglib.h`" criterion, I built a new integration test with a C probe. Then found the criterion already satisfied — and the existing test is better than mine on both axes: it needs no C compiler (plain `#define` parsing), and it has exact accounting where mine enumerated a hardcoded list, so a *new* upstream constant would not have failed it. Deleted rather than merged.

**2. My first version of this commit claimed those 24 tests "executed on none" of CI. That was false.** `sanitizers.yml` runs `cargo test --workspace --lib` under ASan and UBSan on every PR, which covers them. What this step actually adds is a **stable, uninstrumented** run — so a failure isn't confounded with sanitizer instrumentation and doesn't depend on that workflow being reached. Corrected in the phase record and the workflow comment rather than quietly dropped.

That second one is the same overclaim I've been finding in other people's docs all session, in mine.

## P4-104's root cause was contradicting its own status

The item's opening paragraph still said the shim defines `DSTATE_STOPPING = 206` against upstream's 210, with intermediate states missing. Neither is true — it was fixed some time ago, and the **red-test proof is sitting in the same item's Status section**. The root cause was simply never updated.

Rewritten rather than annotated, so it now describes what actually remains: header parse landing on `INHEADER` instead of `READY`, the missing repeated-call guard, and finish's unconditional reset.

Also recorded: the criterion says to assert "against `jpeglib.h`", but upstream declares `global_state` values in `jpegint.h` and `jpeglib.h` never mentions them — asserting against `jpeglib.h` literally would assert nothing.

## Test plan

- `cargo test -p libjpeg-turbo-rs-capi --lib`: 24/24.
- `cargo test --workspace --release`: 2552 passed / 0 failed / 0 ignored across 288 suites (unchanged — this PR adds no tests, it runs existing ones).
- `cargo fmt --check`, `actionlint`-equivalent YAML parse: clean.
- codex review: 3 rounds. Round 1 caught the duplicate test, round 2 caught the false "never ran" claim.

Related: #468 (P4-104/P4-106), whose transition work is the actual remaining scope.