### PR TITLE
docs: define adoption strategy and migration path

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,152 @@
+## Summary
+
+<!-- What user, adopter, or maintainer problem does this solve? -->
+
+## Product priority and gate
+
+- PRD priority: <!-- P0 / P1 / P2 / maintenance -->
+- Live-gate item or issue: <!-- P4-..., #...; write N/A only with a reason -->
+- Integration path affected: <!-- Rust API / image bridge / Wasm / TurboJPEG 3 / classic libjpeg v8 / release tooling / docs -->
+
+## Public behavior
+
+### Before
+
+<!-- Exact observable behavior, limitation, failure, or adoption cost. -->
+
+### After
+
+<!-- Exact observable behavior after this change. Do not overstate readiness. -->
+
+## Scope
+
+### Included
+
+-
+
+### Deliberately not included
+
+-
+
+## Evidence
+
+| Command or artifact | Environment | Result |
+| --- | --- | --- |
+|  |  |  |
+
+<!--
+For benchmarks, include CPU, operating system, compiler/toolchain, C oracle
+version, portable/native flags, corpus, warmup, sample count, statistic, noise
+threshold, and raw output.
+
+For C compatibility, identify the exact API/ABI version, shared library,
+SONAME/install name, symbol version, and whether the packaged artifact or only
+an intermediate Cargo artifact was tested.
+-->
+
+## Correctness
+
+- [ ] A regression test exercises the documented public path.
+- [ ] The result is cross-validated against a pinned C oracle when a C contract
+      exists.
+- [ ] Every generated/differential attempt is accounted for as pass, refusal,
+      expected failure, or unexpected failure.
+- [ ] Relevant malformed, truncated, oversized, short-buffer, stride, pitch,
+      alignment, and lifecycle cases are covered.
+- [ ] Output pixels/bytes/metadata are compared using a rule defined before the
+      test.
+- [ ] I have stated anything that remains unverified.
+
+## Safety and resource handling
+
+- [ ] No unsafe code or unsafe contract changes.
+- [ ] New/changed unsafe code documents its safety contract and why safe callers
+      cannot violate it.
+- [ ] Size, offset, stride, allocation, and slice-span arithmetic use checked
+      operations or an enforced checked abstraction.
+- [ ] Scalar/SIMD equivalence and runtime feature-detection behavior are tested.
+- [ ] Relevant Miri, AddressSanitizer, Undefined Behavior checks, fuzz, or
+      manual-audit evidence is included.
+- [ ] Memory limits, allocation behavior, and termination behavior were
+      considered.
+
+## Performance
+
+- [ ] No performance-sensitive path changes.
+- [ ] Correctness is checked before timing.
+- [ ] Portable `cargo build --release` and `-C target-cpu=native` results are
+      reported separately.
+- [ ] Before/after measurements use the same hardware, build class, input,
+      output format, and concurrency.
+- [ ] Raw dated evidence is added under `experiments/`.
+- [ ] Any regression above the project threshold is explained and justified.
+- [ ] Emulation is used only for functional evidence, not hardware performance
+      claims.
+
+## Rust API and dependencies
+
+- [ ] No public Rust API or Cargo feature changes.
+- [ ] Public items have documentation, examples, tests, and explicit error and
+      ownership behavior.
+- [ ] A breaking change has migration and changelog notes.
+- [ ] Minimum Supported Rust Version (MSRV), `no_std`, WebAssembly (Wasm), and
+      dependency-graph impact were checked.
+- [ ] A new dependency includes maintenance, security, MSRV, binary-size, and
+      feature justification.
+
+## C API and ABI
+
+- [ ] No C Application Programming Interface (API) or Application Binary
+      Interface (ABI) changes.
+- [ ] Targeted TurboJPEG/libjpeg version and every changed symbol are identified.
+- [ ] Ownership, allocation, callbacks, errors, suspension, abort/reuse,
+      precision, and threading contracts are tested as applicable.
+- [ ] SONAME/install name, symbol versions, and create-time version/size guards
+      are verified.
+- [ ] The exact packaged artifact users receive is tested where release behavior
+      changes.
+- [ ] This change does not generalize a TurboJPEG 3 result to classic libjpeg or
+      a v8 result to v6b/v7.
+
+## Platform and release artifacts
+
+- [ ] No platform, packaging, or release-artifact changes.
+- [ ] Clean-machine or isolated installation and sample compile/run are shown.
+- [ ] Unsupported-CPU fallback behavior is tested.
+- [ ] Native hardware evidence is included for performance claims.
+- [ ] Artifact inventory, hashes, signatures/attestations, and Software Bill of
+      Materials (SBOM) impact are documented.
+- [ ] Rollback to the previous artifact or implementation was considered.
+
+## Documentation
+
+- [ ] README/onboarding remains consistent with the canonical live gate.
+- [ ] `docs/FEATURE_PARITY.md` is updated for feature-status changes.
+- [ ] `docs/TEST_PARITY.md` or `docs/CORPUS_TEST_REPORT.md` is updated for
+      validation changes.
+- [ ] `docs/C_API_REFERENCE.md` is updated for C function changes.
+- [ ] `docs/ABI_COMPATIBILITY.md` is updated for ABI, SONAME, layout,
+      lifecycle, allocator, or threading changes.
+- [ ] `docs/LAST_MILE.md` and the relevant phase item are updated for readiness
+      or blocker changes.
+- [ ] `docs/RELEASE_ARTIFACTS.md` is updated for distribution changes.
+- [ ] `PRD.md` is updated only when product priority, milestone, metric, or
+      release requirement changes.
+- [ ] Links, anchors, commands, examples, terminology, and status dates were
+      checked.
+
+## Adoption impact
+
+<!--
+How does this change lower adoption risk or cost? Examples: fixes a red gate,
+reduces build friction, proves a packaged artifact, improves portable
+performance, adds a maintained integration, clarifies an unsupported path.
+-->
+
+## Compatibility and rollback
+
+<!-- What can break, how will users migrate, and how can they revert? -->
+
+## Reviewer focus
+
+<!-- Point reviewers to the highest-risk files, contracts, and evidence. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,35 @@
 # Agent Rules
 
-- Always read and follow the rules defined in `CLAUDE.md` before starting any task.
+Before starting any task:
+
+1. Read and follow [`CLAUDE.md`](CLAUDE.md).
+2. Read [`PRD.md`](PRD.md) for product priority and acceptance criteria.
+3. Use [`docs/README.md`](docs/README.md) to identify the canonical document
+   for the claim you are changing.
+4. Read the relevant issue, [`docs/LAST_MILE.md`](docs/LAST_MILE.md), and the
+   corresponding phase item before changing replacement readiness.
+
+## Non-negotiable rules
+
+- Do not mark a feature complete because an internal helper exists. Verify the
+  documented public path end to end.
+- Do not promote T1, T2, T3, or T4 compatibility by editing a README. Update
+  the canonical gate, executable evidence, and user-facing summary together.
+- Do not call a release gate green from a debug-only run when release mode is
+  required.
+- Do not use emulation as performance evidence for physical hardware.
+- Do not generalize a TurboJPEG 3 result to classic libjpeg, or a v8 result to
+  v6b/v7.
+- Test the artifact users receive when packaging, relinking, SONAME, symbol
+  versioning, signing, or installation is involved.
+- Account for every generated or differential test case. Silent catch-all
+  success and unexplained skips are prohibited.
+- State exactly what was verified, on which environment, and what remains
+  unverified.
+- Update feature, test, ABI, release, performance, and adoption documentation
+  whenever the corresponding public claim changes.
+- Preserve a focused scope. Do not add speculative abstraction or unrelated
+  refactors.
+
+A task is complete only when its acceptance criteria, tests, evidence, and
+source-of-truth documentation agree.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,44 +1,317 @@
-# Contributing
+# Contributing to libjpeg-turbo-rs
 
-Development workflow notes for `libjpeg-turbo-rs`. User-facing
-documentation lives in [README.md](README.md) and on
-[docs.rs](https://docs.rs/libjpeg-turbo-rs).
+Thank you for helping build a JPEG codec that developers can adopt on evidence,
+not only on feature claims.
+
+Before changing code or public documentation, read:
+
+1. [`PRD.md`](PRD.md) — product direction, priorities, milestones, and the
+   `1.0` definition of done;
+2. [`docs/README.md`](docs/README.md) — documentation map and source-of-truth
+   order;
+3. [`docs/LAST_MILE.md`](docs/LAST_MILE.md) — live T1-T4 release gates;
+4. [`CLAUDE.md`](CLAUDE.md) — repository-specific implementation, test, and
+   review rules;
+5. the relevant issue and phase item under [`docs/last_mile`](docs/last_mile).
+
+The project has broad feature coverage. The highest-value contribution is not
+always another feature: release-mode correctness, safe boundary enforcement,
+portable performance, packaged-artifact validation, supply-chain evidence, and
+maintained ecosystem integrations have direct adoption impact.
 
 ## Ground rules
 
-- All changes go through pull requests; CI must be green (the workspace
-  gate cross-validates against C libjpeg-turbo byte-for-byte).
-- `cargo fmt --all` and `cargo clippy --lib -- -D warnings` before each
-  commit (`git config core.hooksPath .githooks` installs the pre-commit
-  hook).
-- Tests follow TDD and must cross-validate against C `djpeg`/`cjpeg`/
-  `jpegtran` where a C contract exists — see `CLAUDE.md` for the full
-  testing rules, and `docs/LAST_MILE.md` for the live release gate.
+- All changes go through pull requests.
+- Follow test-driven development where a behavior can be specified before its
+  implementation.
+- Cross-validate against pinned C libjpeg-turbo tools or libraries whenever a
+  corresponding C contract exists.
+- Do not convert code presence, a debug-only pass, an emulated benchmark, or an
+  intermediate build artifact into a readiness claim.
+- Do not promote a compatibility tier by changing a README. Promotion requires
+  the canonical live gate, acceptance criteria, executable evidence, and
+  user-facing summary to change together.
+- Keep the scope focused. Necessary integration and documentation changes
+  belong in the same pull request; unrelated refactors do not.
+- New dependencies need a maintenance, security, Minimum Supported Rust Version
+  (MSRV), binary-size, and `no_std` impact justification.
+- New public APIs need documentation, examples, tests, an error contract, and a
+  compatibility rationale.
+- New architecture optimizations need scalar equivalence tests, feature
+  detection, unsupported-CPU behavior, and hardware measurements.
+- Record what was verified and what remains unverified.
+
+## Choose work by adoption impact
+
+Use the priorities in [`PRD.md`](PRD.md). In brief:
+
+### P0 — trustworthy adoption
+
+Examples include:
+
+- required release-mode gate failures;
+- safe-API soundness and checked layout arithmetic;
+- automated unsafe-dispatch and boundary regression detection;
+- validation of the exact packaged library users download;
+- stale or contradictory readiness documentation;
+- private security reporting and release evidence.
+
+### P1 — lower migration and deployment cost
+
+Examples include:
+
+- portable performance that does not require `target-cpu=native`;
+- Windows native bundles;
+- signatures or attestations and a Software Bill of Materials (SBOM);
+- removal of the classic C API cross-thread ownership divergence;
+- reproducible benchmark results and maintained downstream integrations.
+
+### P2 — expand the addressable platform
+
+Examples include AArch32 NEON, RISC-V Vector (RVV), additional package-manager
+support, and separately built ABI variants. These require hardware or adopter
+evidence rather than speculative implementation.
+
+## Development setup
+
+```bash
+git clone --recurse-submodules https://github.com/developer0hye/libjpeg-turbo-rs.git
+cd libjpeg-turbo-rs
+
+git config core.hooksPath .githooks
+cargo build --workspace
+```
+
+The submodules under `references/` pin upstream sources used by differential
+validation. Do not silently update an oracle. An oracle update requires its own
+reviewable version/hash change and a report of behavioral differences.
+
+## Local checks
+
+Run the checks relevant to your change before opening a pull request:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --lib -- -D warnings
+cargo test --doc
+```
+
+For code changes, run the narrowest relevant test first, then the workspace
+release gate when the environment supports it:
+
+```bash
+cargo test --workspace --release --no-fail-fast
+```
+
+The canonical current result is recorded in
+[`docs/LAST_MILE.md`](docs/LAST_MILE.md). If the base branch has a known
+failure, reproduce it on an unmodified base commit, state that clearly, and
+show that your change adds no unexplained failures. A green debug run does not
+replace a required release-mode run.
+
+Useful repository entry points include:
+
+```bash
+# Root library tests
+cargo test -p libjpeg-turbo-rs --release
+
+# C ABI crate and integration tests
+cargo test -p libjpeg-turbo-rs-capi --release
+
+# image adapter
+cargo test -p libjpeg-turbo-rs-image --release
+
+# no_std core build
+cargo build -p libjpeg-turbo-rs --no-default-features \
+  --target thumbv7em-none-eabihf
+
+# Compile-checked public documentation
+cargo test --doc
+```
+
+Use the exact commands in the relevant live-gate item for full C parity,
+architecture, Wasm, downstream, or timing-sensitive matrices.
+
+## Evidence required by change type
+
+### Codec behavior or feature
+
+Include:
+
+- a regression test through the public path;
+- differential evidence against the pinned C oracle when a C contract exists;
+- success/failure accounting for every generated case;
+- malformed and boundary inputs relevant to the behavior;
+- updates to [`docs/FEATURE_PARITY.md`](docs/FEATURE_PARITY.md),
+  [`docs/TEST_PARITY.md`](docs/TEST_PARITY.md), or the live gate when their
+  claims change.
+
+A checkbox may be marked complete only when the documented public surface is
+wired end to end. An internal helper, stored parameter, or nearby API does not
+count as parity.
+
+### Unsafe code, SIMD, or buffer arithmetic
+
+Include:
+
+- the safety contract and caller obligations;
+- proof that safe callers cannot violate the contract;
+- scalar equivalence and short/misaligned/edge-length tests;
+- architecture feature-detection behavior;
+- Miri, sanitizer, fuzz, or manual-review evidence appropriate to the risk;
+- checked overflow, allocation, alignment, and slice-span handling;
+- an update to the unsafe/layout inventory or live gate when applicable.
+
+Do not describe a sanitizer pass as a proof of memory safety. The verification
+program is cumulative.
+
+### Performance
+
+Include correctness checks before timing. Record:
+
+- processor, operating system, and power/governor state;
+- Rust/LLVM and C compiler versions;
+- C oracle version;
+- portable or native build flags;
+- corpus hashes or deterministic generator parameters;
+- output format, quality, subsampling, precision, and thread count;
+- warmup, sample count, statistic, noise threshold, and raw output;
+- before/after results on the same machine.
+
+Keep portable `cargo build --release` results separate from
+`-C target-cpu=native`. Emulation can prove functional execution but not target
+hardware performance.
+
+Store dated evidence under [`experiments/`](experiments) and update a
+user-facing performance summary only when the evidence supports it.
+
+### Rust API or Cargo feature
+
+Include:
+
+- API documentation and a compile-checked example;
+- success, error, allocation/ownership, and threading semantics;
+- compatibility or migration notes for a breaking change;
+- MSRV, `no_std`, Wasm, and dependency-graph impact;
+- changelog entry when user-visible behavior changes.
+
+### C API or ABI
+
+Include:
+
+- exact symbol/signature and the targeted TurboJPEG or libjpeg version;
+- create/destroy, ownership, allocation, error, callback, suspension, reuse,
+  and threading behavior as applicable;
+- differential tests through the produced shared library, not only a Rust
+  helper;
+- symbol/SONAME/install-name/version checks;
+- the packaged-artifact path when release behavior is affected;
+- updates to [`docs/C_API_REFERENCE.md`](docs/C_API_REFERENCE.md),
+  [`docs/ABI_COMPATIBILITY.md`](docs/ABI_COMPATIBILITY.md), and the live gate.
+
+A TurboJPEG 3 success does not imply classic libjpeg readiness. A v8 result
+must not be generalized to v6b or v7.
+
+### Platform, package, or release artifact
+
+Include:
+
+- clean-machine or isolated-environment installation;
+- artifact inventory, hashes, linkage metadata, and sample compile/run;
+- native hardware evidence for performance claims;
+- fallback behavior on unsupported CPUs;
+- reproducible packaging path;
+- updates to [`docs/RELEASE_ARTIFACTS.md`](docs/RELEASE_ARTIFACTS.md) and the
+  support matrix.
+
+Test the artifact users receive. Passing against `target/release` is not enough
+when the release script relinks, renames, signs, packages, or otherwise changes
+the library.
+
+### Documentation-only change
+
+Verify:
+
+- links and anchors;
+- code examples and commands where practical;
+- consistency with the canonical live gate and ABI policy;
+- terminology and status dates;
+- that no compatibility or safety claim was promoted without new evidence.
+
+## Pull request expectations
+
+Use [`.github/pull_request_template.md`](.github/pull_request_template.md) and
+include:
+
+- the user or adopter problem;
+- the selected PRD priority and live-gate item;
+- the exact public behavior before and after;
+- tests and raw evidence;
+- supported and unverified environments;
+- safety, performance, API/ABI, and documentation impact;
+- rollback or compatibility notes for user-visible changes.
+
+Keep commits reviewable. A commit should explain *why* the change exists, not
+only repeat the file name.
+
+### Developer Certificate of Origin
+
+This repository uses a Developer Certificate of Origin (DCO) check. Sign off
+each commit:
+
+```bash
+git commit -s -m "component: explain the change"
+```
+
+## Documentation source-of-truth rules
+
+When a public claim changes, update the corresponding canonical document:
+
+| Change | Required source of truth |
+| --- | --- |
+| Implemented JPEG capability | `docs/FEATURE_PARITY.md` |
+| C function status | `docs/C_API_REFERENCE.md` |
+| ABI, SONAME, layout, lifecycle, allocator, or threading policy | `docs/ABI_COMPATIBILITY.md` |
+| Replacement readiness or open blocker | `docs/LAST_MILE.md` and the relevant phase file |
+| C behavior/test mapping | `docs/TEST_PARITY.md` |
+| Corpus result | `docs/CORPUS_TEST_REPORT.md` |
+| Benchmark claim | dated `experiments/` evidence and the relevant summary |
+| Release contents or verification | `docs/RELEASE_ARTIFACTS.md` |
+| Product priority or milestone | `PRD.md` |
+| Onboarding or migration | README and `docs/ADOPTION_GUIDE.md` |
+
+Read [`docs/README.md`](docs/README.md) for the complete hierarchy. A concise
+README is a summary, not the authority for a contested compatibility claim.
 
 ## Issues worked on unattended
 
-`scripts/issue_loop.sh` can work through the open issues without supervision,
-one fresh agent per issue; `CLAUDE.md` documents how to run it. Two label
-conventions come out of that, and both are meant for humans to use:
+`scripts/issue_loop.sh` can work through open issues without supervision, one
+fresh agent per issue. [`CLAUDE.md`](CLAUDE.md) documents how to run it.
 
-- **`autofix-skip`** — put it on an umbrella or tracker issue that closes only
-  when its children do, so no agent tries to "fix" the tracker itself.
-- **`autofix-blocked`** — the loop applies this after two attempts produce no
-  merged pull request, and an agent applies it itself when the issue needs a
-  human decision or hardware it does not have. Either way it means *read the
-  issue comments*; removing the label puts the issue back in the queue.
+Two labels are also useful for human contributors:
+
+- **`autofix-skip`** — an umbrella or tracker issue that closes only when its
+  child issues close; an unattended worker must not try to "fix" the tracker.
+- **`autofix-blocked`** — two attempts produced no merged pull request, or the
+  issue requires a human decision, private data, hardware, signing authority,
+  or another unavailable resource. Read the comments before removing it.
 
 Run reports land in `target/issue-loop-logs/` on the machine that ran the loop.
+An unattended worker must satisfy the same acceptance and evidence criteria as
+a human contributor.
 
 ## Running sanitizers locally
 
-Requires a nightly toolchain (`rustup install nightly`) and the `rust-src` component:
+Install a nightly toolchain and `rust-src`:
 
 ```bash
+rustup install nightly
 rustup component add rust-src --toolchain nightly
 ```
 
-**AddressSanitizer** (detects heap overflows, use-after-free, stack overflows):
+### AddressSanitizer
+
+Detects heap overflows, use-after-free, and stack overflows:
 
 ```bash
 RUSTFLAGS="-Z sanitizer=address" \
@@ -48,7 +321,10 @@ cargo +nightly test --workspace --lib \
   --no-fail-fast -- --test-threads=1
 ```
 
-**UB checks** (detects signed integer overflow, invalid enum discriminant, misaligned pointer dereference):
+### Rust Undefined Behavior checks
+
+Detects supported classes such as signed integer overflow, invalid enum
+discriminants, and misaligned pointer dereferences:
 
 ```bash
 RUSTFLAGS="-Z ub-checks=yes" \
@@ -56,7 +332,29 @@ cargo +nightly test --workspace --lib \
   --no-fail-fast -- --test-threads=1
 ```
 
-Note: `rustc` does not implement `sanitizer=undefined`; `-Z ub-checks=yes` is the correct nightly knob for runtime UB detection.
+`rustc` does not implement `sanitizer=undefined`; `-Z ub-checks=yes` is the
+correct nightly runtime check used here.
 
-All three sanitizer jobs (asan, ubsan, and the P4-11 C-boundary asan harness) run on every PR via `.github/workflows/sanitizers.yml`. macOS is excluded because the NEON SIMD paths produce spurious cross-thread ASan shadow-map false positives under parallel test execution.
+The sanitizer workflow also includes the C-boundary AddressSanitizer harness.
+macOS is excluded from the sanitizer jobs because the NEON SIMD paths produce
+spurious cross-thread AddressSanitizer shadow-map failures under parallel test
+execution; that exclusion is a recorded tool limitation, not evidence that the
+platform needs no safety testing.
 
+## Review standard
+
+A review should answer:
+
+1. Does the public contract match the implementation?
+2. Can safe Rust reach an unsafe operation without satisfying its contract?
+3. Does the C behavior match the targeted upstream API/ABI version?
+4. Are all generated attempts accounted for rather than silently skipped?
+5. Are size, stride, pitch, alignment, multiplication, and addition checked?
+6. Does runtime feature detection protect unsupported CPUs?
+7. Is the performance comparison fair, reproducible, and correctness-checked?
+8. Is the shipped artifact the artifact that was tested?
+9. Do the documentation and live gate state exactly what remains unverified?
+10. Does this change lower adoption risk or add a justified maintenance burden?
+
+A pull request is complete when its acceptance criteria and evidence are
+satisfied, not when an implementation file exists.

--- a/PRD.md
+++ b/PRD.md
@@ -1,0 +1,731 @@
+# Product Requirements Document: Adoption Strategy
+
+**Status:** Active  
+**Last reviewed:** 2026-08-27  
+**Scope:** `libjpeg-turbo-rs` workspace, from the current `0.8.x` line through a trustworthy `1.0` release  
+**Primary audience:** maintainers, contributors, downstream evaluators, package maintainers, and agentic coding tools
+
+## 1. Executive summary
+
+`libjpeg-turbo-rs` is not competing with an ordinary codec. The C implementation of
+[libjpeg-turbo](https://github.com/libjpeg-turbo/libjpeg-turbo) is a mature,
+widely packaged, industry-standard implementation with long-lived Application
+Programming Interface (API) and Application Binary Interface (ABI) contracts,
+official binaries, broad Single Instruction, Multiple Data (SIMD) coverage, and
+a large installed base. Version 3.2.0, released on 2026-06-30, is the upstream
+comparison baseline at the time of this document.
+
+The product strategy is therefore not "rewrite the same code in Rust and wait
+for adoption." It is to win where a Rust-native implementation can deliver a
+materially better total developer experience while preserving measurable
+correctness and performance:
+
+1. become the default high-performance JPEG codec for new Rust-native projects;
+2. remove C build-system and Foreign Function Interface (FFI) friction for
+   cross-platform, embedded, and WebAssembly (Wasm) deployments;
+3. provide a well-evidenced migration path for TurboJPEG 3 consumers;
+4. expand classic libjpeg replacement only when the shipped artifact, ABI,
+   lifecycle, threading, and error contracts are proved rather than assumed;
+5. make every adoption claim reproducible from public tests, benchmarks, and
+   release artifacts.
+
+The long-term ambition is broader adoption than the C implementation in the
+segments where Rust-native delivery is a meaningful advantage. It is not a
+near-term claim that this project can replace the C implementation in every
+existing operating system, application, architecture, or ABI configuration.
+
+## 2. Source-of-truth hierarchy
+
+Documents have different jobs. When wording conflicts, use this order:
+
+1. [`docs/LAST_MILE.md`](docs/LAST_MILE.md) and its phase files: live
+   replacement gates and exact T1-T4 readiness.
+2. [`docs/ABI_COMPATIBILITY.md`](docs/ABI_COMPATIBILITY.md): C ABI and SONAME
+   policy.
+3. [`docs/FEATURE_PARITY.md`](docs/FEATURE_PARITY.md): implemented feature
+   inventory.
+4. [`docs/TEST_PARITY.md`](docs/TEST_PARITY.md),
+   [`docs/CORPUS_TEST_REPORT.md`](docs/CORPUS_TEST_REPORT.md), and dated
+   benchmark evidence: validation status.
+5. This Product Requirements Document (PRD): product direction, priorities,
+   success criteria, and release requirements.
+6. [`README.md`](README.md) and crate READMEs: concise user-facing summaries.
+
+A compatibility tier may only be promoted by changing the live gate with the
+required evidence. Marketing or onboarding documentation must never promote a
+tier by itself.
+
+## 3. Current product baseline
+
+The current workspace version is `0.8.0`. The following is a concise product
+snapshot, not a replacement for the live gate.
+
+| Surface | Current position | Appropriate use now | Principal remaining risk |
+| --- | --- | --- | --- |
+| **T1: Rust API** | Feature-rich, C-cross-validated, competitive on measured x86_64 and aarch64 workloads | Evaluation and production use after the adopter reviews the documented limitations | No known live Undefined Behavior (UB) is recorded in the safe Rust API, but a formal memory-safety guarantee still requires the remaining layout-centralization and verification work in P4-139/P4-141. The full release-mode workspace gate is currently red because of P4-170. |
+| **T2: TurboJPEG 3 C ABI** | Primary C ABI target; opaque-handle API avoids classic struct-layout risk | TurboJPEG 3 consumers whose required symbols and behavior are covered by the reference matrix | Legacy TurboJPEG 1.x/2.x aliases are partial; the release artifact and exact downstream workload still need to be evaluated by each adopter. |
+| **T3: classic libjpeg v8 C ABI** | Experimental and partial | Controlled pilots with an explicit compatibility test plan and rollback | Open lifecycle, ownership, option, error, threading, artifact-validation, and downstream-coverage gaps. It is not a general system-library replacement. |
+| **T4: libjpeg v6b/v7 ABI** | Explicit non-goal without separately built ABI variants | None as a drop-in replacement | Struct layouts differ. Renaming a v8-layout library to a v6b/v7 SONAME does not make it binary-compatible. |
+| **Distribution** | crates.io, npm for Wasm, and Linux/macOS x86_64/aarch64 native bundles | Rust-native use and supported native pilots | No Windows native bundle; bundles are checksummed but not yet signed and do not publish a Software Bill of Materials (SBOM). |
+| **Architecture performance** | Strongest on x86_64 and aarch64; Wasm SIMD128 supported | Measured target/platform combinations | AArch32/armv7 lacks a production SIMD backend; RISC-V Vector (RVV) is not implemented; scalar-only architectures need current hardware measurements. |
+
+## 4. Problem statement
+
+### 4.1 Why developers stay on C libjpeg-turbo
+
+The C implementation has advantages that cannot be erased by codec feature
+parity alone:
+
+- decades of downstream testing and operational familiarity;
+- broad operating-system and package-manager availability;
+- stable TurboJPEG and classic libjpeg contracts;
+- official, signed binaries for common platforms;
+- wide SIMD coverage and platform-specific tuning;
+- existing integrations in image libraries, frameworks, browsers, computer
+  vision systems, and language bindings;
+- established security reporting and maintenance practices.
+
+### 4.2 Why developers would choose this project
+
+A Rust-native implementation can remove costs that the C implementation cannot
+remove without changing its architecture:
+
+- one Cargo dependency instead of a C compiler, CMake/NASM/Yasm setup, system
+  package discovery, and FFI bindings;
+- Rust ownership and error types at the public API;
+- `no_std + alloc` and Wasm delivery from the same codec codebase;
+- caller-owned reusable output buffers and idiomatic streaming APIs;
+- a direct path to Rust ecosystem integrations;
+- easier cross-compilation and hermetic builds;
+- the ability to validate every unsafe boundary and expose the remaining risk
+  rather than hiding it behind a "pure Rust" label.
+
+### 4.3 Adoption barriers in the current project
+
+The implementation is ahead of its adoption experience. The main barriers are:
+
+1. **Trust is difficult to summarize.** Detailed evidence exists, but status is
+   distributed across large documents and dated experiment files.
+2. **The safe choice is not obvious.** Rust API, image bridge, Wasm, TurboJPEG
+   3, classic libjpeg v8, and unsupported v6b/v7 paths need a visible decision
+   tree.
+3. **Compatibility language has drifted.** Some user-facing text still refers
+   to already-closed safety defects, while the live release-mode test failure
+   is less visible.
+4. **Portable performance is not always the quoted performance.** Native
+   `target-cpu` results and portable release results must remain clearly
+   separated.
+5. **Distribution trails the C project.** Windows bundles, signatures,
+   provenance, SBOMs, and package-manager integrations are incomplete.
+6. **Ecosystem integration is early.** A bridge crate exists for the `image`
+   crate, but adoption requires downstream pull requests, stable adapter APIs,
+   and public case studies.
+7. **Classic ABI replacement is expensive.** Every unproved lifecycle or
+   threading behavior can invalidate a nominally correct symbol surface.
+
+## 5. Product vision
+
+> A production-grade JPEG codec that Rust developers can adopt with one
+> dependency, evaluate with reproducible evidence, deploy across native,
+> embedded, and Wasm targets, and migrate to without accepting ambiguous
+> compatibility claims.
+
+## 6. Goals
+
+### G1. Win new Rust-native JPEG workloads
+
+For projects that do not require an existing classic libjpeg ABI, the default
+recommendation should be the Rust API rather than a binding to the C codec.
+
+### G2. Make evaluation fast and honest
+
+A technically competent developer should be able to determine the correct
+integration path in under ten minutes and complete a representative pilot in
+one working day without reading the entire replacement gate.
+
+### G3. Match or beat the C implementation on total adoption cost
+
+Performance is necessary but not sufficient. The product must reduce build,
+cross-compilation, packaging, deployment, and maintenance complexity while
+remaining competitive on throughput, latency, and memory for supported
+workloads.
+
+### G4. Establish release-level trust
+
+Every release must publish an evidence bundle covering correctness, safety,
+performance, supported platforms, exact oracle versions, artifact integrity,
+and known limitations.
+
+### G5. Create a credible migration path for C consumers
+
+TurboJPEG 3 should be the first-class C migration target. Classic libjpeg v8
+must remain explicitly experimental until its complete release gate is green.
+
+### G6. Grow through ecosystem integrations
+
+Adoption should come from maintained integrations in widely used Rust and
+cross-platform libraries, not only direct dependencies on the core crate.
+
+## 7. Non-goals
+
+The following are not required to declare the Rust-native product successful:
+
+- replacing every system `libjpeg.so.62` installation;
+- claiming v6b or v7 binary compatibility from a renamed v8-layout library;
+- matching upstream performance on every architecture before `1.0`;
+- preserving every pre-1.0 Rust API shape if a change materially improves
+  soundness or usability and is documented in the changelog;
+- adding unrelated image formats to the core crate;
+- optimizing obscure paths without a measured workload or adopter signal;
+- publishing benchmark wins that cannot be reproduced from a documented
+  environment.
+
+## 8. Target users and jobs to be done
+
+### 8.1 Rust application developers
+
+**Job:** decode, encode, transform, inspect, or stream JPEG data without a C
+build dependency.
+
+**Must have:** simple one-shot API, reusable-buffer API, predictable errors,
+examples, SemVer policy, documentation on memory and threading behavior.
+
+### 8.2 Rust library and framework maintainers
+
+**Job:** expose JPEG functionality to many downstream users without imposing a
+fragile native dependency.
+
+**Must have:** stable adapter interfaces, controlled feature flags, Minimum
+Supported Rust Version (MSRV) policy, low dependency footprint, benchmark and
+fuzz evidence, and a clear maintenance commitment.
+
+### 8.3 Cross-platform, embedded, and Wasm teams
+
+**Job:** use the same codec implementation across native, browser, WebAssembly
+System Interface (WASI), and constrained `no_std + alloc` environments.
+
+**Must have:** explicit target matrix, compile-time SIMD instructions, memory
+limits, no hidden runtime dependency, and reproducible builds.
+
+### 8.4 C/C++ TurboJPEG users
+
+**Job:** replace or pilot `libturbojpeg` without rewriting the application.
+
+**Must have:** symbol inventory, versioned headers, prebuilt artifacts,
+behavioral parity tests, installation instructions, and rollback guidance.
+
+### 8.5 Classic libjpeg and distribution maintainers
+
+**Job:** determine whether a specific downstream binary can safely use the v8
+shim.
+
+**Must have:** exact ABI identity, symbol versions, lifecycle and threading
+contracts, tested shipped artifacts, package metadata, and an explicit list of
+unsupported configurations.
+
+## 9. Positioning
+
+### 9.1 Primary positioning
+
+**Fast, evidence-driven, pure-Rust JPEG for applications that want
+libjpeg-turbo-class capability without depending on a C codec.**
+
+"Pure Rust" means the Rust-native codec does not call a C JPEG implementation.
+It does not mean the repository contains no `unsafe` code. SIMD kernels and C
+ABI boundaries necessarily require narrowly reviewed unsafe code.
+
+### 9.2 Differentiators
+
+- Cargo-native installation and cross-compilation;
+- Rust-first one-shot, builder, streaming, coefficient, metadata, and
+  caller-owned-buffer APIs;
+- `no_std + alloc` and Wasm support;
+- broad JPEG feature support, including progressive, arithmetic, lossless,
+  high precision, transforms, metadata, and YUV paths;
+- byte-level and behavior-level cross-validation against pinned C oracles;
+- competitive measured performance on x86_64 and aarch64;
+- tiered compatibility language that separates Rust API readiness from C ABI
+  replacement readiness.
+
+### 9.3 Competitive rule
+
+A benchmark win does not compensate for a correctness, soundness, packaging,
+or compatibility regression. A feature win does not compensate for an
+unusable migration path. Product decisions should optimize the entire adoption
+funnel.
+
+## 10. Product principles
+
+1. **Evidence before claims.** Every compatibility or performance statement
+   links to a test, benchmark, or release artifact.
+2. **Safe Rust path first.** Work reachable from the safe API has higher
+   priority than expanding an experimental classic C ABI surface.
+3. **One obvious default.** Common decode and encode workflows require minimal
+   configuration; advanced controls remain available through builders.
+4. **Portable numbers are the default numbers.** Native-CPU measurements may
+   be reported, but never presented as portable release performance.
+5. **Compatibility is tiered.** A green TurboJPEG 3 path does not imply a green
+   classic libjpeg path.
+6. **Shipped artifacts are the product.** Testing an intermediate `cargo`
+   artifact is insufficient when users download a relinked or packaged binary.
+7. **Unsupported is better than silently unsafe.** Reject mismatched ABI
+   versions and invalid geometry instead of attempting best-effort behavior.
+8. **Maintenance cost is a feature.** New APIs, architectures, and packages
+   require an owner, tests, and a lifecycle plan.
+
+## 11. Adoption funnel requirements
+
+### 11.1 Discover
+
+A visitor must understand within the first README screen:
+
+- what the project is;
+- why it exists despite C libjpeg-turbo;
+- the current Rust API, TurboJPEG 3, classic v8, and v6b/v7 statuses;
+- whether their target platform is optimized or scalar;
+- where to find a quick start, migration guide, benchmark evidence, and live
+  limitations.
+
+### 11.2 Evaluate
+
+The repository must provide:
+
+- one representative decode and encode example;
+- a decision table for each integration path;
+- a reproducible benchmark command and methodology;
+- dated C-oracle version pins;
+- a correctness corpus summary;
+- memory and reusable-buffer guidance;
+- a checklist for unsupported formats, architectures, and ABIs.
+
+### 11.3 Integrate
+
+The project must support these explicit paths:
+
+1. direct Rust API;
+2. `image`-crate-compatible adapter;
+3. Wasm/npm package;
+4. TurboJPEG 3 C ABI bundle;
+5. controlled classic libjpeg v8 pilot.
+
+Each path needs installation, minimum example, error model, supported feature
+matrix, platform notes, and rollback instructions where replacement is
+involved.
+
+### 11.4 Validate
+
+A downstream pilot must be able to compare:
+
+- decoded dimensions, color format, and pixel output;
+- encoded decode-equivalence and, where relevant, byte identity;
+- metadata preservation;
+- latency, throughput, peak memory, and allocation behavior;
+- malformed-input handling;
+- concurrency behavior;
+- artifact loading and symbol resolution.
+
+### 11.5 Operate
+
+Production adopters need:
+
+- SemVer and MSRV policies;
+- security reporting instructions;
+- release notes and known limitations;
+- signed or attestable artifacts and SBOMs;
+- supported-version policy;
+- a stable issue-triage path;
+- migration instructions for breaking pre-1.0 changes.
+
+## 12. Functional requirements
+
+### FR1. Rust-native onboarding
+
+- `cargo add libjpeg-turbo-rs` must lead to a compiling decode example.
+- One-shot decode/encode, caller-owned-buffer, builder, streaming, transform,
+  metadata, and `no_std` examples must remain compile-checked.
+- Public examples must use stable APIs and explicit quality/subsampling where
+  required.
+
+**Acceptance:** documentation examples run in Continuous Integration (CI) as
+`cargo test --doc` or dedicated example smoke tests.
+
+### FR2. Integration-path decision support
+
+- README and adoption guide must expose a consistent T1-T4 decision table.
+- Unsupported v6b/v7 drop-in use must be visible before installation steps.
+- Each C ABI path must link to the symbol and behavioral reference.
+
+**Acceptance:** a documentation-drift check fails when readiness wording
+contradicts the live gate's canonical status block.
+
+### FR3. Rust ecosystem bridge
+
+- The `libjpeg-turbo-rs-image` crate must implement the relevant `image` traits
+  with documented color mappings and limitations.
+- Adapter performance and compatibility must be measured separately from the
+  core codec so bridge overhead is visible.
+- The project should pursue an accepted optional integration in at least one
+  widely used downstream crate rather than relying only on a standalone
+  adapter.
+
+**Acceptance:** at least one maintained downstream integration has automated
+compatibility tests against its upstream project.
+
+### FR4. Wasm and embedded delivery
+
+- Wasm SIMD128 requirements must be explicit because repository-local Cargo
+  configuration does not travel with a published crate.
+- `no_std + alloc` builds must remain in CI.
+- Memory growth and maximum input/output sizing behavior must be documented.
+
+**Acceptance:** browser/WASI smoke tests and `thumbv7em` builds pass on every
+release candidate.
+
+### FR5. TurboJPEG 3 C ABI
+
+- The supported TJ3 symbol set must be complete and versioned in the reference
+  document.
+- Missing legacy aliases must have a migration mapping or a deliberate
+  compatibility decision.
+- Release bundles must include headers, shared/static linkage metadata, and
+  reproducible install instructions.
+
+**Acceptance:** the shipped bundle, not only the raw Cargo cdylib, passes stock
+TJ3 tools and representative downstream harnesses.
+
+### FR6. Classic libjpeg v8 pilot path
+
+- The project must preserve the v8 identity and reject incompatible create-time
+  version/size pairs.
+- Ownership, lifecycle, suspension, error, source/destination manager,
+  threading, option, precision, and symbol-version contracts must each have
+  executable differential coverage.
+- The classic path remains experimental until every P0/P1 release gate for T3
+  is closed.
+
+**Acceptance:** T3 promotion requires a dedicated release-gate change and
+public downstream evidence; documentation changes alone cannot promote it.
+
+### FR7. Release artifacts
+
+- Linux and macOS x86_64/aarch64 bundles remain reproducible.
+- Windows x64 and Arm64 bundles, including import libraries, are required for
+  broad C ABI adoption.
+- Artifacts must publish provenance/signatures, checksums, and an SBOM.
+
+**Acceptance:** a clean machine can verify, install, compile a sample, and run
+it without a Rust toolchain.
+
+## 13. Quality requirements
+
+### QR1. Correctness
+
+- Pinned libjpeg-turbo 3.1.x and 3.2.x oracles remain in CI where behavior may
+  differ across versions.
+- Every claimed feature has an end-to-end public-path test.
+- Differential tests must account for every attempted case; silent skip or
+  catch-all success branches are prohibited.
+
+### QR2. Memory safety and unsafe-code discipline
+
+- No known UB may remain reachable from the safe Rust API for `1.0`.
+- All public-size and layout arithmetic must flow through centralized checked
+  abstractions or an enforced equivalent.
+- Every unsafe function and block must have a documented safety contract and a
+  test strategy.
+- Miri, AddressSanitizer, fuzzing, and code review are complementary; no single
+  tool is a proof of safety.
+
+### QR3. Performance
+
+- Benchmarks report portable and native builds separately.
+- Every result records processor, operating system, compiler, Rust toolchain,
+  C oracle version, build flags, image corpus, warmup, sample count, and noise
+  threshold.
+- Regressions greater than 5% on a supported representative workload require
+  investigation; exceptions need a documented correctness or maintainability
+  justification.
+- Small-image latency, large-image throughput, progressive workloads,
+  transforms, reusable-buffer paths, and adapter overhead are measured
+  separately.
+
+### QR4. Portability
+
+- x86_64 and aarch64 Linux/macOS/Windows are first-class Rust API targets.
+- Wasm is first-class for browser/WASI decode/encode within documented limits.
+- armv7 and RVV are not described as performance-competitive until measured on
+  hardware with production SIMD paths.
+
+### QR5. Reliability and security
+
+- Fuzz targets cover parser, entropy, transform, metadata, high-precision, and
+  C ABI entry points.
+- Release candidates pass release-mode tests, sanitizers, fuzz smoke, corpus
+  tests, and cross-architecture jobs.
+- A private vulnerability-reporting path and supported-version policy are
+  required before `1.0`.
+
+### QR6. API stability
+
+- `1.0` requires a documented SemVer policy for public Rust APIs and feature
+  flags.
+- MSRV changes occur only in minor versions and are called out in the
+  changelog.
+- C ABI behavior is versioned independently from Rust API SemVer where needed.
+
+## 14. Success metrics
+
+### 14.1 North-star metric
+
+**Verified production workloads using a supported `libjpeg-turbo-rs`
+integration path.**
+
+A workload is verified when the adopter, integration repository, public case
+study, or reproducible downstream test identifies the path and version in use.
+Download counts alone do not prove adoption.
+
+### 14.2 Trust and readiness metrics
+
+For a `1.0` release candidate:
+
+- zero known safe-API UB defects;
+- zero red required release-mode gates for 30 consecutive days;
+- 100% of public unsafe boundaries listed in an auditable inventory;
+- all supported artifacts built, verified, and tested from their packaged
+  form;
+- portable benchmark report available for every first-class architecture;
+- signed/attested artifacts plus SBOM;
+- no stale readiness statement detected by the documentation gate.
+
+### 14.3 Adoption targets
+
+Within twelve months of `1.0`:
+
+- at least 10 publicly identifiable production adopters across at least three
+  product categories;
+- at least 3 accepted or maintained downstream ecosystem integrations;
+- at least 2 regular non-maintainer contributors owning a tested subsystem;
+- at least 2 public migration case studies, including one C/TurboJPEG pilot;
+- measurable growth in 90-day crate downloads and reverse dependencies from
+  the baseline captured at the `1.0` tag.
+
+These are product targets, not compatibility evidence. Missing an adoption
+target does not justify weakening a release gate.
+
+### 14.4 Developer-experience targets
+
+- first successful decode from the README in under 10 minutes;
+- representative Rust-native evaluation in under 1 hour;
+- C ABI bundle verification and sample link in under 30 minutes on a supported
+  platform;
+- no more than one documentation hop from a readiness warning to the exact
+  live gate item.
+
+## 15. Milestones
+
+### M0. Adoption documentation baseline
+
+Deliver:
+
+- this PRD;
+- an adoption and migration guide;
+- a shorter, decision-oriented README;
+- a documentation index;
+- contribution and pull-request evidence requirements;
+- corrected safety/readiness wording across crate READMEs.
+
+Exit criterion: a new evaluator can identify the correct integration path and
+known blockers without reading every engineering tracker.
+
+### M1. Trustworthy `0.9`
+
+Priority work:
+
+- close P4-170 and make the full release-mode workspace gate green;
+- finish or explicitly bound P4-139 layout centralization;
+- implement P4-141-style automated unsafe-boundary regression detection;
+- test the exact shipped C ABI artifact in all downstream harnesses (P4-124);
+- publish a reproducible portable-vs-native benchmark report;
+- add documentation-drift CI.
+
+Exit criterion: T1 and T2 have green, repeatable release evidence, with no
+known safe-API UB and no required red gate.
+
+### M2. Migration-ready `1.0`
+
+Priority work:
+
+- freeze and document the public Rust API and feature-flag policy;
+- publish a security policy and private reporting route;
+- ship Windows native artifacts;
+- add signed build provenance and SBOMs;
+- complete clean-machine artifact install tests;
+- validate at least three external pilot workloads;
+- publish the `1.0` evidence bundle and limitations.
+
+Exit criterion: Rust-native adoption is low-friction and release artifacts are
+suitable for a production dependency review.
+
+### M3. Ecosystem expansion
+
+Priority work:
+
+- upstream or co-maintain integrations in major Rust image/computer-vision
+  crates;
+- publish framework adapters only where they have maintainers and tests;
+- provide benchmark dashboards generated from reproducible result files;
+- add migration case studies and adopter references;
+- pursue distribution packages after T3 risk is appropriately scoped.
+
+Exit criterion: most new users arrive through maintained ecosystem paths, not
+only the root crate page.
+
+### M4. Classic C replacement expansion
+
+Priority work:
+
+- eliminate the stricter cross-thread `cinfo` ownership divergence (P4-132);
+- close remaining classic lifecycle, option, error, precision, and suspension
+  gaps;
+- test packaged libraries against representative prebuilt consumers;
+- decide whether per-ABI v6b/v7 variants are worth the maintenance cost.
+
+Exit criterion: T3 is promoted only if its complete live gate is green. T4
+remains a separate product decision.
+
+## 16. Prioritized backlog
+
+### P0: blocks trustworthy adoption
+
+1. Fix P4-170: release-only classic source-manager parity failures.
+2. Keep the required release-mode workspace gate green on every pull request.
+3. Complete the remaining checked-layout centralization and enforcement in
+   P4-139.
+4. Add automated detection for unsafe dispatch/boundary regressions as tracked
+   by P4-141.
+5. Run downstream compatibility harnesses against the exact release bundle
+   (P4-124), not an intermediate library.
+6. Remove stale or contradictory readiness wording automatically.
+7. Establish a private security-reporting route before `1.0`.
+
+### P1: directly increases adoption
+
+1. Close the portable x86_64 performance gap without requiring
+   `target-cpu=native` where practical (#464).
+2. Produce Windows x64/Arm64 C ABI bundles.
+3. Add signatures/provenance and SBOMs to every native release.
+4. Remove the classic C API thread-ownership divergence (P4-132/#463).
+5. Maintain a public, reproducible benchmark result format and dashboard.
+6. Pursue at least one upstream `image` ecosystem integration and one
+   computer-vision/media integration.
+7. Publish migration case studies with rollback and benchmark results.
+
+### P2: expands addressable platforms and workloads
+
+1. Implement and measure AArch32 NEON if adopter demand justifies it.
+2. Implement and measure RISC-V Vector support (#465).
+3. Evaluate POWER and s390x optimization only with hardware and adopter
+   sponsorship.
+4. Add package-manager integration after artifact and compatibility gates are
+   mature.
+5. Consider per-ABI v6b/v7 libraries only as separate tested artifacts, never
+   as SONAME aliases of the v8 layout.
+
+## 17. Definition of done for `1.0`
+
+`1.0` is ready only when all of the following are true:
+
+- [ ] Full required workspace tests pass in release mode on the first-class
+      matrix.
+- [ ] No known UB is reachable through the safe Rust API.
+- [ ] Unsafe-code inventory, contracts, Miri/sanitizer/fuzz coverage, and
+      manual audit status are published.
+- [ ] Public layout/size arithmetic is centralized or equivalently enforced.
+- [ ] T1 and T2 claims are tested against the exact packaged artifacts.
+- [ ] T3 remains explicitly experimental unless its separate gate is green.
+- [ ] Portable and native performance reports are clearly separated and
+      reproducible.
+- [ ] Linux, macOS, and Windows first-class artifacts are available where
+      applicable.
+- [ ] Release artifacts have checksums, signatures or attestations, and SBOMs.
+- [ ] Security policy, supported-version policy, and disclosure path exist.
+- [ ] SemVer, MSRV, feature-flag, deprecation, and compatibility policies are
+      documented.
+- [ ] At least three independent pilot workloads have passed their own
+      correctness and performance acceptance criteria.
+- [ ] README, adoption guide, API docs, ABI docs, and live gate agree.
+
+## 18. Release evidence bundle
+
+Every release candidate should publish or link to a machine-readable and human
+readable bundle containing:
+
+- source commit and dirty-tree status;
+- Rust, LLVM, C compiler, and linker versions;
+- pinned C oracle versions and hashes;
+- supported target matrix and feature flags;
+- release-mode test summary with exact pass/fail/ignore accounting;
+- fuzz and sanitizer summary;
+- corpus and differential-test summary;
+- portable and native benchmark results with methodology;
+- artifact hashes, signatures/attestations, and SBOM;
+- API/ABI compatibility changes;
+- current T1-T4 status;
+- known limitations and rollback instructions.
+
+## 19. Contribution and governance rules
+
+- Work is prioritized by P0/P1/P2 impact in this PRD and the live release gate.
+- A pull request that changes readiness, performance, feature parity, or ABI
+  behavior must update the corresponding source-of-truth document.
+- New dependencies require a documented maintenance, security, MSRV, and
+  binary-size justification.
+- New architecture backends require scalar equivalence tests, feature
+  detection, unsupported-CPU behavior, and hardware benchmarks.
+- New public APIs require documentation, examples, tests, and a compatibility
+  rationale.
+- Agents and unattended issue loops must not close tracker items based only on
+  code presence; acceptance criteria and evidence must be satisfied.
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) and
+[`.github/pull_request_template.md`](.github/pull_request_template.md).
+
+## 20. Risks and mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Overclaiming safety or drop-in compatibility | Production failures and loss of trust | Tiered status, live-gate links, documentation-drift CI, explicit unsupported paths |
+| Benchmark cherry-picking | Adopters choose the codec on misleading evidence | Portable/native separation, dated matrices, raw results, representative workload categories |
+| Unsafe SIMD regression | Memory corruption reachable from safe Rust | Centralized dispatch contracts, unsafe inventory, Miri/sanitizers/fuzzing, manual review |
+| Maintainer overload | Stalled issues and fragile integrations | Narrow first-class matrix, subsystem ownership, contribution evidence template, reject unsupported surfaces |
+| Upstream C advances faster | Performance or feature gap widens | Track current stable and previous stable oracle, currency CI, adoption-priority backlog |
+| C ABI scope consumes Rust API roadmap | Core Rust experience stagnates | T1/T2 first; T3 work gated by adopter evidence and separate milestones |
+| Packaging increases support burden | Broken releases across toolchains | Reproducible scripts, clean-machine tests, artifact attestations, explicit supported environments |
+| Low ecosystem visibility | Strong implementation remains unused | Downstream integrations, case studies, concise README, docs index, stable bridge crates |
+
+## 21. Open product decisions
+
+The maintainer must eventually decide:
+
+1. whether T3 classic libjpeg replacement is a core `1.x` commitment or a
+   separately versioned compatibility product;
+2. whether first-party deb/rpm/Homebrew/Windows package-manager distribution is
+   sustainable;
+3. which downstream integrations have committed co-maintainers;
+4. whether v6b/v7 per-ABI builds justify their test and release matrix cost;
+5. what support window applies to pre-1.0 and post-1.0 releases;
+6. which performance architectures are first-class after x86_64/aarch64/Wasm;
+7. which private security-reporting channel will be maintained long term.
+
+## 22. References
+
+- [libjpeg-turbo upstream repository](https://github.com/libjpeg-turbo/libjpeg-turbo)
+- [libjpeg-turbo 3.2.0 release](https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/3.2.0)
+- [Official libjpeg-turbo documentation](https://libjpeg-turbo.org/Documentation/Documentation)
+- [Official libjpeg-turbo binary policy](https://libjpeg-turbo.org/Documentation/OfficialBinaries)
+- [`docs/LAST_MILE.md`](docs/LAST_MILE.md)
+- [`docs/FEATURE_PARITY.md`](docs/FEATURE_PARITY.md)
+- [`docs/ABI_COMPATIBILITY.md`](docs/ABI_COMPATIBILITY.md)
+- [`docs/TEST_PARITY.md`](docs/TEST_PARITY.md)
+- [`docs/CORPUS_TEST_REPORT.md`](docs/CORPUS_TEST_REPORT.md)
+- [`docs/RELEASE_ARTIFACTS.md`](docs/RELEASE_ARTIFACTS.md)

--- a/README.md
+++ b/README.md
@@ -6,265 +6,171 @@
 ![MSRV](https://img.shields.io/badge/MSRV-1.87-blue)
 ![license](https://img.shields.io/crates/l/libjpeg-turbo-rs)
 
-Pure-Rust reimplementation of [libjpeg-turbo](https://github.com/libjpeg-turbo/libjpeg-turbo) with NEON/AVX2/SSE2/WASM-SIMD128 acceleration. No C dependencies, no FFI to a C codec, `no_std`-capable — and byte-for-byte cross-validated against C libjpeg-turbo in CI.
+A high-performance, pure-Rust JPEG codec inspired by
+[libjpeg-turbo](https://github.com/libjpeg-turbo/libjpeg-turbo), with
+NEON/AVX2/SSE2/WebAssembly SIMD128 acceleration, `no_std + alloc` support,
+Rust-native streaming and buffer-reuse Application Programming Interfaces
+(APIs), and extensive differential validation against pinned C
+libjpeg-turbo oracles.
 
-> **Safety status.** "No C dependencies" is not "no unsafe code" — the SIMD kernels are `unsafe`, and the boundary between them and the safe API is under audit (P4-135..P4-139 in [`docs/LAST_MILE.md`](docs/LAST_MILE.md)). Until those close this project makes **no memory-safety guarantee** and no unqualified drop-in-replacement claim.
->
-> **C compatibility tiers.** **TurboJPEG 3 is the primary target.** The classic libjpeg leg targets the **v8 identity only** (`libjpeg.so.8`) and is experimental; **v6b (`libjpeg.so.62`) and v7 are explicit non-goals** — their struct layouts differ, so substituting this library for them corrupts memory rather than merely failing.
+The Rust codec does **not** call a C JPEG implementation through a Foreign
+Function Interface (FFI). "Pure Rust" does not mean "no `unsafe`":
+architecture-specific Single Instruction, Multiple Data (SIMD) kernels and the
+optional C Application Binary Interface (ABI) shim use narrowly scoped unsafe
+code.
 
-```sh
+```bash
 cargo add libjpeg-turbo-rs
 ```
 
 ```rust
 use libjpeg_turbo_rs::{compress, decompress_to, PixelFormat, Subsampling};
 
-let image = decompress_to(&jpeg_bytes, PixelFormat::Rgb)?; // decode any JPEG to RGB
-let jpeg = compress(&image.data, image.width, image.height,
-                    image.pixel_format, 85, Subsampling::S420)?; // re-encode
+let image = decompress_to(&jpeg_bytes, PixelFormat::Rgb)?;
+let encoded = compress(
+    &image.data,
+    image.width,
+    image.height,
+    PixelFormat::Rgb,
+    85,
+    Subsampling::S420,
+)?;
 ```
 
-The crate-level doctests mirror these snippets and are compile-checked
-(`cargo test --doc`); the doctest decode calls `decompress`, the
-format-defaulting sibling of `decompress_to`. Runnable examples live in
-[`examples/`](examples/README.md).
+## Should I use it?
 
-## How it compares
+Choose the interface you actually need. The readiness of one interface does
+not promote the others.
 
-Measured with the in-repo harnesses (methodology: [#361](https://github.com/developer0hye/libjpeg-turbo-rs/issues/361), [#392](https://github.com/developer0hye/libjpeg-turbo-rs/issues/392); `examples/bench_zune_matrix.rs`, `experiments/image_bridge.md`):
-
-| vs | Result (decode) |
-| --- | --- |
-| **zune-jpeg** (the `image` crate's default) | **31 wins / 3 losses** of 34 scored cases (±2% threshold) across subsampling × progressive × 16×16→8K, quiet aarch64, 2026-07-28; e.g. 4K progressive **0.65×**, 4K 4:2:0 **0.74×** of zune's time. Through the `image`-crate bridge: **1.31× faster** at 1080p. Two losses are 16×16 fixed-cost cases (1.20×, 1.08×); the third is a 64×64 non-interleaved 4:4:0 image (1.78×) on the multi-scan path. Full output: [`experiments/zune_matrix_aarch64_2026-07-28.md`](experiments/zune_matrix_aarch64_2026-07-28.md). |
-| **C libjpeg-turbo** | **Decode** (stock `cargo build --release`): matches or beats C on most benchmarks on x86_64/AVX2 (i5-10400), within a few % on aarch64/NEON (M1 Pro). **Encode**: the x86_64 tables below are built with `RUSTFLAGS="-C target-cpu=native"`, not a stock release build — see [Portable vs native builds](#portable-vs-native-builds) before quoting them. Dated per-platform tables below. |
-
-## Performance
-
-### x86_64 (AVX2)
-
-Intel Core i5-10400 @ 2.90GHz (turbo off, `performance` governor), C libjpeg-turbo 3.1.2, quality 75:
-
-#### Decoding
-
-| Image | Subsampling | Rust (us) | C (us) | Ratio |
-|-------|-------------|-----------|--------|-------|
-| 64x64 | 4:2:0 | 60 | 49 | 1.23x |
-| 320x240 | 4:2:0 | 769 | 996 | **0.77x** |
-| 640x480 | 4:2:0 | 929 | 880 | 1.05x |
-| 640x480 | 4:2:2 | 3,267 | 3,480 | **0.94x** |
-| 640x480 | 4:4:4 | 4,794 | 5,525 | **0.87x** |
-| 1280x720 | 4:2:0 | 8,707 | 9,997 | **0.87x** |
-| 1920x1080 | 4:2:0 | 19,736 | 22,031 | **0.90x** |
-| 1920x1080 | 4:2:2 | 25,382 | 26,227 | **0.97x** |
-| 1920x1080 | 4:4:4 | 37,585 | 40,026 | **0.94x** |
-| 2560x1440 | 4:2:0 | 35,137 | 37,918 | **0.93x** |
-| 3840x2160 | 4:2:0 | 78,868 | 89,325 | **0.88x** |
-
-#### Encoding (built with `RUSTFLAGS="-C target-cpu=native"`)
-
-| Image | Subsampling | Rust (µs) | C (µs) | Ratio |
-|-------|-------------|-----------|--------|-------|
-| 320x240 | 4:2:0 | 381 | 403 | **0.94x** |
-| 320x240 | 4:2:2 | 474 | 508 | **0.93x** |
-| 320x240 | 4:4:4 | 709 | 764 | **0.93x** |
-| 640x480 | 4:2:2 | 1,653 | 1,731 | **0.96x** |
-| 640x480 | 4:4:4 | 2,397 | 2,558 | **0.94x** |
-| 1920x1080 | 4:2:0 | 10,273 | 10,474 | **0.98x** |
-| 1920x1080 | 4:2:2 | 12,783 | 13,082 | **0.98x** |
-| 1920x1080 | 4:4:4 | 19,057 | 19,873 | **0.96x** |
-
-### aarch64 (NEON)
-
-Apple M1 Pro, C libjpeg-turbo 3.1.0, quality 75:
-
-#### Decoding (1920x1080)
-
-| Subsampling | Rust (µs) | C (µs) | Ratio |
-|-------------|-----------|--------|-------|
-| 4:2:0 | 12,159 | 11,333 | 1.07x |
-| 4:2:2 | 15,246 | 15,329 | **0.99x** |
-| 4:4:4 | 22,972 | 23,130 | **0.99x** |
-
-#### Encoding (1920x1080)
-
-| Subsampling | Rust (µs) | C (µs) | Ratio |
-|-------------|-----------|--------|-------|
-| 4:2:0 | 5,724 | 5,332 | 1.07x |
-| 4:2:2 | 7,148 | 6,766 | 1.06x |
-| 4:4:4 | 10,596 | 10,272 | 1.03x |
-
-**aarch64**: Decoding matches or beats C for 4:2:2 and 4:4:4; 4:2:0 has a 7% gap. Encoding matches or beats C in 7 of 8 configurations (see [`docs/ENCODING_PERFORMANCE.md`](docs/ENCODING_PERFORMANCE.md)); the remaining 1080p 4:2:0 gap (~4%) is structural function-call overhead.
-
-**x86_64**: Decoding beats C across most resolutions. Encoding (with `target-cpu=native`) beats C in every benchmark above by 2–7 %; the encoder runs SSE2 Huffman + AVX2 FDCT/quantize/color/downsample. The Huffman bitmap-iteration hot path uses runtime `is_x86_feature_detected!("bmi1") && is_x86_feature_detected!("lzcnt")` dispatch (P4-8, see `src/encode/huffman_encode.rs:508,580,703`) so a stock `cargo build --release` automatically lights up TZCNT/BLSR/LZCNT on any CPU that supports them — no `RUSTFLAGS` needed for the AC-encoding inner loop. `target-cpu=native` still wins because it unlocks BMI2 PEXT/PDEP and FMA in code paths the runtime dispatch does not yet cover (FDCT scalar fallback, scalar quantization tail), so the recommendation stands for the last few percent: `RUSTFLAGS="-C target-cpu=native"` (best) or `-C target-feature=+bmi1,+lzcnt,+bmi2,+fma`. Pre-P4-8 the stock baseline trailed C by 5–10 pp at 1080p; that gap is now < 2 pp on a Haswell-class CPU.
-
-## Quick Start
-
-```toml
-[dependencies]
-libjpeg-turbo-rs = "0.8"
-
-# Optional: enable PNG support for tj3LoadImage8 / tj3SaveImage8
-# libjpeg-turbo-rs = { version = "0.8", features = ["png"] }
-```
-
-### Build flags
-
-
-#### Portable vs native builds
-
-Two numbers exist and they are not interchangeable (P4-133 / [#464](https://github.com/developer0hye/libjpeg-turbo-rs/issues/464)):
-
-- **Portable** — plain `cargo build --release`. This is what a distribution ships and what a packager should judge the project on. AVX2/NEON/SSE2 kernels are still reached, by runtime detection.
-- **Native** — `RUSTFLAGS="-C target-cpu=native"`. Faster, but the binary is only valid on CPUs matching the build host.
-
-**The x86_64 encoding table below is a native build.** The remaining native-only win is BMI2 PEXT/PDEP and FMA in paths runtime dispatch does not yet cover; moving those behind `cpu_has!` so a portable build reaches them is #464, and the per-benchmark delta is unmeasured until then — treat "the last few percent" as a claim awaiting measurement, not a result.
-
-
-#### x86_64
-
-For x86_64 production builds, set:
-
-```sh
-RUSTFLAGS="-C target-cpu=native" cargo build --release
-# or, for a portable v3 baseline:
-RUSTFLAGS="-C target-feature=+bmi1,+lzcnt,+bmi2,+fma" cargo build --release
-```
-
-This unlocks BMI1 / LZCNT / BMI2 / FMA in the encoder's scalar
-bitmap-iteration hot path, which the C reference's NASM SIMD already
-embeds. Without these flags `cargo build --release` defaults to the
-SSE2-only `x86_64-v1` baseline and the encoder trails C by 5–10 pp at
-1080p; with them, Rust beats C in every encode benchmark in the
-Performance section above. aarch64 / NEON builds are unaffected.
-
-#### 32-bit ARM (`armv7`) — measure before you ship it
-
-The `armv7-unknown-linux-gnueabihf` target carries `-neon` in its baseline,
-so LLVM's auto-vectoriser never runs on our kernels there — on `x86_64`,
-where SSE2 *is* baseline, the same code vectorises silently. Enabling the
-feature turns it back on with no `unsafe` and no intrinsics:
-
-```sh
-RUSTFLAGS="-C target-feature=+neon -C target-cpu=cortex-a7" cargo build --release \
-  --target armv7-unknown-linux-gnueabihf
-```
-
-Measured effect on the generated code (`experiments/armv7_autovec_2026-07-30.md`):
-`idct_8x8` goes from 0 to 270 vector instructions, `ycbcr_to_rgb_row` 0 to
-140, `fancy_h2v2_row` 0 to 232; 204/204 tests still pass under `qemu-arm`.
-
-**This is not a recommended default, for two reasons.** `target-feature` is
-compile-time, so a `+neon` binary **crashes with SIGILL on an ARMv7 core
-that has no NEON** (C ships one binary for both by probing `/proc/cpuinfo`;
-a compile-time flag cannot). And it is **unmeasured on hardware**: the only
-A/B available was under emulation, which models no pipeline, cache, or
-NEON↔ARM register transfer cost — the very things that make
-auto-vectorised code regress on Cortex-A8 (transfer stalls) and A7/A9
-(64-bit NEON datapath). Set `-C target-cpu=` to your actual core, A/B it
-per kernel on the real device, and keep it off if you cannot.
-
-## Feature flags, MSRV, platforms
-
-**MSRV: 1.87** for the root and capi crates, CI-enforced (`cargo +1.87
-check` job). The `image`-bridge crate is 1.88 (inherited from
-`image@0.25`). MSRV bumps are considered minor, never patch, changes and
-are called out in `CHANGELOG.md`.
-
-| Target | SIMD | Notes |
+| Your workload | Path | Current status |
 | --- | --- | --- |
-| `aarch64` (Linux/macOS) | NEON | compile-time selection, CI-tested |
-| `x86_64` (Linux/macOS/Windows) | AVX2/SSE2 | runtime CPUID dispatch (`std`), CI-tested incl. no-AVX2 emulation |
-| `wasm32` (browser/WASI) | SIMD128 | compile-time `target_feature` — see the wasm crate README |
-| RISC-V / POWER / s390x | scalar | works, unoptimized. The ~1.1–1.7× C advantage measured in [#359](https://github.com/developer0hye/libjpeg-turbo-rs/issues/359) was **scalar vs scalar**; libjpeg-turbo **3.2.0 added RISC-V Vector (RVV)**, so on RVV hardware the real gap is larger and currently **unmeasured** ([#465](https://github.com/developer0hye/libjpeg-turbo-rs/issues/465)). POWER/s390x remain scalar on both sides. |
-| `armv7` / 32-bit ARM (Cortex-A) | scalar | CI-tested: 204 tests run under `qemu-arm`. Our widest gap: C *does* vectorize 32-bit ARM (AArch32 NEON), we do not — **estimated** 2–5× slower, not yet measured on hardware ([#424](https://github.com/developer0hye/libjpeg-turbo-rs/issues/424), [P4-78](docs/last_mile/phase4.md#p4-78-no-32-bit-arm-aarch32-neon-backend--armv7-is-our-widest-gap-vs-c--open)) |
-| `thumbv7em` (bare metal) | scalar | `no_std + alloc`, CI-built; no NEON backend is registered for thumb targets |
+| Rust application or library | [`libjpeg-turbo-rs`](https://crates.io/crates/libjpeg-turbo-rs) | **T1:** feature-rich and appropriate for evaluation or production use after reviewing the live limitations below |
+| Rust code using `image` traits | [`libjpeg-turbo-rs-image`](crates/libjpeg-turbo-rs-image) | Maintained bridge; validate color mapping and adapter overhead for your workload |
+| Browser or WebAssembly System Interface (WASI) | [`libjpeg-turbo-rs-wasm`](crates/libjpeg-turbo-rs-wasm) | Supported; explicit `+simd128` compiler configuration is required outside this repository for the hand-written SIMD path |
+| C/C++ using TurboJPEG 3 (`tj3*`) | [`libjpeg-turbo-rs-capi`](crates/libjpeg-turbo-rs-capi) | **T2:** primary C ABI target; use the symbol matrix and test the exact packaged artifact |
+| Prebuilt C/C++ using classic libjpeg v8 (`libjpeg.so.8`) | Experimental v8 shim | **T3:** controlled pilots only; not a general system-library replacement |
+| Prebuilt C/C++ using libjpeg v6b or v7 | None | **T4:** unsupported as a drop-in replacement because the exposed C structure layouts differ |
 
+Read [`docs/ADOPTION_GUIDE.md`](docs/ADOPTION_GUIDE.md) for the decision tree,
+evaluation checklist, migration steps, production rollout, stop conditions,
+and rollback plan.
 
-| flag | default | effect |
-|---|---|---|
-| `std` | ✅ | `std::io` streaming API (`decompress_from_reader`, `compress_to_writer`, bounded-memory `decompress_from_reader_incremental`), file-path helpers, PNG image I/O, runtime CPU-feature detection, and `std::io::Error` interop. |
-| `simd` | ✅ | Architecture intrinsics: NEON (aarch64), SSE2/AVX2 (x86_64), SIMD128 (wasm32). |
-| `png` | ❌ | PNG support for `tj3LoadImage8` / `tj3SaveImage8` (implies `std`). |
+## Current readiness
 
-**`no_std` + `alloc`**: build with `--no-default-features` for the core
-codec — headers, entropy decode, IDCT, upsample, colour convert, and
-encode all work. `alloc` is required (the decoder allocates pixel and
-coefficient buffers). Without `std` there is no CPUID probe, so SIMD
-dispatches on compile-time `target_feature` only; pass `-C
-target-feature=+neon` (or equivalent) to vectorise a bare-metal build.
-CI builds the crate for `thumbv7em-none-eabihf` on every PR.
+The canonical, continuously maintained readiness source is
+[`docs/LAST_MILE.md`](docs/LAST_MILE.md). This summary deliberately avoids an
+unqualified "drop-in replacement" claim.
 
-### Decompress
+### Rust API
+
+The major safe-API Undefined Behavior (UB) defects found during the 2026-08
+audit are recorded as closed, and the live gate reports no known remaining UB
+reachable through the safe Rust API. A formal memory-safety guarantee still
+requires the remaining checked-layout centralization and automated unsafe-path
+regression detection tracked by P4-139 and P4-141.
+
+The full release-mode workspace gate is currently **red** because of P4-170:
+two classic source-manager differential tests pass in debug mode and fail in
+release mode. That does not imply that every Rust-native decode or encode path
+fails, but it does mean the complete release gate must not be described as
+green until the issue closes and the matrix is re-measured.
+
+### C compatibility
+
+- **TurboJPEG 3 is the primary C ABI target.** Its opaque handles avoid the
+  version-dependent public-structure risk of classic libjpeg. Legacy
+  TurboJPEG 1.x/2.x aliases are only partially covered; use the migration
+  matrix in [`docs/ABI_COMPATIBILITY.md`](docs/ABI_COMPATIBILITY.md).
+- **Classic libjpeg targets the v8 identity only** (`libjpeg.so.8`) and remains
+  experimental and partial. Open lifecycle, option, error, threading,
+  artifact-validation, and downstream-coverage gaps are tracked in the live
+  gate.
+- **v6b (`libjpeg.so.62`) and v7 (`libjpeg.so.7`) are not drop-in targets.**
+  Renaming a v8-layout library does not make it binary-compatible with a
+  consumer compiled against a different structure layout.
+
+## Why choose it over a C binding?
+
+For workloads that can use a Rust-native API, the project is designed to
+remove adoption costs that codec benchmarks alone do not capture:
+
+- one Cargo dependency rather than a C compiler, CMake/NASM setup, system
+  package discovery, bindings, and platform-specific link configuration;
+- Rust ownership, result types, builders, scanline/streaming APIs, and
+  caller-owned reusable output buffers;
+- one codec codebase for native, `no_std + alloc`, and WebAssembly (Wasm)
+  targets;
+- coefficient-domain transforms, metadata access, high-precision and lossless
+  paths without crossing an FFI boundary;
+- reproducible C-oracle differential tests, fuzzing, sanitizers, corpus tests,
+  and explicit compatibility tiers;
+- competitive measured performance on the strongest current targets: x86_64
+  and aarch64.
+
+The C implementation remains the safer choice when you require its installed
+base, a v6b/v7 ABI, official platform packaging this project does not ship, an
+uncovered architecture SIMD backend, or a classic libjpeg behavior that has
+not passed this project's live replacement gate.
+
+## Quick start
+
+### Decode
 
 ```rust
 use libjpeg_turbo_rs::{decompress, decompress_to, PixelFormat};
 
-// Decode to RGB
-let img = decompress(&jpeg_bytes)?;
-println!("{}x{}", img.width, img.height);
+let rgb = decompress(&jpeg_bytes)?;
+println!("{}x{}", rgb.width, rgb.height);
 
-// Decode to specific format
-let img = decompress_to(&jpeg_bytes, PixelFormat::Rgba)?;
-
-// Decode into a caller-owned, reusable buffer (no per-frame output allocation)
-use libjpeg_turbo_rs::{decompress_into, output_buffer_size};
-let size = output_buffer_size(&jpeg_bytes, PixelFormat::Rgb)?;
-let mut out = vec![0u8; size];
-let info = decompress_into(&jpeg_bytes, PixelFormat::Rgb, &mut out)?;
-println!("{}x{} ({} bytes)", info.width, info.height, info.bytes_written);
+let rgba = decompress_to(&jpeg_bytes, PixelFormat::Rgba)?;
 ```
 
-### Compress
+### Decode into reusable memory
+
+```rust
+use libjpeg_turbo_rs::{decompress_into, output_buffer_size, PixelFormat};
+
+let required = output_buffer_size(&jpeg_bytes, PixelFormat::Rgb)?;
+let mut output = vec![0_u8; required];
+let info = decompress_into(&jpeg_bytes, PixelFormat::Rgb, &mut output)?;
+let pixels = &output[..info.bytes_written];
+```
+
+Keep and reuse the allocation in frame loops or services instead of measuring
+only the one-shot convenience path.
+
+### Encode
 
 ```rust
 use libjpeg_turbo_rs::{compress, PixelFormat, Subsampling};
 
-let jpeg = compress(&rgb_pixels, width, height, PixelFormat::Rgb, 85, Subsampling::S420)?;
+let jpeg = compress(
+    &rgb_pixels,
+    width,
+    height,
+    PixelFormat::Rgb,
+    85,
+    Subsampling::S420,
+)?;
 ```
 
-### Builder API
+### Configure advanced encoding
 
 ```rust
-use libjpeg_turbo_rs::Encoder;
+use libjpeg_turbo_rs::{Encoder, PixelFormat, Subsampling};
 
 let jpeg = Encoder::new(&pixels, width, height, PixelFormat::Rgb)
     .quality(85)
     .subsampling(Subsampling::S420)
     .progressive(true)
     .optimize_huffman(true)
-    .icc_profile(&icc_data)
-    .xmp_data(&xmp_packet)   // APP1 XMP
-    .iptc_data(&iptc_iim)    // APP13 Photoshop IRB
+    .icc_profile(&icc_profile)
+    .xmp_data(&xmp_packet)
+    .iptc_data(&iptc_iim)
     .encode()?;
 ```
 
-Every builder option composes with every other, on every colorspace and in
-every mode — including CMYK, and `colorspace(Rgb)` with `progressive`,
-`arithmetic` or `lossless`
-([#313](https://github.com/developer0hye/libjpeg-turbo-rs/issues/313),
-[#322](https://github.com/developer0hye/libjpeg-turbo-rs/issues/322),
-[#343](https://github.com/developer0hye/libjpeg-turbo-rs/issues/343),
-[#345](https://github.com/developer0hye/libjpeg-turbo-rs/issues/345)).
-
-### Composing baseline options
-
-`Encoder` covers the common cases; `CompressParams` is the baseline core
-underneath it, and takes every option at once — on every pixel format, CMYK
-included.
-
-```rust
-use libjpeg_turbo_rs::encode::pipeline::{compress_with_params, CompressParams};
-
-let jpeg = compress_with_params(
-    &CompressParams::new(&rgb_pixels, width, height, PixelFormat::Rgb, 85, Subsampling::S420)
-        .dct_method(DctMethod::IsFast)
-        .restart_interval(8)
-        .custom_quant(&quant_tables)
-        .custom_huffman(&dc_tables, &ac_tables),
-)?;
-```
-
-### Lossless Transform
+### Lossless coefficient transform
 
 ```rust
 use libjpeg_turbo_rs::{transform, TransformOp};
@@ -272,154 +178,243 @@ use libjpeg_turbo_rs::{transform, TransformOp};
 let rotated = transform(&jpeg_bytes, TransformOp::Rot90)?;
 ```
 
-`transform` preserves metadata (EXIF/ICC/COM markers) by default, matching
-C TurboJPEG's `tjTransform`; use `transform_jpeg_with_options` with
-`MarkerCopyMode::None` to strip markers.
+Transforms rotate, flip, transpose, or crop Discrete Cosine Transform (DCT)
+coefficients without decoding pixels. Metadata is preserved by default; use
+`transform_jpeg_with_options` when you need an explicit marker-copy policy.
 
-Lossless transforms are coefficient-domain: they entropy-decode to DCT
-coefficients, permute blocks, and entropy-encode — no pixels are ever
-produced, so the pixel-path SIMD (IDCT / color convert / upsample) is not
-involved and transform throughput rides on scalar codegen. Build with the
-default release profile (`opt-level = 3`); a size-optimized profile
-(`opt-level = "z"`) roughly halves transform throughput. `-C
-target-cpu=native` buys only a further ~3% (measured on a 24 MP rot90,
-Zen 4; issue #308 has the full numbers).
-
-### EXIF Orientation (load a phone photo the right way up)
-
-Nearly every camera JPEG carries an EXIF orientation tag. Read it from
-the header alone — no pixel decode — and apply it in whichever domain
-fits (issue #391):
-
-```rust
-use libjpeg_turbo_rs::{decompress, Decoder, TransformOp};
-
-// Probe without decoding pixels (None when the JPEG carries no EXIF):
-let orientation: Option<u8> = Decoder::new(&jpeg_bytes)?.exif_orientation();
-
-// Pixel domain — decode, then reorient in one call:
-let upright = decompress(&jpeg_bytes)?.apply_orientation();
-
-// DCT domain — rewrite the JPEG losslessly instead (skip the no-op
-// re-encode for upright/untagged images). Strip the markers: transforms
-// copy them by default, and a stale orientation tag on already-rotated
-// pixels would make EXIF-aware viewers rotate twice. Note lossless
-// transforms cannot fully reorient partial edge blocks when dimensions
-// are not iMCU-aligned (see TransformOp::from_exif_orientation docs) —
-// the pixel-domain path above is exact at any size.
-use libjpeg_turbo_rs::{MarkerCopyMode, TransformOptions};
-if let Some(op) = orientation.and_then(TransformOp::from_exif_orientation) {
-    if op != TransformOp::None {
-        let upright_jpeg = libjpeg_turbo_rs::transform_jpeg_with_options(
-            &jpeg_bytes,
-            &TransformOptions { op, copy_markers: MarkerCopyMode::None, ..Default::default() },
-        )?;
-    }
-}
-```
-
-### Scanline-Level I/O
+### Scanline processing
 
 ```rust
 use libjpeg_turbo_rs::ScanlineDecoder;
 
 let mut decoder = ScanlineDecoder::new(&jpeg_bytes)?;
-let height = decoder.header().height as usize;
 let width = decoder.header().width as usize;
-let mut buf = vec![0u8; width * 3]; // RGB row buffer
+let height = decoder.header().height as usize;
+let mut row = vec![0_u8; width * 3];
+
 while decoder.output_scanline() < height {
-    decoder.read_scanline(&mut buf)?;
-    // process buf...
+    decoder.read_scanline(&mut row)?;
+    // Process this RGB row.
 }
-let img = decoder.finish()?;
+
+let image = decoder.finish()?;
 ```
+
+Runnable examples live in [`examples/`](examples). The crate-level examples
+are compile-checked with `cargo test --doc`.
 
 ## Features
 
-### Codec Support
+### JPEG modes
 
-| Feature | Encode | Decode |
-|---------|--------|--------|
-| Baseline DCT (Huffman) | yes | yes |
+| Capability | Encode | Decode |
+| --- | --- | --- |
+| Baseline DCT with Huffman coding | yes | yes |
 | Progressive DCT | yes | yes |
 | Arithmetic coding | yes | yes |
 | Lossless JPEG | yes | yes |
 | 8/12/16-bit precision | yes | yes |
-| Optimized Huffman tables | yes | - |
+| Optimized Huffman tables | yes | not applicable |
 
-### Pixel Formats
+The detailed feature inventory, including classic C API gaps, is maintained in
+[`docs/FEATURE_PARITY.md`](docs/FEATURE_PARITY.md).
 
-Grayscale, RGB, BGR, RGBA, BGRA, ARGB, ABGR, RGBX, BGRX, XRGB, XBGR, CMYK, RGB565
+### Pixel formats and subsampling
 
-### Chroma Subsampling
+Supported packed formats include grayscale, RGB, BGR, RGBA, BGRA, ARGB, ABGR,
+RGBX, BGRX, XRGB, XBGR, CMYK, and RGB565 where the relevant operation supports
+it.
 
-4:4:4, 4:2:2, 4:2:0, 4:4:0, 4:1:1, 4:4:1, 4:1:0, 2:4
+Supported chroma layouts include 4:4:4, 4:2:2, 4:2:0, 4:4:0, 4:1:1, 4:4:1,
+4:1:0, and 2:4, plus grayscale and unusual/custom subsampling detection.
 
-### SIMD
+### Additional capabilities
 
-| Platform | Backend | Decode | Encode |
-|----------|---------|--------|--------|
-| aarch64 | NEON | IDCT, color convert, upsample, dequantize | FDCT, color convert, quantize+zigzag, downsample, Huffman |
-| x86_64 | SSE2 | IDCT, color convert, upsample | Huffman bitmap+sign-correction |
-| x86_64 | AVX2 | IDCT, color convert, upsample, merged upsample+color | FDCT, color convert, quantize+zigzag, downsample (fused H2V1/H2V2) |
+- all 16 libjpeg scaled inverse DCT factors;
+- coefficient access and lossless spatial transforms;
+- Exchangeable Image File Format (EXIF) orientation inspection and application;
+- International Color Consortium (ICC) profiles, XMP, IPTC, JFIF, Adobe APP14,
+  and comment markers;
+- packed and planar luminance/chrominance (YUV) paths;
+- scanline and `std::io` streaming APIs;
+- caller-owned reusable output buffers;
+- MCU-aligned crop decoding;
+- color quantization and dithering;
+- recovery mode, custom Huffman/quantization tables, restart markers, and
+  progress callbacks;
+- `no_std + alloc` core codec;
+- `image` trait bridge and Wasm/npm wrapper;
+- TurboJPEG 3 and experimental classic libjpeg v8 C ABI shims.
 
-aarch64 has comprehensive SIMD across the full pipeline. x86_64 decode and encode are both fully accelerated; encode pairs SSE2 Huffman bitmap construction with AVX2 fused FDCT/quantize/color/downsample.
+## Feature flags and platform support
 
-All SIMD routines have scalar fallbacks. SIMD is enabled by default via the `simd` feature flag.
+The root crate defaults to `std` and `simd`.
 
-### Additional Features
+| Cargo feature | Default | Effect |
+| --- | --- | --- |
+| `std` | yes | `std::io` streaming, file helpers, runtime CPU-feature detection, standard error interoperability, and standard-library-dependent helpers |
+| `simd` | yes | architecture intrinsics for supported targets |
+| `png` | no | PNG image input/output for the relevant TurboJPEG image-loading helpers; implies `std` |
 
-- Scaled IDCT (all 16 libjpeg factors: 2/1, 15/8, 7/4, ..., 1/2, 1/4, 1/8)
-- Lossless spatial transforms (rotate, flip, transpose)
-- DCT coefficient access (`read_coefficients` / `write_coefficients`)
-- Metadata: JFIF, EXIF, ICC profile, XMP (read incl. Extended XMP reassembly; write is single-segment), IPTC (APP13 Photoshop IRB), Adobe APP14, comments
-- YUV plane encode/decode (raw component data)
-- Scanline-level streaming API
-- Crop decoding (MCU-aligned)
-- Color quantization with dithering
-- Error recovery mode
-- Custom Huffman/quantization tables
-- Restart markers (DRI)
-- Progress callbacks
+Build the core codec for `no_std + alloc` with:
 
-## C ABI replacement tiers
+```bash
+cargo build --release --no-default-features
+```
 
-Beyond the Rust crate, the workspace ships C ABI shims: a TurboJPEG 3
-cdylib (`libturbojpeg.so.0`, ready for TJ3 consumers) and a classic
-libjpeg v8 cdylib (`libjpeg.so.8`, experimental/partial). A pinned OpenCV 4.6
-workload and stock-tool gates prove important default paths, but open classic
-ABI ownership, lifecycle, option, error, and test-integrity gaps mean it is not
-yet a general system-library replacement; GNU ELF symbol versions are also
-tracked as P4-81. The
-legacy-alias matrix, SONAME opt-ins, threading contract, and the v6b/v7
-drop-in non-goal live in
-[`docs/ABI_COMPATIBILITY.md`](docs/ABI_COMPATIBILITY.md); the T1–T4
-replacement-tier framing and its readiness status live in
-[`docs/LAST_MILE.md`](docs/LAST_MILE.md).
+`alloc` is still required because decode, encode, and coefficient operations
+own dynamically sized buffers.
 
-Tagged releases attach prebuilt bundles of those shims — libraries, headers,
-`.pc` files and CMake config for x86_64/aarch64 Linux and macOS, with a
-`SHA256SUMS` manifest. There is no Windows bundle and no signature yet.
-[`docs/RELEASE_ARTIFACTS.md`](docs/RELEASE_ARTIFACTS.md) covers what ships,
-how to verify and install it, and what is still missing. Downloading a bundle
-does not change the tiers above.
+| Target | Current acceleration | Status |
+| --- | --- | --- |
+| x86_64 Linux/macOS/Windows | AVX2 and SSE2 with runtime dispatch under `std` | First-class Rust target; Continuous Integration (CI) includes no-AVX2 coverage |
+| aarch64 Linux/macOS | NEON | First-class and CI-tested |
+| `wasm32` browser/WASI | SIMD128 when compiled with `+simd128` | Supported; compiler target feature is explicit outside this repository |
+| `thumbv7em` bare metal | scalar | `no_std + alloc` build is CI-tested |
+| armv7 / AArch32 | scalar by default | Functional CI coverage, but no production AArch32 NEON backend and no hardware performance claim |
+| RISC-V, POWER, s390x | scalar | Functional support; compare on target hardware before adoption |
+
+The root and C ABI crates currently declare Minimum Supported Rust Version
+(MSRV) 1.87. The `image` bridge follows the higher requirement inherited from
+its `image` dependency. MSRV changes are minor-version changes and are recorded
+in [`CHANGELOG.md`](CHANGELOG.md).
+
+## Performance
+
+Performance claims are evidence, not universal properties. The tables below
+are dated measurements from the repository harnesses. **A ratio below 1.00
+means Rust used less time than C.**
+
+### Representative C libjpeg-turbo comparison
+
+| Platform and build | Operation | Workload | Rust / C time |
+| --- | --- | --- | --- |
+| Intel Core i5-10400, portable release decode, C 3.1.2 | decode | 1920x1080 4:2:0 | **0.90x** |
+| Intel Core i5-10400, portable release decode, C 3.1.2 | decode | 3840x2160 4:2:0 | **0.88x** |
+| Intel Core i5-10400, `target-cpu=native` encode, C 3.1.2 | encode | 1920x1080 4:2:0 | **0.98x** |
+| Apple M1 Pro, portable release, C 3.1.0 | decode | 1920x1080 4:2:0 | 1.07x |
+| Apple M1 Pro, portable release, C 3.1.0 | decode | 1920x1080 4:2:2 / 4:4:4 | **0.99x / 0.99x** |
+| Apple M1 Pro, portable release, C 3.1.0 | encode | 1920x1080 4:2:0 / 4:2:2 / 4:4:4 | 1.07x / 1.06x / 1.03x |
+
+Against `zune-jpeg` on the recorded aarch64 matrix, the decoder won 31 of 34
+scored cases with a ±2% threshold; the losses were small fixed-cost or unusual
+multi-scan cases. See
+[`experiments/zune_matrix_aarch64_2026-07-28.md`](experiments/zune_matrix_aarch64_2026-07-28.md).
+
+### Portable versus native x86_64 builds
+
+Do not quote the native encode table as portable performance:
+
+- **Portable:** plain `cargo build --release`. This is the relevant default for
+  distributed binaries. Runtime dispatch still reaches SSE2/AVX2 kernels.
+- **Native:** `RUSTFLAGS="-C target-cpu=native" cargo build --release`. This may
+  enable additional BMI/FMA code generation, but the binary is tied to the
+  build host's CPU capabilities.
+
+Use a native build only for a controlled fleet whose CPUs match the build
+target. Measure both paths with the same corpus before choosing one.
+
+Full methodology and dated evidence live in
+[`docs/ENCODING_PERFORMANCE.md`](docs/ENCODING_PERFORMANCE.md),
+[`docs/CORPUS_TEST_REPORT.md`](docs/CORPUS_TEST_REPORT.md), and
+[`experiments/`](experiments). The Product Requirements Document (PRD) requires
+future benchmark reports to record CPU, operating system, compiler/toolchain,
+C oracle version, build flags, corpus, warmup, sample count, and noise
+threshold.
+
+## Correctness, safety, and validation
+
+The repository uses multiple complementary forms of evidence:
+
+- differential tests against pinned `djpeg`, `cjpeg`, `jpegtran`, TurboJPEG,
+  and classic libjpeg oracles;
+- full feature-cross-product tests where exhaustive or bounded enumeration is
+  practical;
+- real and generated corpus tests;
+- fuzz smoke jobs and longer-running fuzz targets;
+- AddressSanitizer, UB checks, and C-boundary harnesses;
+- cross-architecture and no-SIMD CI legs;
+- WebAssembly and `no_std` builds;
+- downstream OpenCV, libtiff, stock-tool, package, and loader harnesses where
+  documented;
+- code-level unsafe-boundary reviews and checked sizing/layout utilities.
+
+No individual test, fuzzer, sanitizer, or review proves memory safety. The live
+gate records both closed defects and the evidence still required before the
+project offers a stronger guarantee.
+
+Start with:
+
+- [`docs/LAST_MILE.md`](docs/LAST_MILE.md) — canonical readiness and blockers;
+- [`docs/TEST_PARITY.md`](docs/TEST_PARITY.md) — upstream behavior/test mapping;
+- [`docs/CORPUS_TEST_REPORT.md`](docs/CORPUS_TEST_REPORT.md) — corpus results;
+- [`docs/oracle_versions.tsv`](docs/oracle_versions.tsv) — pinned oracle
+  identities.
+
+## C ABI packages and release artifacts
+
+The workspace includes `libjpeg-turbo-rs-capi`, which can produce the
+TurboJPEG 3 library and an experimental classic v8 library. Tagged releases
+publish checksummed native bundles for x86_64/aarch64 Linux and macOS,
+including headers, package configuration files, CMake configuration, and the
+SONAME/install-name chains.
+
+Current distribution gaps:
+
+- no Windows native C ABI bundle;
+- no artifact signature or build attestation;
+- no Software Bill of Materials (SBOM);
+- no first-party deb/rpm package;
+- classic v8 downstream harnesses do not yet prove every open lifecycle and
+  compatibility contract against the exact shipped artifact.
+
+Read [`docs/RELEASE_ARTIFACTS.md`](docs/RELEASE_ARTIFACTS.md) before installing
+a bundle and [`docs/ABI_COMPATIBILITY.md`](docs/ABI_COMPATIBILITY.md) before
+changing a dynamic-library search path.
+
+## Documentation
+
+[`docs/README.md`](docs/README.md) maps documents by audience and records their
+source-of-truth order.
+
+| Document | Purpose |
+| --- | --- |
+| [`PRD.md`](PRD.md) | Adoption strategy, requirements, milestones, priorities, and `1.0` definition of done |
+| [`docs/ADOPTION_GUIDE.md`](docs/ADOPTION_GUIDE.md) | Integration choice, migration, evaluation, rollout, and rollback |
+| [`docs/LAST_MILE.md`](docs/LAST_MILE.md) | Canonical T1-T4 release gate |
+| [`docs/FEATURE_PARITY.md`](docs/FEATURE_PARITY.md) | Implemented feature inventory |
+| [`docs/ABI_COMPATIBILITY.md`](docs/ABI_COMPATIBILITY.md) | C ABI, SONAME, layout, lifecycle, and threading policy |
+| [`docs/C_API_REFERENCE.md`](docs/C_API_REFERENCE.md) | Per-function C API status |
+| [`docs/TEST_PARITY.md`](docs/TEST_PARITY.md) | C reference and behavior validation map |
+| [`docs/RELEASE_ARTIFACTS.md`](docs/RELEASE_ARTIFACTS.md) | Bundle contents, verification, installation, and known gaps |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Development workflow and required evidence |
 
 ## Contributing
 
-Development workflow, the pre-commit gate, and the local sanitizer
-recipes live in [CONTRIBUTING.md](CONTRIBUTING.md).
+The highest-priority work is not the largest unchecked feature list. It is the
+work that makes adoption claims safer and easier to verify: release-mode gate
+health, checked layout arithmetic, unsafe-boundary regression detection,
+packaged-artifact validation, portable performance, supply-chain evidence,
+and maintained ecosystem integrations.
+
+Read [`CONTRIBUTING.md`](CONTRIBUTING.md), [`PRD.md`](PRD.md), and the relevant
+live-gate item before starting. Pull requests that change feature, safety,
+performance, API, ABI, platform, or readiness claims must include the evidence
+and documentation update for that claim.
 
 ## License
 
-Licensed under either of
+Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT License ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([`LICENSE-APACHE`](LICENSE-APACHE)); or
+- MIT License ([`LICENSE-MIT`](LICENSE-MIT));
 
 at your option.
 
 ## Acknowledgments
 
 This software is based in part on the work of the Independent JPEG Group.
-
-Algorithms and implementation techniques referenced from [libjpeg-turbo](https://github.com/libjpeg-turbo/libjpeg-turbo) (IJG License / Modified BSD License) and [zune-jpeg](https://github.com/etemesi254/zune-image).
+Algorithms and implementation techniques are informed by
+[libjpeg-turbo](https://github.com/libjpeg-turbo/libjpeg-turbo) and
+[zune-jpeg](https://github.com/etemesi254/zune-image). Their licenses and
+attribution requirements remain distinct from this project's dual license.

--- a/crates/libjpeg-turbo-rs-capi/README.md
+++ b/crates/libjpeg-turbo-rs-capi/README.md
@@ -1,79 +1,195 @@
 # libjpeg-turbo-rs-capi
 
-C ABI shim over [libjpeg-turbo-rs](https://crates.io/crates/libjpeg-turbo-rs)
-for the two shared libraries C consumers link against.
+C Application Binary Interface (ABI) shim over
+[`libjpeg-turbo-rs`](https://crates.io/crates/libjpeg-turbo-rs), providing the
+shared-library surfaces used by TurboJPEG and classic libjpeg consumers.
 
-> **Tiers and status (P4-140).** **TurboJPEG 3 (`libturbojpeg.so.0`) is the
-> primary target.** The classic libjpeg leg targets the **v8 identity only**
-> (`libjpeg.so.8`) and is experimental and partial. **v6b (`libjpeg.so.62`)
-> and v7 are explicit non-goals** — their struct layouts differ, so
-> substituting this library for them corrupts memory rather than merely
-> failing. The safe-Rust/unsafe-SIMD boundary in the underlying crate is under
-> audit (P4-135..P4-139), so no memory-safety guarantee is offered yet, and
-> "drop-in replacement" is not a claim this project currently makes.
+> **Writing Rust?** Use the root `libjpeg-turbo-rs` crate unless you explicitly
+> need a C ABI. It provides the idiomatic Rust Application Programming
+> Interface (API) without C handles, public C structures, loader behavior, or
+> manual buffer ownership.
 
-> **Writing Rust?** You almost certainly want the root
-> [libjpeg-turbo-rs](https://crates.io/crates/libjpeg-turbo-rs) crate
-> instead — it is the safe, idiomatic API. This crate exists for C/C++
-> programs (and language runtimes binding `libjpeg`/`libturbojpeg`) that
-> need the C ABI.
+## Choose the correct C interface
 
-- **libjpeg v8 ABI** (`libjpeg.so.8` / `jpeglib.h` surface): `jpeg_std_error`,
-  `jpeg_CreateDecompress/Compress`, source/destination managers, marker
-  readers, `jpeg_read_header` … `jpeg_finish_decompress`, raw-data and
-  coefficient access, `jpeg_simple_progression`, error/message formatting.
-- **TurboJPEG 3 API** (`libturbojpeg.so.0` / `turbojpeg.h`): the `tj3*`
-  family (8/12/16-bit, lossless, YUV planes, crop/scale, transforms), plus
-  21 of the 39 TJ 1.x/2.x legacy aliases; the remaining 18 are documented
-  with a migration matrix.
+| Consumer | Library surface | Current status |
+| --- | --- | --- |
+| TurboJPEG 3 application using `tj3*` | `libturbojpeg.so.0` / macOS equivalent | **T2:** primary C ABI target; validate the exact functions and packaged artifact your application uses |
+| TurboJPEG 1.x/2.x application | Legacy aliases in `libturbojpeg.so.0` | Partial; some aliases are implemented and the remainder require migration to their TurboJPEG 3 successors |
+| Classic libjpeg v8 consumer | `libjpeg.so.8` / `libjpeg.8.dylib` | **T3:** experimental and partial; controlled pilots only |
+| Classic libjpeg v6b or v7 consumer | `libjpeg.so.62` / `libjpeg.so.7` | **T4:** not supported as a drop-in replacement |
 
-The definitive per-function status table (✅ implemented / 🔶 partial /
-❌ missing) is
-[`docs/C_API_REFERENCE.md`](https://github.com/developer0hye/libjpeg-turbo-rs/blob/main/docs/C_API_REFERENCE.md)
-in the repository root.
+Start with the decision tree and pilot instructions in
+[`docs/ADOPTION_GUIDE.md`](../../docs/ADOPTION_GUIDE.md). The canonical live
+readiness gate is [`docs/LAST_MILE.md`](../../docs/LAST_MILE.md).
 
-## Building
+## Current safety and release status
 
-Tagged releases attach prebuilt bundles — libraries, headers, `.pc` files and
-CMake config for x86_64/aarch64 Linux and macOS, checksummed — so building
-from source is not the only way to get one. There is no Windows bundle and no
-signature yet;
-[`docs/RELEASE_ARTIFACTS.md`](https://github.com/developer0hye/libjpeg-turbo-rs/blob/main/docs/RELEASE_ARTIFACTS.md)
-covers what ships, how to verify it, and what is missing.
+The underlying codec is implemented in Rust and does not call a C JPEG codec.
+It still contains narrowly scoped `unsafe` code in architecture-specific
+Single Instruction, Multiple Data (SIMD) kernels; this crate necessarily adds
+unsafe C pointer and callback boundaries.
 
-To build it yourself:
+The major safe-Rust Undefined Behavior (UB) defects found in the 2026-08 audit
+are recorded as closed, and the live gate currently reports no known remaining
+UB reachable through the safe Rust API. A formal memory-safety guarantee still
+requires the remaining checked-layout centralization and automated
+unsafe-boundary verification work tracked by P4-139 and P4-141.
 
-```sh
+The full release-mode workspace gate is currently red because of P4-170, a
+classic source-manager differential test that passes in debug mode and fails in
+release mode. Do not describe the complete release gate as green until the live
+gate records a successful re-measurement.
+
+The C ABI surface has additional risks that do not exist in the Rust API:
+public structure layout, symbol versioning, loader identity, allocator
+ownership, callbacks, lifecycle, suspension, errors, and threading. Read
+[`docs/ABI_COMPATIBILITY.md`](../../docs/ABI_COMPATIBILITY.md) before changing a
+dynamic-library search path.
+
+## Supported surfaces
+
+### TurboJPEG 3
+
+The primary surface is the opaque-handle `tj3*` API, including the implemented
+8/12/16-bit, lossy/lossless, YUV, scaling/crop, transform, parameter, buffer,
+and image-loading paths documented in
+[`docs/C_API_REFERENCE.md`](../../docs/C_API_REFERENCE.md).
+
+Opaque handles avoid classic libjpeg's version-dependent public-structure ABI,
+but they do not eliminate behavioral compatibility work. Check the function
+matrix, error contract, allocator ownership, and the exact operation your
+application uses.
+
+### Legacy TurboJPEG aliases
+
+Only part of the TurboJPEG 1.x/2.x alias surface is exported. Missing aliases
+have recommended TurboJPEG 3 successors and thin-shim guidance in the migration
+matrix under
+[`docs/ABI_COMPATIBILITY.md`](../../docs/ABI_COMPATIBILITY.md).
+
+A missing symbol fails at link time or `dlsym`; it is not automatically mapped
+to a similarly named function.
+
+### Classic libjpeg v8
+
+The classic shim targets `JPEG_LIB_VERSION = 80` and the v8 public structure
+layout. It includes substantial encode/decode, raw-data, coefficient, marker,
+source/destination manager, error, and helper coverage, but remains
+experimental and partial.
+
+Important current constraints include:
+
+- open lifecycle, option, error, precision, suspension, and downstream-coverage
+  items in the live gate;
+- a stricter threading contract than upstream: each `jpeg_compress_struct` or
+  `jpeg_decompress_struct` must remain on the thread that created it, tracked by
+  P4-132;
+- the need to validate the exact packaged/relinked artifact rather than only
+  the raw Cargo `cdylib`, tracked by P4-124;
+- no blanket guarantee for arbitrary prebuilt classic libjpeg consumers.
+
+Do not replace a system library globally as the first test. Use the isolated
+pilot and rollback sequence in
+[`docs/ADOPTION_GUIDE.md`](../../docs/ADOPTION_GUIDE.md).
+
+### v6b and v7 are not drop-in targets
+
+The shim mirrors v8 structures. A consumer compiled against v6b or v7 sees a
+different structure contract. Renaming or setting a v6b/v7 SONAME does not
+change the actual layout and cannot create binary compatibility.
+
+The explicit v6b SONAME build opt-in exists for narrowly controlled consumers
+that are themselves built against v8 headers but resolve a historical SONAME.
+It is not permission to load the library into a binary compiled against v6b
+headers. The create-time version/size guard rejects that mismatch.
+
+## Building from source
+
+```bash
 cargo build --release -p libjpeg-turbo-rs-capi
 ```
 
-produces `rlib`, `cdylib`, and `staticlib` artifacts. On Linux/macOS the
-cdylib can be soname-aliased to `libjpeg.so.8` / `libturbojpeg.so.0` and
-substituted for the C libraries; the test suite exercises exactly that via
-`dlopen` (`libloading`), including a libtiff integration test.
+The crate produces Rust library, C dynamic library, and static library artifact
+forms according to its Cargo configuration. The raw Cargo dynamic library is
+useful for development tests, but it is not identical to every shipped native
+bundle: the Linux installation path can relink the static library with the
+required symbol-version script and stage SONAME links, headers, package
+configuration, and CMake metadata.
 
-SONAME selection (v8 default, v6b opt-in via `CAPI_ACK_V6B_SONAME=1`),
-the ABI-version matrix, and which settings are safe for which consumers
-are documented in
-[`docs/ABI_COMPATIBILITY.md`](https://github.com/developer0hye/libjpeg-turbo-rs/blob/main/docs/ABI_COMPATIBILITY.md).
+When testing release behavior, test the staged artifact users will install.
 
-Features:
+### Optional PNG support
 
-| flag | default | effect |
-|---|---|---|
-| `png` | off | enables PNG input/output in `tj3LoadImage8` / `tj3SaveImage8` |
+```bash
+cargo build --release -p libjpeg-turbo-rs-capi --features png
+```
 
-## Compatibility notes
+The `png` feature enables PNG input/output for the relevant TurboJPEG image
+loading/saving functions. It is off by default so the codec and C ABI build do
+not add that dependency unless requested.
 
-- The codec underneath is cross-validated against C libjpeg-turbo
-  (`djpeg` / `cjpeg` / `jpegtran`) by the repository test suite.
-- Error messages reproduce the C `format_message` table so callers that
-  parse message strings keep working. The default `output_message` prints
-  them to stderr as upstream does; a caller wanting silence installs its own
-  callback.
-- The crate is `unsafe` at the boundary by nature (C ABI); the underlying
-  codec is pure Rust.
+## Native release bundles
+
+Tagged releases publish native bundles for the target matrix listed in
+[`docs/RELEASE_ARTIFACTS.md`](../../docs/RELEASE_ARTIFACTS.md). Bundles include,
+where applicable:
+
+- `libturbojpeg` and `libjpeg` shared-library identities;
+- public headers;
+- `pkg-config` metadata;
+- CMake package configuration;
+- SONAME/install-name links;
+- license files, bundle metadata, and checksums.
+
+Current delivery gaps include no Windows C ABI bundle, no signature/build
+attestation, no Software Bill of Materials (SBOM), and no first-party deb/rpm
+package. Follow the release-artifact guide for verification and installation;
+do not copy symbolic-link chains as unrelated regular files.
+
+## Evaluation checklist
+
+Before a TurboJPEG or classic v8 pilot:
+
+- [ ] Identify the exact API family and compiled ABI version.
+- [ ] Inventory every imported or dynamically resolved symbol.
+- [ ] Check each function in `C_API_REFERENCE.md`.
+- [ ] Compile a canary against the headers shipped with the same artifact.
+- [ ] Verify SONAME/install name and, on Linux, symbol versions.
+- [ ] Compare success/failure, error handling, dimensions, colorspace,
+      precision, pixels, metadata, and buffer ownership against upstream.
+- [ ] Exercise malformed input, short buffers, custom managers, callbacks,
+      abort/reuse, and threading behavior used by the application.
+- [ ] Measure portable release performance and peak memory on the deployment
+      hardware.
+- [ ] Run the exact packaged artifact in an isolated loader environment.
+- [ ] Exercise rollback to upstream before serving production output.
+
+The root [`docs/ADOPTION_GUIDE.md`](../../docs/ADOPTION_GUIDE.md) provides a
+complete corpus, correctness, performance, rollout, and issue-reporting plan.
+
+## Validation evidence
+
+The repository uses differential C-oracle tests, stock tools, loader/symbol
+checks, sanitizers, fuzz targets, cross-architecture jobs, and selected
+real-downstream harnesses. The following documents separate implementation
+coverage from release readiness:
+
+- [`docs/C_API_REFERENCE.md`](../../docs/C_API_REFERENCE.md) — per-function
+  status;
+- [`docs/ABI_COMPATIBILITY.md`](../../docs/ABI_COMPATIBILITY.md) — layout,
+  SONAME, symbol, allocator, lifecycle, and threading policy;
+- [`docs/TEST_PARITY.md`](../../docs/TEST_PARITY.md) — upstream behavior/test
+  mapping;
+- [`docs/LAST_MILE.md`](../../docs/LAST_MILE.md) — canonical T1-T4 gate;
+- [`docs/RELEASE_ARTIFACTS.md`](../../docs/RELEASE_ARTIFACTS.md) — what users
+  actually download.
+
+A test through a Rust helper is not sufficient evidence for a C entry point.
+C ABI behavior must be exercised through the produced shared library and, when
+packaging matters, through the packaged artifact.
 
 ## License
 
-MIT OR Apache-2.0, same as the root crate.
+MIT OR Apache-2.0, matching the root crate. See the repository's
+[`LICENSE-MIT`](../../LICENSE-MIT) and
+[`LICENSE-APACHE`](../../LICENSE-APACHE).

--- a/crates/libjpeg-turbo-rs-image/README.md
+++ b/crates/libjpeg-turbo-rs-image/README.md
@@ -1,56 +1,140 @@
 # libjpeg-turbo-rs-image
 
-[`image`](https://crates.io/crates/image) crate backend powered by [`libjpeg-turbo-rs`](https://crates.io/crates/libjpeg-turbo-rs) — a fast pure-Rust JPEG codec with NEON/AVX2 SIMD acceleration.
+An [`image`](https://crates.io/crates/image) crate adapter powered by
+[`libjpeg-turbo-rs`](https://crates.io/crates/libjpeg-turbo-rs), exposing JPEG
+decode and encode through the `image` crate's `ImageDecoder` and
+`ImageEncoder` traits.
 
-## Usage
+Use this crate when your application or library already depends on `image`
+traits but wants to select `libjpeg-turbo-rs` explicitly. Use the root codec
+crate directly when you need its full pixel-format, metadata, transform,
+high-precision, luminance/chrominance (YUV), scanline, or caller-owned-buffer
+Application Programming Interface (API).
+
+For the project-wide readiness and evaluation process, read
+[`docs/ADOPTION_GUIDE.md`](../../docs/ADOPTION_GUIDE.md) and
+[`docs/LAST_MILE.md`](../../docs/LAST_MILE.md).
+
+## Why an explicit adapter?
+
+The adapter keeps codec choice visible in your dependency graph and avoids
+assuming that changing a transitive `image` feature automatically replaces its
+JPEG implementation. It also provides a stable place to test color mapping,
+trait behavior, and bridge overhead separately from the core codec.
+
+A core-codec benchmark is not an end-to-end adapter benchmark. Measure the
+actual trait path and surrounding image representation your application uses.
+
+## Installation
 
 ```toml
 [dependencies]
 libjpeg-turbo-rs-image = "0.1"
-# default-features = false keeps image's other format codecs (and the
-# AVIF encoder's advisory-carrying rav1e chain) out of your build graph.
-# Add the formats you actually use, e.g. features = ["png"].
+
+# Keep unrelated image formats out of the dependency graph, then add only the
+# formats your application uses.
 image = { version = "0.25", default-features = false }
 ```
 
-### Decoding
+This bridge follows the Minimum Supported Rust Version (MSRV) required by its
+`image` dependency, which may be higher than the root codec's MSRV.
+
+## Decoding
 
 ```rust
-use libjpeg_turbo_rs_image::JpegDecoder;
 use image::ImageDecoder;
-use std::fs;
+use libjpeg_turbo_rs_image::JpegDecoder;
 
-let data = fs::read("photo.jpg").unwrap();
-let mut decoder = JpegDecoder::new(&data).unwrap();
+let mut decoder = JpegDecoder::new(&jpeg_bytes)?;
 let (width, height) = decoder.dimensions();
-let mut buf = vec![0u8; decoder.total_bytes() as usize];
-decoder.read_image(&mut buf).unwrap();
-// buf now contains RGB or L8 pixels depending on the JPEG color space
+let mut pixels = vec![0_u8; decoder.total_bytes() as usize];
+decoder.read_image(&mut pixels)?;
+
+println!("decoded {width}x{height}");
 ```
 
-### Encoding
+The default output is RGB for color JPEGs and L8 for grayscale JPEGs.
+Use `JpegDecoder::new_with_format()` when you need one of the additional packed
+formats exposed by the bridge.
+
+## Encoding
 
 ```rust
-use libjpeg_turbo_rs_image::JpegEncoder;
 use image::{ExtendedColorType, ImageEncoder};
+use libjpeg_turbo_rs_image::JpegEncoder;
 
 let pixels: Vec<u8> = vec![/* RGB pixels */];
-let mut output: Vec<u8> = Vec::new();
+let mut output = Vec::new();
+
 JpegEncoder::new_with_quality(&mut output, 85)
-    .write_image(&pixels, 640, 480, ExtendedColorType::Rgb8)
-    .unwrap();
-// output contains the compressed JPEG bytes
+    .write_image(&pixels, 640, 480, ExtendedColorType::Rgb8)?;
 ```
 
-## Color type mapping
+Set quality explicitly so codec behavior remains visible in application code.
+For advanced subsampling, progressive, arithmetic, lossless, metadata, custom
+tables, or transform controls, use the root `libjpeg-turbo-rs::Encoder` and
+related APIs.
 
-| JPEG source    | `image::ColorType` |
-|----------------|--------------------|
-| Grayscale (1c) | `L8`               |
-| YCbCr / RGB    | `Rgb8`             |
+## Color mapping
 
-For other pixel formats (BGR, BGRA, CMYK, etc.) use `JpegDecoder::new_with_format()`.
+| JPEG source or requested output | `image::ColorType` / behavior |
+| --- | --- |
+| Grayscale, one component | `L8` |
+| YCbCr or RGB color source | `Rgb8` by default |
+| Other packed formats such as BGR/BGRA/CMYK | use `JpegDecoder::new_with_format()` and the bridge-specific API |
+
+Do not assume that a four-byte packed format has alpha semantics merely because
+it has four bytes per pixel. Verify the selected format's alpha/padding and
+channel order.
+
+## When to use the root crate instead
+
+Prefer `libjpeg-turbo-rs` directly when you need:
+
+- reusable caller-owned output buffers with no per-frame output allocation;
+- scanline or `std::io` streaming beyond the adapter contract;
+- coefficient-domain rotate/flip/transpose/crop;
+- Exchangeable Image File Format (EXIF), International Color Consortium (ICC),
+  XMP, IPTC, or marker-level control;
+- CMYK/YCCK policy beyond the adapter's color mapping;
+- 12/16-bit precision, lossless JPEG, arithmetic coding, or custom scan scripts;
+- raw YUV planes, custom Huffman/quantization tables, or advanced recovery;
+- `no_std + alloc` or direct WebAssembly integration.
+
+## Evaluation checklist
+
+Before replacing an existing `image`-based JPEG path:
+
+- [ ] Run the same representative corpus through both adapters.
+- [ ] Compare dimensions, `ColorType`, row layout, channel order, and decoded
+      pixels.
+- [ ] Include grayscale, progressive, CMYK/YCCK, embedded color profiles,
+      metadata, very small images, and malformed inputs relevant to your data.
+- [ ] Benchmark the `ImageDecoder`/`ImageEncoder` calls end to end rather than
+      quoting only a root-codec benchmark.
+- [ ] Measure allocation and conversion overhead in the surrounding
+      `DynamicImage` or application buffer path.
+- [ ] Verify encoder quality and output color type explicitly.
+- [ ] Keep the previous adapter/version available until rollback has been
+      exercised.
+
+The repository's dated adapter evidence is recorded under
+[`experiments/`](../../experiments), while core feature and release readiness
+remain in [`docs/FEATURE_PARITY.md`](../../docs/FEATURE_PARITY.md) and
+[`docs/LAST_MILE.md`](../../docs/LAST_MILE.md).
+
+## Scope and limitations
+
+This crate is an adapter, not a promise to expose every root-codec capability
+through `image` traits. Trait contracts intentionally have a smaller option
+surface than the root builder APIs. New bridge behavior should be added only
+with trait-level compatibility tests and a clear downstream use case.
+
+The bridge inherits the root codec's safety and correctness status. It does not
+promote the experimental classic C ABI and does not depend on a C JPEG codec.
 
 ## License
 
-MIT OR Apache-2.0
+MIT OR Apache-2.0, matching the root codec. See
+[`LICENSE-MIT`](../../LICENSE-MIT) and
+[`LICENSE-APACHE`](../../LICENSE-APACHE).

--- a/crates/libjpeg-turbo-rs-wasm/README.md
+++ b/crates/libjpeg-turbo-rs-wasm/README.md
@@ -1,28 +1,121 @@
 # libjpeg-turbo-rs-wasm
 
-WASM bindings for [`libjpeg-turbo-rs`](https://crates.io/crates/libjpeg-turbo-rs) — a fast, pure-Rust JPEG codec for the browser.
+WebAssembly (Wasm) bindings for
+[`libjpeg-turbo-rs`](https://crates.io/crates/libjpeg-turbo-rs), providing a
+Rust-native JPEG codec for browsers and WebAssembly System Interface (WASI)
+environments without a C JPEG implementation.
+
+Use this wrapper when JavaScript or TypeScript is the caller. Rust applications
+targeting `wasm32` directly may depend on the root crate instead and choose the
+appropriate Rust Application Programming Interface (API).
+
+Read [`docs/ADOPTION_GUIDE.md`](../../docs/ADOPTION_GUIDE.md) for the project
+readiness, evaluation, memory, rollout, and rollback checklist.
 
 ## Build
 
-```sh
-wasm-pack build --release --target web
+```bash
+RUSTFLAGS="-C target-feature=+simd128" \
+  wasm-pack build --release --target web
 ```
 
-The generated `pkg/` directory is a ready-to-use ES module. A browser benchmark harness lives in `bench/`.
+The generated `pkg/` directory is an ECMAScript module package suitable for a
+browser build. A browser benchmark harness lives under [`bench/`](bench).
 
-**SIMD128 is a compile-time flag, and it is NOT self-contained in this crate.** In-repo builds get it from this repository's `.cargo/config.toml` (`-C target-feature=+simd128` for the wasm32 targets). If you consume this crate from crates.io — outside this repository — that config does not travel with it, and without the flag the codec's WASM SIMD kernels compile out, silently falling back to scalar. Set it yourself:
+## SIMD128 must be enabled explicitly
 
-```sh
-RUSTFLAGS="-C target-feature=+simd128" wasm-pack build --release --target web
+The repository's `.cargo/config.toml` enables `+simd128` for in-repository
+`wasm32` builds. Cargo configuration from this repository does **not** travel
+with a crate published to crates.io or npm.
+
+Without this compiler target feature, the hand-written Single Instruction,
+Multiple Data (SIMD) kernels are not selected and the codec uses the scalar
+path. The build remains functional, but a benchmark result from an in-repo
+SIMD build must not be compared with an external scalar build as though they
+were configured identically.
+
+For direct Rust builds:
+
+```bash
+RUSTFLAGS="-C target-feature=+simd128" \
+  cargo build --release --target wasm32-unknown-unknown
 ```
+
+For a deployment that must support clients without Wasm SIMD, publish a scalar
+fallback or use feature detection before loading a SIMD-targeted module. A
+module compiled with required SIMD instructions is not a universal fallback
+binary.
+
+## Core feature selection
+
+The wrapper builds the root codec with default features disabled and the
+`simd` Cargo feature enabled. On `wasm32`, SIMD dispatch is a compile-time
+target-feature decision rather than the native `std` runtime CPU-feature
+probe.
+
+A direct root-crate dependency can choose a scalar build by omitting the
+compiler target feature or disable hand-written SIMD through Cargo features as
+documented by the root crate. Keep build configuration in source control so a
+release and its benchmark use the same settings.
 
 ## Distribution
 
-Documented with issue #380:
+The release workflow supports:
 
-- **npm** — the primary channel. `.github/workflows/release.yml` builds with `wasm-pack` and runs `npm publish` on every `v*` (root release) and `wasm-v*` (bindings-only release) tag; `capi-v*` tags skip it.
-- **crates.io** — additionally possible since the dependency on the core codec carries a `version` key (this issue's fix), so Rust-side wasm consumers can `cargo add libjpeg-turbo-rs-wasm`. Publication rides the same maintainer release step as the other crates.
+- **npm** as the primary JavaScript distribution channel;
+- **crates.io** for Rust-side Wasm consumers;
+- root `v*` releases and Wasm-specific release tags according to the repository
+  release workflow.
 
-## Feature notes
+Before publishing or consuming a package, verify the exact package version,
+root codec version, compiler flags, generated package metadata, and module
+hash. Native C ABI release bundles and their compatibility tiers are unrelated
+to this wrapper.
 
-The core codec is built with `default-features = false, features = ["simd"]`: on `wasm32`, SIMD128 selection is a compile-time `target_feature` decision, so the `std` runtime-CPU-detection rationale that applies to the native `image` bridge (issue #381) does not apply here.
+## Evaluation checklist
+
+Record at least:
+
+- browser/runtime and version;
+- `wasm-bindgen`/`wasm-pack`, Rust, and LLVM versions;
+- whether the loaded module requires and receives SIMD128;
+- compressed and uncompressed module size;
+- instantiation and first-call cost separately from steady-state throughput;
+- p50, p95, and p99 latency on representative images;
+- linear-memory growth, peak memory, and maximum accepted dimensions;
+- copy cost between JavaScript buffers and Wasm linear memory;
+- worker/threading model and number of concurrent codec instances;
+- malformed-input timeout and memory limits;
+- output pixel format, metadata behavior, and correctness against the current
+  production codec.
+
+Measure the JavaScript-to-Wasm wrapper end to end. A root-codec native
+benchmark excludes module initialization, boundary copies, garbage collection,
+and browser scheduling.
+
+## Production guidance
+
+- Keep one deterministic build command for the package and benchmark.
+- Reuse module instances and buffers where the wrapper API permits it.
+- Reject dimensions and requested output sizes before committing excessive
+  linear memory.
+- Run malformed and adversarial inputs inside the same worker and timeout model
+  used in production.
+- Roll out behind a codec selector or package version that can return to the
+  previous implementation.
+- Monitor out-of-memory failures, traps, latency, and decode errors separately
+  from network or application failures.
+
+## Current project status
+
+The wrapper inherits the root codec's correctness and safe-Rust status. It does
+not depend on or promote the optional C Application Binary Interface (ABI)
+shim. Canonical readiness and open verification work remain in
+[`docs/LAST_MILE.md`](../../docs/LAST_MILE.md); Wasm feature coverage is
+summarized in the root [`README.md`](../../README.md).
+
+## License
+
+MIT OR Apache-2.0, matching the root codec. See
+[`LICENSE-MIT`](../../LICENSE-MIT) and
+[`LICENSE-APACHE`](../../LICENSE-APACHE).

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -1,0 +1,454 @@
+# Adoption and Migration Guide
+
+**Last reviewed:** 2026-08-27
+
+Use this guide to select the correct `libjpeg-turbo-rs` integration, evaluate
+it against your production workload, and roll it out without treating every
+Rust and C interface as equally mature.
+
+The canonical readiness source is [`LAST_MILE.md`](LAST_MILE.md). The canonical
+C Application Binary Interface (ABI) policy is
+[`ABI_COMPATIBILITY.md`](ABI_COMPATIBILITY.md). This guide summarizes those
+contracts; it does not override them.
+
+## 1. Choose your integration path
+
+| Application | Recommended path | Current status |
+| --- | --- | --- |
+| New or existing Rust application | Root `libjpeg-turbo-rs` crate | **T1:** feature-rich and appropriate for evaluation or production use after reviewing the live limitations |
+| Rust code built around `image` traits | `libjpeg-turbo-rs-image` | Adapter available; validate color mapping and bridge overhead |
+| Browser or WebAssembly System Interface (WASI) application | `libjpeg-turbo-rs-wasm` or the root crate on `wasm32` | Supported; hand-written SIMD128 requires an explicit compiler target feature outside this repository |
+| C/C++ application using TurboJPEG 3 (`tj3*`) | `libjpeg-turbo-rs-capi` / `libturbojpeg.so.0` | **T2:** primary C ABI target; evaluate the exact functions and packaged artifact you use |
+| C/C++ application compiled against classic libjpeg v8 (`libjpeg.so.8`) | Controlled pilot | **T3:** experimental and partial; not a general system-library replacement |
+| Binary compiled against libjpeg v6b (`libjpeg.so.62`) or v7 (`libjpeg.so.7`) | Keep upstream or rebuild against a supported API | **T4:** unsupported as a drop-in replacement |
+
+### Sixty-second decision tree
+
+1. **Can you change Rust source code?** Use the root crate.
+2. **Does the code require `image::ImageDecoder` or `image::ImageEncoder`?**
+   Use the image bridge and benchmark that complete adapter path.
+3. **Are you targeting a browser or WASI?** Use the Wasm package and make the
+   `+simd128` build choice explicit.
+4. **Can a C/C++ application use TurboJPEG 3?** Prefer the opaque-handle `tj3*`
+   API over classic libjpeg.
+5. **Must you preserve a prebuilt classic libjpeg ABI?** Continue only for a
+   v8-layout consumer and only with the isolated pilot below.
+6. **Is the consumer compiled against v6b or v7 headers?** Do not substitute
+   this project's v8-layout library.
+
+## 2. Readiness you must understand
+
+### Rust safety status
+
+The Rust codec does not call a C JPEG codec. It still contains narrowly scoped
+`unsafe` code in architecture-specific Single Instruction, Multiple Data
+(SIMD) kernels, and the optional C ABI shim necessarily handles raw pointers
+and callbacks.
+
+The major safe-Rust Undefined Behavior (UB) defects found during the 2026-08
+audit are recorded as closed, and the live gate currently reports no known UB
+remaining through the safe Rust Application Programming Interface (API). A
+formal memory-safety guarantee still requires the remaining checked-layout
+centralization and automated unsafe-path verification work tracked by P4-139
+and P4-141.
+
+### Current release gate
+
+The full release-mode workspace gate is currently red because of P4-170: two
+classic source-manager differential tests pass in debug mode and fail in
+release mode. This is not evidence that every Rust-native encode or decode path
+fails. It is evidence that the project must not describe the complete release
+gate as green before the issue closes and the matrix is re-measured.
+
+Check the current status block in [`LAST_MILE.md`](LAST_MILE.md) before pinning
+a version.
+
+### Compatibility tiers are independent
+
+A ready TurboJPEG 3 operation does not make classic libjpeg v8 ready. A working
+v8 pilot does not make v6b or v7 compatible. Evaluate the exact API, ABI,
+platform, compiler flags, and artifact you will ship.
+
+## 3. Rust-native integration
+
+### Install
+
+```bash
+cargo add libjpeg-turbo-rs
+```
+
+Or pin the reviewed line explicitly:
+
+```toml
+[dependencies]
+libjpeg-turbo-rs = "0.8"
+```
+
+The root crate's Minimum Supported Rust Version (MSRV) is declared in
+[`Cargo.toml`](../Cargo.toml) and enforced in Continuous Integration (CI).
+
+### Decode and encode
+
+```rust
+use libjpeg_turbo_rs::{
+    compress, decompress_to, JpegError, PixelFormat, Subsampling,
+};
+
+fn transcode(jpeg_bytes: &[u8]) -> Result<Vec<u8>, JpegError> {
+    let image = decompress_to(jpeg_bytes, PixelFormat::Rgb)?;
+
+    compress(
+        &image.data,
+        image.width,
+        image.height,
+        PixelFormat::Rgb,
+        85,
+        Subsampling::S420,
+    )
+}
+```
+
+Set quality and subsampling explicitly so production codec decisions remain
+visible in source code.
+
+### Reuse output memory
+
+For frame loops and services, evaluate the caller-owned-buffer path rather than
+only one-shot convenience functions:
+
+```rust
+use libjpeg_turbo_rs::{decompress_into, output_buffer_size, PixelFormat};
+
+let required = output_buffer_size(&jpeg_bytes, PixelFormat::Rgb)?;
+let mut output = vec![0_u8; required];
+let info = decompress_into(&jpeg_bytes, PixelFormat::Rgb, &mut output)?;
+let pixels = &output[..info.bytes_written];
+```
+
+Retain and resize the buffer only when a later image needs more capacity.
+Measure allocations, peak resident memory, and throughput with the reuse
+strategy your deployment will actually use.
+
+### Select the API by workload
+
+| Need | API direction |
+| --- | --- |
+| Complete in-memory decode/encode | `decompress*`, `compress`, `Encoder` |
+| Reusable caller-owned output | `decompress_into` and sizing helpers |
+| Row-at-a-time processing | scanline APIs |
+| `std::io` readers and writers | streaming APIs with the default `std` feature |
+| Rotate, flip, transpose, or crop without a pixel round trip | coefficient-domain transform APIs |
+| Inspect or preserve EXIF, ICC, XMP, IPTC, and comments | metadata and marker APIs |
+| Run without the Rust standard library | `default-features = false` with `alloc` available |
+| YUV planes or custom JPEG tables | raw/component and advanced builder APIs |
+
+Compile-checked examples live in [`../examples`](../examples) and on
+[docs.rs](https://docs.rs/libjpeg-turbo-rs).
+
+### Rust production checklist
+
+- [ ] Pin a reviewed crate version and record the Rust toolchain.
+- [ ] Test baseline, progressive, grayscale, CMYK/YCCK, and malformed inputs
+      present in your workload.
+- [ ] Verify output pixel format, channel order, and alpha/padding semantics.
+- [ ] Compare metadata behavior for EXIF/ICC/XMP/IPTC-bearing images.
+- [ ] Benchmark a portable release build before adding machine-specific flags.
+- [ ] Measure reusable-buffer and streaming paths when they match production.
+- [ ] Apply your own dimensions, memory, concurrency, and timeout limits.
+- [ ] Keep a rollback version until production traffic has passed acceptance
+      criteria.
+
+## 4. `image` crate integration
+
+Use `libjpeg-turbo-rs-image` when the caller expects `image` crate decoder or
+encoder traits.
+
+```toml
+[dependencies]
+libjpeg-turbo-rs-image = "0.1"
+image = { version = "0.25", default-features = false }
+```
+
+```rust
+use image::ImageDecoder;
+use libjpeg_turbo_rs_image::JpegDecoder;
+
+let mut decoder = JpegDecoder::new(&jpeg_bytes)?;
+let mut pixels = vec![0_u8; decoder.total_bytes() as usize];
+decoder.read_image(&mut pixels)?;
+```
+
+Review the adapter
+[`README.md`](../crates/libjpeg-turbo-rs-image/README.md) for color mapping,
+advanced-format access, and limitations.
+
+Benchmark the adapter end to end. A core-codec benchmark excludes trait
+adaptation, representation conversion, and surrounding application buffers.
+Prefer an explicit bridge dependency rather than a hidden global patch of a
+transitive `image` dependency; explicit selection makes review and rollback
+simpler.
+
+## 5. WebAssembly integration
+
+Use the Wasm wrapper when JavaScript or TypeScript calls the codec, or depend on
+the root crate directly from Rust targeting `wasm32`.
+
+```bash
+RUSTFLAGS="-C target-feature=+simd128" \
+  wasm-pack build --release --target web
+```
+
+The repository's local Cargo configuration does not travel with a published
+crate. Without the explicit target feature, the hand-written SIMD128 path is
+not selected and the build falls back to scalar execution.
+
+Record these separately in a browser/WASI evaluation:
+
+- runtime/version and SIMD128 availability;
+- module size and instantiation cost;
+- first-call and steady-state latency;
+- linear-memory growth and maximum accepted dimensions;
+- JavaScript/Wasm boundary copies;
+- worker/concurrency model;
+- malformed-input timeout and memory limits.
+
+See [`../crates/libjpeg-turbo-rs-wasm/README.md`](../crates/libjpeg-turbo-rs-wasm/README.md).
+
+## 6. TurboJPEG 3 migration
+
+TurboJPEG 3 is the preferred C migration path because its public API uses
+opaque handles instead of version-dependent classic libjpeg structures.
+
+### Preconditions
+
+Proceed after confirming:
+
+- the application uses `tj3*`, or every legacy symbol it uses is supported in
+  [`C_API_REFERENCE.md`](C_API_REFERENCE.md);
+- your platform has a supported bundle or a build you can package and test;
+- the workload does not depend on undocumented implementation behavior;
+- loader or package selection can be returned to upstream during rollout.
+
+### Obtain and verify the artifact
+
+Tagged releases publish the bundle matrix described in
+[`RELEASE_ARTIFACTS.md`](RELEASE_ARTIFACTS.md). Follow its checksum, unpack,
+installation, and package-discovery instructions.
+
+A checksum published beside an artifact is not an offline signature. Until
+signing or build provenance is published, record that supply-chain limitation
+or build from a pinned commit in your controlled pipeline.
+
+### Compile a canary against shipped headers
+
+Compile against the headers and package metadata from the same bundle as the
+shared library. The canary should:
+
+1. create every handle type used in production;
+2. set quality, subsampling, and all relevant parameters explicitly;
+3. compress and decompress representative images;
+4. exercise an invalid input and the error API;
+5. destroy handles and free buffers through the documented allocator;
+6. verify the library identity selected by the loader.
+
+### Run application-level differential tests
+
+Run each production operation through upstream libjpeg-turbo and this shim,
+then compare:
+
+- success/failure classification and error behavior;
+- dimensions, subsampling, colorspace, and precision;
+- decoded pixels under a predefined comparison rule;
+- metadata and transform behavior;
+- buffer ownership and reallocation semantics;
+- latency, throughput, allocations, and peak memory;
+- concurrent use of independent handles.
+
+### Legacy aliases
+
+The library implements the TurboJPEG 3 surface and only part of the legacy
+1.x/2.x alias set. The migration matrix in
+[`ABI_COMPATIBILITY.md`](ABI_COMPATIBILITY.md) maps missing symbols to supported
+successors. Missing symbols fail at link time or dynamic lookup; they are not
+substituted automatically.
+
+## 7. Classic libjpeg v8 pilot
+
+The classic v8 shim is experimental and partial. Never replace a system library
+globally as the first test.
+
+### Required preconditions
+
+- The consumer is compiled against `JPEG_LIB_VERSION = 80` and expects the v8
+  library identity.
+- Every imported `jpeg_*` symbol has been inventoried.
+- Required behavior is covered in `C_API_REFERENCE.md` and the live gate.
+- Every `jpeg_compress_struct` and `jpeg_decompress_struct` stays on the thread
+  that created it; the current shim's stricter contract is P4-132.
+- Loading can be isolated to a process, container, test prefix, or explicit
+  runtime search path.
+- Upstream can be restored without rebuilding the entire application.
+
+### Pilot sequence
+
+1. Inventory imported symbols and compiled ABI identity.
+2. Build or unpack the exact artifact intended for deployment.
+3. Verify SONAME/install name and symbol versions.
+4. Run stock-tool and canary tests in an isolated loader environment.
+5. Cross-decode both directions and run same-operation differential tests.
+6. Exercise lifecycle edges used by the application: suspension, short input,
+   custom source/destination managers, callbacks, abort/reuse, errors,
+   precision, raw data, coefficients, and threading.
+7. Shadow production traffic in a separate process before serving output.
+8. Roll out gradually with an automatic fallback to upstream.
+
+### Stop conditions
+
+Stop and remain on upstream when:
+
+- the consumer is v6b/v7 rather than v8;
+- a required symbol or behavior is partial or missing;
+- the application transfers a `cinfo` across threads;
+- the packaged artifact has not passed loader and lifecycle tests;
+- malformed input has a worse termination, memory, or error contract;
+- rollback requires an unsafe global replacement or a full application rebuild.
+
+## 8. Unsupported or unproved paths
+
+### v6b and v7 drop-in replacement
+
+The classic shim mirrors v8 structures. A different SONAME does not change the
+layout. Use upstream, rebuild against TurboJPEG 3, or rebuild against v8 and
+run the controlled pilot. Separately built and tested per-ABI variants would be
+a future product decision, not an aliasing trick.
+
+### Unmeasured architecture performance
+
+Do not infer x86_64/aarch64 results on armv7, RISC-V Vector (RVV), POWER, or
+s390x. Use scalar support only after measuring on the deployment hardware. The
+root [`README.md`](../README.md) records current SIMD coverage and gaps.
+
+### Unsigned native artifacts
+
+Current native bundles are checksummed but not yet signed and do not include a
+Software Bill of Materials (SBOM). Organizations requiring verified provenance
+should build from a pinned commit in a controlled pipeline or wait for the
+provenance milestone.
+
+## 9. Build a representative evaluation
+
+A codec evaluation should model production, not a single synthetic image.
+
+### Corpus
+
+Include relevant examples of:
+
+- tiny icons, ordinary camera/web images, 1080p/4K, and maximum dimensions;
+- grayscale, 4:4:4, 4:2:2, 4:2:0, and unusual subsampling;
+- baseline and progressive JPEG;
+- CMYK/YCCK and embedded color profiles;
+- EXIF orientation and other metadata;
+- lossless, high-precision, or arithmetic streams when accepted;
+- truncated, corrupted, oversized, and adversarial inputs;
+- outputs produced by the current production encoder.
+
+Record hashes or deterministic generator parameters. Do not commit private
+customer images to the public repository.
+
+### Correctness criteria
+
+Define the rule before testing:
+
+- exact bytes when the contract requires identity;
+- exact pixels when both implementations promise the same conversion;
+- a justified bounded pixel difference only when valid inverse transforms may
+  differ;
+- cross-decode success when encoded bytes may legitimately differ;
+- exact metadata preservation or intentional stripping;
+- matching failure class, with no panic, abort, hang, out-of-bounds access, or
+  unbounded allocation.
+
+### Performance criteria
+
+Measure at least:
+
+- p50, p95, and p99 latency;
+- images or megapixels per second;
+- peak resident memory and observable allocations;
+- first-call and steady-state behavior;
+- one-shot and reusable-buffer paths;
+- one thread and production concurrency;
+- portable release and machine-specific builds separately.
+
+Use the same optimization class, CPU policy, thread count, input bytes, output
+format, and correctness checks for both codecs.
+
+### Operational criteria
+
+Confirm repeatable installation, loader behavior, memory/time limits,
+monitoring that identifies the selected codec, and a rollback that has been
+exercised rather than merely documented.
+
+## 10. Production rollout
+
+A recommended sequence is:
+
+1. offline differential test on the full corpus;
+2. permanent CI canary on a smaller redistributable corpus;
+3. shadow mode that computes but does not serve the new result;
+4. opt-in or internal traffic with immediate fallback;
+5. small-percentage rollout with correctness, latency, memory, and error alerts;
+6. progressive increase after a defined observation window;
+7. intentional end-of-life decision before removing the rollback dependency.
+
+For Rust, rollback is commonly a Cargo version change. For C ABI replacement,
+preserve the previous package or library path and keep loader selection
+explicit.
+
+## 11. Report an adoption blocker
+
+Open an issue with this information:
+
+```markdown
+## Integration path
+Rust API / image bridge / Wasm / TurboJPEG 3 / classic libjpeg v8
+
+## Version and source
+crate/release version, commit, artifact filename and checksum
+
+## Environment
+OS, architecture, CPU, Rust/C compiler, linker, build flags, runtime
+
+## Production operation
+API calls, pixel format, subsampling, precision, dimensions, threading
+
+## Expected and actual behavior
+specification/upstream result and observed error/output/regression
+
+## Minimal reproduction
+source plus a redistributable fixture or deterministic generator
+
+## Differential evidence
+upstream version, commands, raw output, hashes, benchmark methodology
+
+## Adoption impact
+blocks evaluation / rollout / production / optimization request
+```
+
+Do not publish exploit details in a normal issue. Use GitHub private
+vulnerability reporting when the repository exposes it; establishing and
+documenting a permanent private disclosure route is a `1.0` requirement in the
+Product Requirements Document (PRD).
+
+## 12. Related documents
+
+- [`../PRD.md`](../PRD.md) — product direction and adoption priorities
+- [`README.md`](README.md) — documentation index
+- [`LAST_MILE.md`](LAST_MILE.md) — canonical T1-T4 release gates
+- [`FEATURE_PARITY.md`](FEATURE_PARITY.md) — implemented feature inventory
+- [`TEST_PARITY.md`](TEST_PARITY.md) — C behavior/test parity
+- [`CORPUS_TEST_REPORT.md`](CORPUS_TEST_REPORT.md) — corpus evidence
+- [`ABI_COMPATIBILITY.md`](ABI_COMPATIBILITY.md) — ABI and SONAME policy
+- [`C_API_REFERENCE.md`](C_API_REFERENCE.md) — C function status
+- [`RELEASE_ARTIFACTS.md`](RELEASE_ARTIFACTS.md) — bundles and verification gaps
+- [`ENCODING_PERFORMANCE.md`](ENCODING_PERFORMANCE.md) — detailed encoder evidence

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,113 @@
+# Documentation Map
+
+Start with the document that matches the decision you are making. The files in
+this directory include user guides, compatibility contracts, release gates,
+validation evidence, and maintainer work plans; they are not interchangeable.
+
+## I want to adopt the codec
+
+1. Read the root [`README.md`](../README.md) for the project overview and quick
+   start.
+2. Use [`ADOPTION_GUIDE.md`](ADOPTION_GUIDE.md) to choose the Rust API,
+   `image` bridge, WebAssembly (Wasm), TurboJPEG 3, or classic libjpeg path.
+3. Check the live readiness in [`LAST_MILE.md`](LAST_MILE.md) before pinning a
+   release.
+4. Use the evidence documents below to validate the exact feature, platform,
+   artifact, and workload you plan to ship.
+
+## I am using Rust
+
+| Question | Document |
+| --- | --- |
+| How do I decode, encode, stream, transform, or reuse buffers? | Root [`README.md`](../README.md), [`examples/`](../examples), and [docs.rs](https://docs.rs/libjpeg-turbo-rs) |
+| Is a JPEG feature implemented? | [`FEATURE_PARITY.md`](FEATURE_PARITY.md) |
+| How is behavior checked against C libjpeg-turbo? | [`TEST_PARITY.md`](TEST_PARITY.md) and [`CORPUS_TEST_REPORT.md`](CORPUS_TEST_REPORT.md) |
+| What are the current safety and release blockers? | [`LAST_MILE.md`](LAST_MILE.md) |
+| How does encoding performance compare? | [`ENCODING_PERFORMANCE.md`](ENCODING_PERFORMANCE.md) and dated files under [`../experiments`](../experiments) |
+| How do I use the `image` crate traits? | [`../crates/libjpeg-turbo-rs-image/README.md`](../crates/libjpeg-turbo-rs-image/README.md) |
+| How do I build for Wasm? | [`../crates/libjpeg-turbo-rs-wasm/README.md`](../crates/libjpeg-turbo-rs-wasm/README.md) |
+
+## I am using C or C++
+
+| Question | Document |
+| --- | --- |
+| Should I use TurboJPEG 3 or classic libjpeg? | [`ADOPTION_GUIDE.md`](ADOPTION_GUIDE.md) |
+| Which C functions are implemented, partial, or missing? | [`C_API_REFERENCE.md`](C_API_REFERENCE.md) |
+| Which ABI and SONAME are safe for my consumer? | [`ABI_COMPATIBILITY.md`](ABI_COMPATIBILITY.md) |
+| Can this replace a system library today? | [`LAST_MILE.md`](LAST_MILE.md), T1-T4 status |
+| What do release bundles contain and how are they verified? | [`RELEASE_ARTIFACTS.md`](RELEASE_ARTIFACTS.md) |
+| How do I build the C ABI crate? | [`../crates/libjpeg-turbo-rs-capi/README.md`](../crates/libjpeg-turbo-rs-capi/README.md) |
+
+## I am evaluating correctness and performance
+
+| Evidence | Purpose |
+| --- | --- |
+| [`FEATURE_PARITY.md`](FEATURE_PARITY.md) | Public feature inventory; a checked item must be wired end to end |
+| [`TEST_PARITY.md`](TEST_PARITY.md) | Mapping between upstream C behavior/tests and this implementation |
+| [`CORPUS_TEST_REPORT.md`](CORPUS_TEST_REPORT.md) | Real and generated corpus results |
+| [`oracle_versions.tsv`](oracle_versions.tsv) | Pinned oracle identities used by validation jobs |
+| [`ENCODING_PERFORMANCE.md`](ENCODING_PERFORMANCE.md) | Detailed encoding measurements and methodology links |
+| [`../experiments`](../experiments) | Dated raw or summarized benchmark and downstream-integration evidence |
+| [`LAST_MILE.md`](LAST_MILE.md) | Release-gate result and unresolved replacement gaps |
+
+Benchmark evidence must distinguish a portable `cargo build --release` from a
+machine-specific `-C target-cpu=native` build. Results are valid only for the
+recorded processor, operating system, toolchain, build flags, codec versions,
+and corpus.
+
+## I want to contribute
+
+Read these in order:
+
+1. [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — development workflow and the
+   evidence expected in a pull request.
+2. [`../PRD.md`](../PRD.md) — adoption goals, priorities, milestones, and the
+   `1.0` definition of done.
+3. [`LAST_MILE.md`](LAST_MILE.md) — live release blockers and the T1-T4 gate.
+4. [`../CLAUDE.md`](../CLAUDE.md) — repository-specific implementation and
+   testing rules for human and agentic contributors.
+5. The relevant phase file under [`last_mile/`](last_mile/) for the issue you
+   are changing.
+
+Use [`NEXT_SESSION_PLAN.md`](NEXT_SESSION_PLAN.md) only as a current work-plan
+artifact. It does not override the product requirements or compatibility gate.
+Historical design and implementation plans live under [`plans/`](plans/) and
+[`superpowers/`](superpowers/); they explain how earlier work was approached,
+not necessarily the current public contract.
+
+## Source-of-truth hierarchy
+
+When documents disagree, use this order:
+
+1. [`LAST_MILE.md`](LAST_MILE.md) and its phase files for readiness and open
+   replacement gates.
+2. [`ABI_COMPATIBILITY.md`](ABI_COMPATIBILITY.md) for C ABI and SONAME policy.
+3. [`FEATURE_PARITY.md`](FEATURE_PARITY.md) for feature implementation status.
+4. [`TEST_PARITY.md`](TEST_PARITY.md), [`CORPUS_TEST_REPORT.md`](CORPUS_TEST_REPORT.md),
+   and dated benchmark evidence for validation claims.
+5. [`../PRD.md`](../PRD.md) for product direction and priority.
+6. User-facing READMEs for concise summaries.
+
+A README or Product Requirements Document (PRD) cannot promote a compatibility
+tier. Promotion requires the canonical gate, its acceptance criteria, and the
+corresponding executable evidence to change together.
+
+## Documentation maintenance rules
+
+When a change affects a public claim:
+
+- implementation or feature status → update `FEATURE_PARITY.md`;
+- C symbol or behavior → update `C_API_REFERENCE.md`;
+- ABI, SONAME, struct layout, allocator, lifecycle, or threading contract →
+  update `ABI_COMPATIBILITY.md`;
+- release readiness or a P0/P1 replacement blocker → update `LAST_MILE.md` and
+  the relevant phase file;
+- benchmark claim → add dated raw evidence and update the user-facing summary;
+- release contents or verification → update `RELEASE_ARTIFACTS.md`;
+- adoption priority, milestone, or success criterion → update `PRD.md`;
+- public onboarding language → update the relevant README and
+  `ADOPTION_GUIDE.md`.
+
+State what was verified and what remains unverified. Do not turn code presence,
+a debug-only pass, an emulated performance result, or an intermediate build
+artifact into a production-readiness claim.


### PR DESCRIPTION
## Summary

This pull request reorganizes the project's product and user documentation around one goal: make `libjpeg-turbo-rs` easier to evaluate, migrate to, and adopt without overstating compatibility with C libjpeg-turbo.

### Added

- `PRD.md`
  - adoption-focused product vision and positioning
  - source-of-truth hierarchy
  - T1-T4 product baseline
  - functional and quality requirements
  - success metrics, milestones, P0/P1/P2 backlog, and `1.0` definition of done
  - release evidence bundle and governance rules
- `docs/ADOPTION_GUIDE.md`
  - decision tree for Rust, `image`, WebAssembly (Wasm), TurboJPEG 3, classic libjpeg v8, and unsupported v6b/v7 paths
  - representative-corpus, correctness, performance, resource, rollout, stop-condition, and rollback guidance
- `docs/README.md`
  - documentation map by audience
  - explicit source-of-truth and documentation-maintenance rules
- `.github/pull_request_template.md`
  - evidence requirements for correctness, unsafe/Single Instruction, Multiple Data (SIMD), performance, Rust Application Programming Interface (API), C Application Binary Interface (ABI), platform, packaging, and documentation changes

### Updated

- root `README.md`
  - replaces the long feature-first introduction with an adoption decision table, concise quick start, current readiness, representative performance evidence, platform matrix, and documentation map
  - separates portable and `target-cpu=native` performance
  - surfaces the current P4-170 release-mode red gate
  - corrects stale wording that still described P4-135..P4-139 as wholly open
- `CONTRIBUTING.md` and `AGENTS.md`
  - prioritize adoption blockers and require claim-specific executable evidence
  - prohibit tier promotion through README-only changes
  - require packaged-artifact validation where packaging changes behavior
- C ABI, `image`, and Wasm subcrate READMEs
  - document when to use each path, what to measure end to end, unsupported paths, and rollback requirements

## Product direction established

1. Win new Rust-native workloads first by reducing build, cross-compilation, packaging, and Foreign Function Interface (FFI) cost.
2. Keep TurboJPEG 3 as the primary C ABI migration target.
3. Keep classic libjpeg v8 experimental until its independent live gate is green.
4. Keep v6b/v7 drop-in replacement unsupported unless separately built and tested ABI variants are introduced.
5. Treat correctness, soundness, portable performance, shipped-artifact validation, supply-chain evidence, and ecosystem integrations as one adoption funnel.
6. Require every readiness or performance claim to link to reproducible evidence.

## Status wording corrected

- The live gate records no known remaining Undefined Behavior reachable through the safe Rust API after the major 2026-08 audit fixes.
- A formal memory-safety guarantee still depends on P4-139/P4-141 verification work.
- The complete release-mode workspace gate remains red because of P4-170.
- No T1-T4 tier is promoted by this pull request.

## Validation

- Documentation-only change; no runtime code, public Rust API, Cargo feature, C symbol, ABI layout, SONAME, or compatibility tier changed.
- Public Rust snippets were checked against current root exports, including `JpegError`, `decompress_into`, `output_buffer_size`, `Encoder`, and `ScanlineDecoder`.
- Relative links were checked against the current repository tree and newly added files.
- Branch is one Developer Certificate of Origin (DCO)-signed commit, based directly on current `main`; the DCO check passed.
- The latest required GitHub Actions set passed in full:
  - `CI`, including build/check/format/examples/unit tests, `no_std + alloc`, package/publish checks, libjpeg-turbo 3.1.4.1 and 3.2.0 oracle integration, classic/TurboJPEG ABI behavior, Linux/macOS C interoperability, and generated-corpus C parity;
  - `ARMv7 (32-bit ARM)`;
  - `Cross-Arch SIMD`;
  - `WASM`;
  - `Sanitizers`.
- One older duplicate Sanitizers run was superseded and cancelled by workflow concurrency; the latest required run completed successfully.

## Adoption impact

A new evaluator can now identify the correct integration path from the first README screen, understand why the Rust-native path can be preferable to a C binding, see the current red and open gates, run a representative pilot, and preserve a rollback path without reading the entire engineering tracker first.
